### PR TITLE
fix: handle missing X in data_dict for expobj and trainobj

### DIFF
--- a/mllabs/_expobj.py
+++ b/mllabs/_expobj.py
@@ -8,6 +8,12 @@ import os
 import shutil
 import time
 
+
+def _get_process_inputs(data_dict):
+    key = 'X' if 'X' in data_dict else 'y'
+    (train, train_v), valid = data_dict[key]
+    return train, train_v, valid
+
 def _build_sub(node_attrs, data_dict, fit_process, logger):
     method = node_attrs['method']
     if method in ['transform', 'fit_transform']:
@@ -58,7 +64,7 @@ def _build_iter_output(node_attrs, data_dict_it, logger):
     
     for data_dict in data_dict_it:
         obj, result, info =  _build_sub(node_attrs, data_dict, fit_process, logger)
-        (train_X, train_v_X), valid_X = data_dict['X']
+        train_X, train_v_X, valid_X = _get_process_inputs(data_dict)
         if result is None:
             train_result = obj.process(train_X)
         else:
@@ -113,8 +119,7 @@ class StageObj():
     def exp_idx(self, idx, node_attrs, data_dict_it, logger, include_input = True, include_output = True):
         if self.status == "built":
             for data_dict, (obj, train_, spec) in zip(data_dict_it, self.objs_[idx]):
-                # X key로 데이터 가져오기
-                (train_X, train_v_X), valid_X = data_dict['X']
+                train_X, train_v_X, valid_X = _get_process_inputs(data_dict)
                 sub_result = {'spec': spec, 'object': obj}
                 if include_output:
                     if train_ is None:
@@ -206,8 +211,7 @@ class HeadObj():
                     break
                 with open(filename, 'rb') as f:
                     obj, train_, spec = pkl.load(f)
-                # X key로 데이터 가져오기
-                (train_X, train_v_X), valid_X = data_dict['X']
+                train_X, train_v_X, valid_X = _get_process_inputs(data_dict)
                 sub_result = {'spec': spec, 'object': obj}
                 if include_output:
                     if train_ is None:

--- a/mllabs/_trainobj.py
+++ b/mllabs/_trainobj.py
@@ -31,7 +31,8 @@ def _train_build(node_attrs, data_dict, logger):
         result = None
     elapsed_time = time.time() - start_time
 
-    train_X, train_v_X = data_dict['X']
+    _ref_key = 'X' if 'X' in data_dict else 'y'
+    train_X, train_v_X = data_dict[_ref_key]
     info = {
         'build_id': str(uuid.uuid4()),
         'fit_time': elapsed_time,


### PR DESCRIPTION
## Summary
- `_expobj.py`: added `_get_process_inputs()` helper that falls back to `'y'` key when `'X'` is absent from `data_dict`. Applied to `_build_iter_output`, `StageObj.exp_idx`, `HeadObj.exp_idx`.
- `_trainobj.py`: `_build_sub` now picks `'X'` if present, else `'y'` when reading shape info.

Enables `TransformProcessor` nodes (e.g. `LabelEncoder`) that operate on `'y'` only (no `'X'` edge) to run correctly through the full experiment pipeline.

Closes #44