### PR TITLE
feat: add CategoricalConverter processor (#24)

### DIFF
--- a/mllabs/_node_processor.py
+++ b/mllabs/_node_processor.py
@@ -123,7 +123,7 @@ class TransformProcessor():
 
         # 컬럼명 결정 (get_feature_names_out이 있으면 사용)
         if hasattr(self.obj, 'get_feature_names_out'):
-            column_names = self.obj.get_feature_names_out().tolist()
+            column_names = list(self.obj.get_feature_names_out())
             column_names = [f"{self.name}__{col}" for col in column_names]
         else:
             column_names = None
@@ -170,7 +170,7 @@ class TransformProcessor():
         train_wrapper_class = type(train_X)
         # 컬럼명 결정 (get_feature_names_out이 있으면 사용)
         if hasattr(self.obj, 'get_feature_names_out'):
-            column_names = self.obj.get_feature_names_out().tolist()
+            column_names = list(self.obj.get_feature_names_out())
             column_names = [f"{self.name}__{col}" for col in column_names]
         else:
             column_names = None

--- a/mllabs/processor/__init__.py
+++ b/mllabs/processor/__init__.py
@@ -1,7 +1,11 @@
 from ._polars import PolarsLoader, ExprProcessor
 from ._pandas import PandasConverter
+from ._categorical import CategoricalConverter, CategoricalPairCombiner
 
 __all__ = [
-    "PolardLoader",
+    "PolarsLoader",
     "ExprProcessor",
+    "PandasConverter",
+    "CategoricalConverter",
+    "CategoricalPairCombiner",
 ]


### PR DESCRIPTION
## Summary
- Add `CategoricalConverter` processor that converts specified columns to categorical dtype
  - pandas: `astype('category')`
  - polars: `cast(pl.Categorical)`
  - numpy: cast to `str`/`object`
- Fix `_node_processor.py` to use `list()` instead of `.tolist()` for `get_feature_names_out` return value compatibility (supports both `list` and `ndarray`)
- Export `CategoricalConverter` and `CategoricalPairCombiner` from processor package

Closes #24

## Test plan
- [x] Verified numeric columns converted to categorical dtype for LightGBM compatibility
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)