### PR TITLE
fix: close_exp does not save status, causing reopen_exp to fail after reload

### DIFF
--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -340,7 +340,8 @@ class Experimenter():
                 self.logger.info(f"Finalize '{k}'")
                 node_obj.finalize()
         self.status = "closed"
-    
+        self._save()
+
     def reopen_exp(self):
         if self.status != "closed":
             raise RuntimeError("")


### PR DESCRIPTION
## Summary
- `close_exp()` was missing `_save()` call, so `status='closed'` was never persisted
- After kernel restart and `Experimenter.load()`, status was restored as `'open'`, causing `reopen_exp()` to raise `RuntimeError` (requires `status='closed'`)

## Test plan
- `test_close_exp_saves_status`: verifies loaded experimenter has `status='closed'` after `close_exp()`
- `test_reopen_exp_after_save_load`: full cycle — build/exp/close → save/load → reopen/exp succeeds and collector data is valid

Closes #41