### PR TITLE
fix: restructure StackingCollector, fix get_dataset shape mismatch (#17)

### DIFF
--- a/mllabs/collector/_metric.py
+++ b/mllabs/collector/_metric.py
@@ -108,14 +108,14 @@ class MetricCollector(Collector):
             raise ValueError("")
         df = self.get_metrics(nodes)
         if inner_fold:
-            df_agg_mean = df.stack(level=1).groupby(level=0).mean()
+            df_agg_mean = df.stack(level=1, future_stack=True).groupby(level=0).mean()
             if include_std:
-                df_agg_std = df.stack(level=1).groupby(level=0).std()
+                df_agg_std = df.stack(level=1, future_stack=True).groupby(level=0).std()
             else:
                 df_agg_std = None
             if outer_fold:
-                df_agg_mean = df_agg_mean.stack(level=0).groupby(level=0).mean()
+                df_agg_mean = df_agg_mean.stack(level=0, future_stack=True).groupby(level=0).mean()
                 if include_std:
-                    df_agg_std = df_agg_std.stack(level=0).groupby(level=0).mean()
+                    df_agg_std = df_agg_std.stack(level=0, future_stack=True).groupby(level=0).mean()
             return df_agg_mean, df_agg_std
         return df


### PR DESCRIPTION
## Summary
- Fix `get_dataset` shape mismatch error (`ValueError: Shape of passed values is (118800, 5), indices imply (59400, 5)`)
- Move `experimenter` to constructor; pre-build `_index` and `_target` as arrays at creation time
- Move `include_target` from constructor to `get_dataset(include_target=True)` parameter
- Remove `_build_sort_order` / `_build_target_value`; reconstruct DataWrapper via `from_output` with stored index
- Remove `experimenter` parameter from `get_dataset` (no longer needed)
- Fix MetricCollector `FutureWarning` by adding `future_stack=True` to `.stack()` calls
- Update CLAUDE.md with Inferencer, StackingCollector changes, and git English policy

Closes #17

## Test plan
- [x] `TestStackingCollector`: collect, get_dataset, include_target, multi nodes, node filter, save/load, index preserved
- [x] All existing collector tests pass with updated StackingCollector constructor signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)