### PR TITLE
feat: add Inferencer class (#16)

### DIFF
--- a/mllabs/__init__.py
+++ b/mllabs/__init__.py
@@ -1,12 +1,14 @@
 __version__ = "0.2.2"
 
 from ._experimenter import Experimenter
+from ._inferencer import Inferencer
 from ._connector import Connector
 from .collector import Collector, MetricCollector, StackingCollector, ModelAttrCollector, SHAPCollector, OutputCollector
 from .filter import DataFilter, RandomFilter, IndexFilter
 
 __all__ = [
     'Experimenter',
+    'Inferencer',
     'Connector',
     'Collector',
     'MetricCollector',

--- a/mllabs/_inferencer.py
+++ b/mllabs/_inferencer.py
@@ -1,0 +1,115 @@
+import pickle as pkl
+from pathlib import Path
+
+from ._data_wrapper import wrap
+from ._node_processor import resolve_columns
+
+
+class Inferencer:
+
+    def __init__(self, pipeline, selected_stages, selected_heads, n_splits, node_objs, v=None):
+        self.pipeline = pipeline
+        self.selected_stages = selected_stages
+        self.selected_heads = selected_heads
+        self.n_splits = n_splits
+        self.node_objs = node_objs
+        self.v = v
+
+    def process(self, data, agg='mean'):
+        results = list(self._process_splits(data))
+
+        if self.n_splits == 1:
+            return results[0]
+
+        if agg is None:
+            return results
+        elif agg == 'mean':
+            return type(results[0]).mean(iter(results))
+        elif agg == 'mode':
+            return type(results[0]).mode(iter(results))
+        elif callable(agg):
+            return agg(results)
+        else:
+            raise ValueError(f"Unknown agg: {agg}")
+
+    def _process_splits(self, data):
+        data = wrap(data)
+        ordered = [
+            name for name in self.pipeline._get_affected_nodes([None])
+            if name in set(self.selected_stages + self.selected_heads)
+        ]
+        stage_set = set(self.selected_stages)
+
+        for split_idx in range(self.n_splits):
+            data_dicts = {None: (data, None)}
+            head_outputs = []
+
+            for name in ordered:
+                obj = self.node_objs[name][split_idx]
+                node_attrs = self.pipeline.get_node_attrs(name)
+                output = self._process_node(obj, data_dicts, node_attrs['edges'])
+
+                if name in stage_set:
+                    data_dicts[name] = (output, obj)
+                else:
+                    if self.v is not None:
+                        cols = resolve_columns(output, self.v, processor=obj)
+                        output = output.select_columns(cols)
+                    head_outputs.append(output)
+
+            if len(head_outputs) == 1:
+                yield head_outputs[0]
+            else:
+                yield type(head_outputs[0]).concat(head_outputs, axis=1)
+
+    def _process_node(self, obj, data_dicts, edges):
+        input_data = self._get_process_data(data_dicts, edges)
+        return obj.process(input_data['X'])
+
+    def _get_process_data(self, data_dicts, edges):
+        result = {}
+        for key, edge_list in edges.items():
+            parts = []
+            for src_node, var in edge_list:
+                src, obj = data_dicts[src_node]
+                if var is not None:
+                    cols = resolve_columns(src, var, processor=obj)
+                    src = src.select_columns(cols)
+                parts.append(src)
+            if len(parts) == 1:
+                result[key] = parts[0]
+            else:
+                result[key] = type(parts[0]).concat(parts, axis=1)
+        return result
+
+    # ------------------------------------------------------------------
+    # save / load
+    # ------------------------------------------------------------------
+
+    def save(self, path):
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+        save_data = {
+            'pipeline': self.pipeline,
+            'selected_stages': self.selected_stages,
+            'selected_heads': self.selected_heads,
+            'n_splits': self.n_splits,
+            'node_objs': self.node_objs,
+            'v': self.v,
+        }
+        with open(path / '__inferencer.pkl', 'wb') as f:
+            pkl.dump(save_data, f)
+
+    @classmethod
+    def load(cls, path):
+        path = Path(path)
+        with open(path / '__inferencer.pkl', 'rb') as f:
+            save_data = pkl.load(f)
+        return cls(
+            save_data['pipeline'],
+            save_data['selected_stages'],
+            save_data['selected_heads'],
+            save_data['n_splits'],
+            save_data['node_objs'],
+            save_data.get('v'),
+        )

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -305,6 +305,27 @@ class Trainer:
         return result
 
     # ------------------------------------------------------------------
+    # to_inferencer
+    # ------------------------------------------------------------------
+
+    def to_inferencer(self, v=None):
+        from ._inferencer import Inferencer
+
+        all_selected = self.selected_stages + self.selected_heads
+        for name in all_selected:
+            obj = self.node_objs.get(name)
+            if obj is None or obj.status != 'built':
+                raise RuntimeError(f"Node '{name}' is not built. Run train() first.")
+
+        pipeline = self.pipeline.copy_nodes(self.selected_heads)
+        node_objs = {
+            name: [obj for obj, _, _ in self.node_objs[name].get_obj()]
+            for name in all_selected
+        }
+        return Inferencer(pipeline, list(self.selected_stages), list(self.selected_heads),
+                          self.get_n_splits(), node_objs, v=v)
+
+    # ------------------------------------------------------------------
     # path helpers
     # ------------------------------------------------------------------
 

--- a/tests/test_inferencer.py
+++ b/tests/test_inferencer.py
@@ -1,0 +1,175 @@
+import pytest
+import numpy as np
+import pandas as pd
+
+from sklearn.preprocessing import StandardScaler
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.model_selection import ShuffleSplit, KFold
+
+from mllabs._experimenter import Experimenter
+from mllabs._inferencer import Inferencer
+from mllabs._data_wrapper import unwrap
+
+
+@pytest.fixture
+def sample_data():
+    np.random.seed(42)
+    n = 100
+    return pd.DataFrame({
+        'f1': np.random.randn(n),
+        'f2': np.random.randn(n),
+        'f3': np.random.randn(n),
+        'target': np.random.randint(0, 2, n),
+    })
+
+
+@pytest.fixture
+def exp(tmp_path, sample_data):
+    e = Experimenter(
+        data=sample_data,
+        path=tmp_path / 'exp',
+        sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
+        sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
+    )
+    e.set_grp('scale', role='stage', processor=StandardScaler,
+              method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
+    e.set_node('scaler', grp='scale')
+    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+              method='predict',
+              edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+              params={'max_depth': 3, 'random_state': 42})
+    e.set_node('dt', grp='model')
+    e.build()
+    e.exp()
+    return e
+
+
+@pytest.fixture
+def trained_trainer(exp):
+    trainer = exp.add_trainer('t1')
+    trainer.select_head(['dt'])
+    trainer.train()
+    return trainer
+
+
+class TestToInferencer:
+    def test_basic_creation(self, trained_trainer):
+        inf = trained_trainer.to_inferencer()
+        assert isinstance(inf, Inferencer)
+        assert inf.n_splits == trained_trainer.get_n_splits()
+        assert inf.selected_stages == trained_trainer.selected_stages
+        assert inf.selected_heads == trained_trainer.selected_heads
+
+    def test_node_objs_are_processor_lists(self, trained_trainer):
+        inf = trained_trainer.to_inferencer()
+        for name, objs in inf.node_objs.items():
+            assert isinstance(objs, list)
+            assert len(objs) == inf.n_splits
+            assert hasattr(objs[0], 'process')
+
+    def test_minimal_pipeline(self, trained_trainer):
+        inf = trained_trainer.to_inferencer()
+        assert 'scaler' in inf.pipeline.nodes
+        assert 'dt' in inf.pipeline.nodes
+
+    def test_not_trained_raises(self, exp):
+        trainer = exp.add_trainer('t_no_train')
+        trainer.select_head(['dt'])
+        with pytest.raises(RuntimeError, match="not built"):
+            trainer.to_inferencer()
+
+    def test_v_stored(self, trained_trainer):
+        inf = trained_trainer.to_inferencer(v=[0])
+        assert inf.v == [0]
+
+
+class TestProcess:
+    def test_mean_agg(self, trained_trainer, sample_data):
+        inf = trained_trainer.to_inferencer()
+        result = inf.process(sample_data, agg='mean')
+        assert result.get_shape()[0] == len(sample_data)
+
+    def test_mode_agg(self, trained_trainer, sample_data):
+        inf = trained_trainer.to_inferencer()
+        result = inf.process(sample_data, agg='mode')
+        assert result.get_shape()[0] == len(sample_data)
+
+    def test_callable_agg(self, trained_trainer, sample_data):
+        inf = trained_trainer.to_inferencer()
+        result = inf.process(sample_data, agg=lambda results: results[0])
+        assert result.get_shape()[0] == len(sample_data)
+
+    def test_none_agg(self, trained_trainer, sample_data):
+        inf = trained_trainer.to_inferencer()
+        results = inf.process(sample_data, agg=None)
+        assert isinstance(results, list)
+        assert len(results) == inf.n_splits
+
+    def test_v_parameter(self, exp, sample_data):
+        exp.set_grp('model_proba', role='head', processor=DecisionTreeClassifier,
+                    method='predict_proba',
+                    edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                    params={'max_depth': 3, 'random_state': 42})
+        exp.set_node('dt_proba', grp='model_proba')
+        exp.build()
+        exp.exp()
+        trainer = exp.add_trainer('t_proba')
+        trainer.select_head(['dt_proba'])
+        trainer.train()
+        inf = trainer.to_inferencer(v=slice(-1, None))
+        result = inf.process(sample_data)
+        assert result.get_shape()[1] == 1
+
+    def test_single_split(self, exp, sample_data):
+        trainer = exp.add_trainer('t_nosplit', splitter=None)
+        trainer.select_head(['dt'])
+        trainer.train()
+        inf = trainer.to_inferencer()
+        result = inf.process(sample_data)
+        assert result.get_shape()[0] == len(sample_data)
+
+    def test_unknown_agg_raises(self, trained_trainer, sample_data):
+        inf = trained_trainer.to_inferencer()
+        with pytest.raises(ValueError, match="Unknown agg"):
+            inf.process(sample_data, agg='unknown')
+
+
+class TestSaveLoad:
+    def test_save_load_roundtrip(self, trained_trainer, tmp_path):
+        inf = trained_trainer.to_inferencer()
+        save_path = tmp_path / 'inferencer'
+        inf.save(save_path)
+
+        loaded = Inferencer.load(save_path)
+        assert loaded.n_splits == inf.n_splits
+        assert loaded.selected_stages == inf.selected_stages
+        assert loaded.selected_heads == inf.selected_heads
+        assert set(loaded.node_objs.keys()) == set(inf.node_objs.keys())
+
+    def test_loaded_process_matches(self, trained_trainer, sample_data, tmp_path):
+        inf = trained_trainer.to_inferencer()
+        save_path = tmp_path / 'inferencer'
+        inf.save(save_path)
+
+        loaded = Inferencer.load(save_path)
+        original = inf.process(sample_data, agg=None)
+        loaded_result = loaded.process(sample_data, agg=None)
+
+        assert len(original) == len(loaded_result)
+        for orig, load in zip(original, loaded_result):
+            np.testing.assert_array_equal(unwrap(orig), unwrap(load))
+
+    def test_save_creates_file(self, trained_trainer, tmp_path):
+        inf = trained_trainer.to_inferencer()
+        save_path = tmp_path / 'inferencer'
+        inf.save(save_path)
+        assert (save_path / '__inferencer.pkl').exists()
+
+    def test_save_load_with_v(self, trained_trainer, sample_data, tmp_path):
+        exp = trained_trainer
+        inf = trained_trainer.to_inferencer(v=[0])
+        save_path = tmp_path / 'inferencer_v'
+        inf.save(save_path)
+
+        loaded = Inferencer.load(save_path)
+        assert loaded.v == [0]


### PR DESCRIPTION
## Summary
- Trainer.to_inferencer(v)로 학습된 Processor를 추출하여 독립적인 Inferencer 생성
- process(data, agg)로 새 데이터에 적용, split 결과 자동 집계 (mean/mode/callable/None)
- 단일 pkl 파일로 save/load (Trainer, TrainObj 의존성 없음)

## Test plan
- [x] TestToInferencer: 생성, 미학습 에러, Processor 리스트 구조 확인
- [x] TestProcess: mean/mode/callable/None 집계, v 파라미터, single split
- [x] TestSaveLoad: save/load roundtrip, load 후 process 결과 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)