### PR TITLE
fix: return False for non-numeric types in get_type_df (#23)

### DIFF
--- a/mllabs/processor/_dproc.py
+++ b/mllabs/processor/_dproc.py
@@ -51,9 +51,10 @@ def get_type_df(df):
         ('i16', np.iinfo(np.int16).min, np.iinfo(np.int16).max),
         ('i8', np.iinfo(np.int8).min, np.iinfo(np.int8).max)
     ]:
-        df_type[i] = df_type.loc[df_type['dtype'] != 'String'].apply(
+        numeric_mask = df_type['dtype'].str.startswith(('Int', 'Float'))
+        df_type[i] = df_type.loc[numeric_mask].apply(
             lambda x: (x['min'] >= mn) and (x['max'] <= mx), axis=1
-        )
+        ).reindex(df_type.index, fill_value=False)
     return df_type
 
 def get_type_vars(var_list):


### PR DESCRIPTION
## Summary
- `get_type_df` only excluded `String` dtype when computing `f32/i32/i16/i8` flags, causing non-numeric types (e.g., `Boolean`, `Date`) to get `NaN` which behaved as truthy
- Filter by numeric dtype prefix (`Int`/`Float`) and use `reindex(fill_value=False)` to explicitly set non-numeric rows to `False`

Closes #23

## Test plan
- [x] Verified non-numeric columns now show `f32=False, i32=False, i16=False, i8=False`
- [x] Numeric columns still correctly compute range-based flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)