### PR TITLE
fix: always collect affected_nodes in Pipeline.set_grp regardless of edges

### DIFF
--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -350,6 +350,7 @@ class Experimenter():
             del self.node_objs[k]
         self.status = "open"
         self.build()
+        self._save()
 
     def set_node(
         self, name, grp, processor = None, edges = None,

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -377,9 +377,9 @@ class Pipeline:
         grp.update_attrs()
         attrs = grp.get_attrs(self.grps)
         new_edges = attrs['edges']
-        if len(new_edges) > 0:
-            affected_nodes = self._get_all_nodes_in_grp(grp)
+        affected_nodes = self._get_all_nodes_in_grp(grp)
 
+        if len(new_edges) > 0 or len(affected_nodes) > 0:
             for node_name in affected_nodes:
                 if node_name not in self.nodes:
                     continue
@@ -400,8 +400,6 @@ class Pipeline:
                 if has_cycle:
                     cycle_info = ", ".join([f"'{e}'" for e in cycle_edges])
                     raise ValueError(f"Cannot update group '{name}': node '{node_name}' would create cycle through edge(s) {cycle_info}")
-        else:
-            affected_nodes = list()
 
         self.grps[name] = grp
         return {


### PR DESCRIPTION
## Summary

- `Pipeline.set_grp` was only collecting `affected_nodes` inside `if len(new_edges) > 0`, so any group update where the group itself had no edges (but nodes had their own edges, or child groups had nodes) returned an empty `affected_nodes`
- `Experimenter.set_grp` relies on `affected_nodes` to call `reset_nodes`, so stale build artifacts remained after group updates
- Fix: move `affected_nodes = self._get_all_nodes_in_grp(grp)` before the edge guard, extend cycle-check condition to `if len(new_edges) > 0 or len(affected_nodes) > 0`

## Test plan

- [ ] `test_replace_affected_nodes_with_group_edges` — control case (was passing)
- [ ] `test_replace_affected_nodes_without_group_edges` — group has no edges, node has own edges
- [ ] `test_replace_affected_nodes_child_grp_when_parent_has_no_edges` — child group nodes missed when parent has no edges

Closes #51