### PR TITLE
feat: complete Kaggle S6E2 end-to-end notebook + fix 4 bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,15 @@ CLAUDE.md에서 불필요하게 토큰을 낭비 하지 않도록, 작업 내역
 Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한다.
 커밋 메시지에 "Co-Authored-By" 넣지 마라. PR에 "Generated with Claude Code" 같은 광고성 메시지 넣지 마라.
 
+## CLI 버전
+- git 2.43.0
+- gh 2.45.0
+
+## gh CLI 주의사항
+- `gh issue view <num>` 는 Projects Classic 지원 deprecated 경고로 exit code 1 반환 → **반드시 `--json` 플래그 사용**
+  - 예: `gh issue view 40 --json title,body,comments`
+- `--repo` 플래그 없이도 현재 디렉토리의 remote origin에서 자동 추론됨
+
 # modeler 모듈 요약
 
 ## 아키텍처 개요

--- a/examples/kaggle_s6e2/Heart.ipynb
+++ b/examples/kaggle_s6e2/Heart.ipynb
@@ -90,6 +90,26 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "a70033c9-979c-4ceb-bf77-a63fb0dd6ace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "import xgboost as xgb\n",
+    "import lightgbm as lgb\n",
+    "import catboost as cb\n",
+    "from lightgbm import early_stopping as lgb_early_stopping\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from mllabs.adapter import XGBoostAdapter, LightGBMAdapter, CatBoostAdapter\n",
+    "from sklearn.preprocessing import OneHotEncoder, StandardScaler\n",
+    "from mllabs.col import ohe_drop_first\n",
+    "from mllabs.processor import FrequencyEncoder, CatPairCombiner\n",
+    "from sklearn.preprocessing import PolynomialFeatures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "d690f38c-4651-4ef4-b797-1139e4014fff",
    "metadata": {},
    "outputs": [
@@ -394,7 +414,7 @@
        "id                        True   True  False  False        Int64  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -433,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "721b5bc9-b8d1-47c9-bdfc-86bd314d98e3",
    "metadata": {},
    "outputs": [
@@ -495,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "8eb4dd41-a9b9-4951-9f1c-c1e0097ced9e",
    "metadata": {},
    "outputs": [],
@@ -513,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b8b34a25-78d9-4f89-994a-d90e00b3992a",
    "metadata": {},
    "outputs": [
@@ -527,7 +547,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -538,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "88f5a72a-a833-4200-94af-454b04cefe3b",
    "metadata": {},
    "outputs": [
@@ -570,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f22f50a3-2b5b-4586-a1db-321952e9a931",
    "metadata": {},
    "outputs": [
@@ -753,7 +773,7 @@
        "(630000, 14)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -765,7 +785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "4df54d41-c844-4501-8173-6cbf7167d6a7",
    "metadata": {},
    "outputs": [
@@ -941,7 +961,7 @@
        "(270000, 13)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1203,12 +1223,12 @@
    "source": [
     "if os.path.exists('exp/is_test'):\n",
     "    e_is_test = Experimenter.load('exp/is_test', df_is_test)\n",
+    "    if e_is_test.status == 'closed':\n",
+    "        e_is_test.reopen_exp()\n",
     "else:\n",
     "    e_is_test = Experimenter.create(\n",
     "        df_is_test, 'exp/is_test', title = 'Train/Test셋 여부를 구분', sp = StratifiedShuffleSplit(n_splits=1, random_state = 1), splitter_params = {'y': 'is_test'}\n",
     "    )\n",
-    "    if e_is_test.status == 'closed':\n",
-    "        e_is_test.reopen_exp()\n",
     "Markdown(\n",
     "    e_is_test.desc_spec()\n",
     ")"
@@ -1234,7 +1254,7 @@
        "{'result': 'new',\n",
        " 'affected_nodes': [],\n",
        " 'old_obj': None,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f422f98fd70>}"
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f02ae2c14f0>}"
       ]
      },
      "execution_count": 14,
@@ -1331,7 +1351,7 @@
      "data": {
       "text/plain": [
        "{'result': 'new',\n",
-       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f422f990560>,\n",
+       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f02ae2eff50>,\n",
        " 'affected_nodes': []}"
       ]
      },
@@ -1346,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "id": "d8c9df3e-62aa-4a01-92a2-73eb2ede98c8",
    "metadata": {},
    "outputs": [
@@ -1356,10 +1376,10 @@
        "{'result': 'new',\n",
        " 'affected_nodes': [],\n",
        " 'old_obj': None,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f422da9ee40>}"
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f02b1f09370>}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1372,7 +1392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "id": "32c33dfd-4ac0-42a9-ab7a-07474d138f26",
    "metadata": {},
    "outputs": [
@@ -1381,11 +1401,11 @@
       "text/plain": [
        "{'result': 'update',\n",
        " 'affected_nodes': [],\n",
-       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f422f98fd70>,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f422daa0110>}"
+       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f02ae2c14f0>,\n",
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f02adadd3a0>}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1399,7 +1419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "id": "36bff740-a1f0-4309-94c4-32d51af57fb1",
    "metadata": {},
    "outputs": [
@@ -1433,7 +1453,7 @@
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1446,7 +1466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "id": "0463cc71-ab87-4bbb-b4c9-eb23d6616c01",
    "metadata": {},
    "outputs": [
@@ -1488,7 +1508,7 @@
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1501,7 +1521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
    "id": "fe252869-2d9e-4b0b-a559-57b026b6858f",
    "metadata": {},
    "outputs": [
@@ -1521,7 +1541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 23,
    "id": "0a2df579-9f48-46b7-ba48-42b4be10a495",
    "metadata": {},
    "outputs": [
@@ -1541,7 +1561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 24,
    "id": "89416062-b2ab-47aa-935a-345dc16f7c71",
    "metadata": {},
    "outputs": [
@@ -1563,7 +1583,7 @@
        "  [0])]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1574,7 +1594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 25,
    "id": "81408de9-e194-4365-a73c-0d0d0234c2ae",
    "metadata": {},
    "outputs": [
@@ -1618,7 +1638,7 @@
        "lgb1  0.503313   0.542511"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1629,7 +1649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 26,
    "id": "5c641b23-ba5d-40a6-8009-fbc217a5ad0d",
    "metadata": {},
    "outputs": [],
@@ -1639,7 +1659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 27,
    "id": "1f3bc976-5e20-4bc8-8e82-3c955b784d4c",
    "metadata": {},
    "outputs": [
@@ -1663,7 +1683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 28,
    "id": "be58dbda-751b-436c-8e58-48a089e643ac",
    "metadata": {},
    "outputs": [
@@ -1709,7 +1729,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>lgb2</th>\n",
-       "      <td>&lt;mllabs._pipeline.ColSelector object at 0x7f42...</td>\n",
+       "      <td>&lt;mllabs._pipeline.ColSelector object at 0x7f02...</td>\n",
        "      <td>1000.0</td>\n",
        "      <td>0.504157</td>\n",
        "      <td>0.638938</td>\n",
@@ -1722,7 +1742,7 @@
        "                                                 params               \\\n",
        "                                   categorical_features n_estimators   \n",
        "lgb1  [n2c__Chest pain type, n2c__EKG results, n2c__...      default   \n",
-       "lgb2  <mllabs._pipeline.ColSelector object at 0x7f42...       1000.0   \n",
+       "lgb2  <mllabs._pipeline.ColSelector object at 0x7f02...       1000.0   \n",
        "\n",
        "           AUC            \n",
        "         valid train_sub  \n",
@@ -1730,7 +1750,7 @@
        "lgb2  0.504157  0.638938  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1745,7 +1765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 29,
    "id": "a399914f-bda1-44a8-9049-4ae2feeae277",
    "metadata": {},
    "outputs": [
@@ -1781,7 +1801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 30,
    "id": "b81cff9b-8e2d-4bf1-b58b-16e38c10047a",
    "metadata": {},
    "outputs": [
@@ -1802,7 +1822,7 @@
        "  Name: importance, dtype: int32]]"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1829,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 31,
    "id": "21914ed1-dff1-4aa4-bc26-8549ba2319f0",
    "metadata": {},
    "outputs": [
@@ -1885,7 +1905,7 @@
        "Presence       282454  0.44834"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1914,7 +1934,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 56,
    "id": "f23371ac-ea22-4ad6-af83-892a862ef812",
    "metadata": {},
    "outputs": [],
@@ -1925,7 +1945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 57,
    "id": "6315a112-0fd3-41a8-85df-dd89eb7d237e",
    "metadata": {},
    "outputs": [
@@ -1935,7 +1955,7 @@
        "['Age', 'BP', 'Cholesterol', 'Max HR', 'ST depression']"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1946,7 +1966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 58,
    "id": "fc6085da-baef-4e3c-a847-81e14eb5901c",
    "metadata": {},
    "outputs": [
@@ -1974,7 +1994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 35,
    "id": "c5d7443c-c20b-4ecb-8984-38d994c02562",
    "metadata": {},
    "outputs": [
@@ -2024,7 +2044,7 @@
        "AUC  0.755908       0.733678  0.625654     0.552904  0.500486"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2049,7 +2069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 36,
    "id": "e4a439a6-149a-4990-bd62-723e05104dc9",
    "metadata": {},
    "outputs": [
@@ -2158,7 +2178,7 @@
        "9            BP  ST depression -0.001015"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2179,7 +2199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 37,
    "id": "7c742929-991f-46b9-8058-dbab9d4674c6",
    "metadata": {},
    "outputs": [
@@ -2292,7 +2312,7 @@
        "[66 rows x 2 columns]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2307,7 +2327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 38,
    "id": "17fb9b31-3013-4482-af73-f44e2bea92fb",
    "metadata": {},
    "outputs": [
@@ -2317,7 +2337,7 @@
        "SignificanceResult(statistic=np.float64(-0.6640987899506298), pvalue=np.float64(1.2118203419747983e-09))"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2345,7 +2365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 39,
    "id": "0e1329fd-9d81-43b4-b489-272b58ff3e0c",
    "metadata": {},
    "outputs": [
@@ -2404,7 +2424,7 @@
        "n_unique            3                4            3         3  "
       ]
      },
-     "execution_count": 42,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2423,7 +2443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 40,
    "id": "54c3d5ba-1094-4d72-af77-5aae0804039d",
    "metadata": {},
    "outputs": [
@@ -2441,7 +2461,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2472,7 +2492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 41,
    "id": "4de03ced-372c-4667-9602-1de362deaeef",
    "metadata": {},
    "outputs": [
@@ -2490,7 +2510,7 @@
        "Name: IG, dtype: float64"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2526,7 +2546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 42,
    "id": "4f2bd478-e485-4699-8400-cff38d1f7d24",
    "metadata": {},
    "outputs": [
@@ -2541,7 +2561,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2560,7 +2580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 43,
    "id": "f4ef84cd-21f4-4ad3-83e4-d4d27fc607c7",
    "metadata": {},
    "outputs": [
@@ -2574,7 +2594,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2601,7 +2621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 44,
    "id": "8ae13c7a-5290-4128-baa8-402f7032eb09",
    "metadata": {},
    "outputs": [
@@ -2615,7 +2635,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2634,7 +2654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 45,
    "id": "4401a199-dbd7-4c90-8ad9-175ec4ac5e10",
    "metadata": {},
    "outputs": [
@@ -2649,7 +2669,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2668,7 +2688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 46,
    "id": "677174a9-13a0-43ee-9103-b90523a6172f",
    "metadata": {},
    "outputs": [
@@ -2682,7 +2702,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2709,7 +2729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 47,
    "id": "6648b852-b4f0-4276-a592-1f141ce7f81f",
    "metadata": {},
    "outputs": [
@@ -2722,7 +2742,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2741,7 +2761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 48,
    "id": "d7209cc3-dc30-41c6-9f41-6000a1a46be4",
    "metadata": {},
    "outputs": [
@@ -2754,7 +2774,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2773,7 +2793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 49,
    "id": "f9453a57-fa2f-432b-af7e-3171ac367024",
    "metadata": {},
    "outputs": [
@@ -2786,7 +2806,7 @@
        "Name: Heart Disease, dtype: float64"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2813,7 +2833,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 50,
    "id": "6df87f78-309d-41b9-a7d2-6d9e5bd7f09a",
    "metadata": {},
    "outputs": [],
@@ -2823,7 +2843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 51,
    "id": "5dacd18c-5ecd-4d7b-8533-6f026c5910ba",
    "metadata": {},
    "outputs": [
@@ -3058,7 +3078,7 @@
        "11              EKG results             FBS over 120   1.518297e-37"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3094,7 +3114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 52,
    "id": "a4eeb95e-b02e-478c-8b4d-f1077565146a",
    "metadata": {},
    "outputs": [],
@@ -3114,7 +3134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 53,
    "id": "04217eb8-5f85-408f-98b0-0568f909e849",
    "metadata": {},
    "outputs": [
@@ -3293,7 +3313,7 @@
        "24              Slope of ST  ST depression      0.0"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3312,7 +3332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 54,
    "id": "08fc6b6a-40ee-4e30-be19-aeed4478b2bb",
    "metadata": {},
    "outputs": [
@@ -3365,7 +3385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 55,
    "id": "p75ij8uuivi",
    "metadata": {},
    "outputs": [
@@ -3378,7 +3398,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3400,7 +3420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 56,
    "id": "178734f6-e471-466f-8630-772828d78223",
    "metadata": {},
    "outputs": [
@@ -3408,7 +3428,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded: 22 node(s), 6 group(s), 1 fold(s)\n"
+      "📁 Created directory: exp/analysis\n"
      ]
     },
     {
@@ -3428,7 +3448,7 @@
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3452,35 +3472,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "f72102d4-f911-41d2-82b0-6ac15f151380",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import LabelEncoder\n",
-    "import xgboost as xgb\n",
-    "import lightgbm as lgb\n",
-    "import catboost as cb\n",
-    "from lightgbm import early_stopping as lgb_early_stopping\n",
-    "from sklearn.linear_model import LogisticRegression\n",
-    "from mllabs.adapter import XGBoostAdapter, LightGBMAdapter, CatBoostAdapter"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 58,
    "id": "cf5c82ee-4458-45f2-9092-1d6556293708",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'result': 'skip',\n",
-       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f175a5e79e0>,\n",
+       "{'result': 'new',\n",
+       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f0236751070>,\n",
        " 'affected_nodes': []}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3505,19 +3509,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 59,
    "id": "a7dgosknxl6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'result': 'skip',\n",
-       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f175a5e7bf0>,\n",
+       "{'result': 'new',\n",
+       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f02365c1d90>,\n",
        " 'affected_nodes': []}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3574,17 +3578,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 60,
    "id": "f9u8pj9ihxr",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n",
+      "Collect 1/1 (100%) Node 0\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "<mllabs.collector._shap.SHAPCollector at 0x7f1759158a70>"
+       "<mllabs.collector._shap.SHAPCollector at 0x7f0236687b90>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3669,20 +3687,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 61,
    "id": "lvdbho1tffk",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'result': 'skip',\n",
+       "{'result': 'new',\n",
        " 'affected_nodes': [],\n",
-       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f175a509c10>,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f175a509c10>}"
+       " 'old_obj': None,\n",
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f02365c18b0>}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3695,7 +3713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 62,
    "id": "nq2d9a6awt",
    "metadata": {},
    "outputs": [
@@ -3717,37 +3735,27 @@
        "        style node_ohe fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
        "        node_std[\"std\"]\n",
        "        style node_std fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
-       "        node_freq_st[\"freq_st\"]\n",
-       "        style node_freq_st fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
-       "        node_cat_pair[\"cat_pair\"]\n",
-       "        style node_cat_pair fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
-       "        node_cont_inter[\"cont_inter\"]\n",
-       "        style node_cont_inter fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
-       "        node_ohe_pair[\"ohe_pair\"]\n",
-       "        style node_ohe_pair fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
-       "        node_std_cont_inter[\"std_cont_inter\"]\n",
-       "        style node_std_cont_inter fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
        "    end\n",
        "    style grp_pre fill:#e3f2fd,stroke:#1976d2,stroke-width:2px\n",
        "\n",
        "    subgraph grp_clf[\"clf\"]\n",
        "        subgraph grp_xgb[\"xgb\"]\n",
-       "            grp_xgb_count[\"5 node(s)\"]\n",
+       "            grp_xgb_count[\"1 node(s)\"]\n",
        "            style grp_xgb_count fill:#f5f5f5,stroke:#9e9e9e,stroke-dasharray: 5 5\n",
        "        end\n",
        "        style grp_xgb fill:#e3f2fd,stroke:#1976d2,stroke-width:2px\n",
        "        subgraph grp_lgb[\"lgb\"]\n",
-       "            grp_lgb_count[\"3 node(s)\"]\n",
+       "            grp_lgb_count[\"1 node(s)\"]\n",
        "            style grp_lgb_count fill:#f5f5f5,stroke:#9e9e9e,stroke-dasharray: 5 5\n",
        "        end\n",
        "        style grp_lgb fill:#e3f2fd,stroke:#1976d2,stroke-width:2px\n",
        "        subgraph grp_cb[\"cb\"]\n",
-       "            grp_cb_count[\"2 node(s)\"]\n",
+       "            grp_cb_count[\"1 node(s)\"]\n",
        "            style grp_cb_count fill:#f5f5f5,stroke:#9e9e9e,stroke-dasharray: 5 5\n",
        "        end\n",
        "        style grp_cb fill:#e3f2fd,stroke:#1976d2,stroke-width:2px\n",
        "        subgraph grp_lr[\"lr\"]\n",
-       "            grp_lr_count[\"3 node(s)\"]\n",
+       "            grp_lr_count[\"1 node(s)\"]\n",
        "            style grp_lr_count fill:#f5f5f5,stroke:#9e9e9e,stroke-dasharray: 5 5\n",
        "        end\n",
        "        style grp_lr fill:#e3f2fd,stroke:#1976d2,stroke-width:2px\n",
@@ -3763,15 +3771,12 @@
        "<IPython.core.display.Markdown object>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from sklearn.preprocessing import OneHotEncoder, StandardScaler\n",
-    "from mllabs.col import ohe_drop_first\n",
-    "\n",
     "# OHE: X_nom + X_ord 가변수화\n",
     "e_aml.set_node(\n",
     "    'ohe', grp='pre', processor=OneHotEncoder,\n",
@@ -3796,27 +3801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "089319a2-19a2-4c7b-9172-df54dc009e93",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Building 0 node(s)\n",
-      "Build 1/1 (100%) Node 0\n",
-      "Build complete: 0 node(s)\n"
-     ]
-    }
-   ],
-   "source": [
-    "e_aml.build()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 63,
    "id": "10cc1c1e-9901-4f1e-8b0e-4e321447ffd8",
    "metadata": {},
    "outputs": [
@@ -3824,19 +3809,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experimenting 0 node(s)\n",
-      "Exp 1/1 (100%) Node 0\n",
-      "Experimentation complete: 0 node(s)\n"
+      "Building 4 node(s)\n",
+      "Build 1/1 (100%) n2c 4/4 (100%)\n",
+      "Build complete: 4 node(s)\n",
+      "Experimenting 4 node(s)\n",
+      "Exp 0/1 (0%) > lgb1 0/4 (0%) > 1/1000 (0%) valid_0-auc: 0.9335, valid_0-binary_logloss: 0.6583Training until validation scores don't improve for 50 rounds\n",
+      "Exp 0/1 (0%) > lgb1 0/4 (0%) > 600/1000 (60%) valid_0-auc: 0.9565, valid_0-binary_logloss: 0.2644Early stopping, best iteration is:\n",
+      "[617]\tvalid_0's auc: 0.956518\tvalid_0's binary_logloss: 0.264348\n",
+      "Evaluated only: auc\n",
+      "Exp 1/1 (100%) xgb1 4/4 (100%)> 500/1000 (50%) validation_0-auc: 0.9564\n",
+      "Experimentation complete: 4 node(s)\n"
      ]
     }
    ],
    "source": [
+    "e_aml.build()\n",
     "e_aml.exp()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 64,
    "id": "7f71bd85-e3a4-4c4f-8f5d-39b2fe4cb669",
    "metadata": {},
    "outputs": [
@@ -3854,7 +3847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 65,
    "id": "8bd9b9cd-6636-4b60-8cb3-ee8d10facd43",
    "metadata": {},
    "outputs": [
@@ -3898,58 +3891,10 @@
        "      <td>0.956418</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>xgb_freq</th>\n",
-       "      <td>0.954906</td>\n",
-       "      <td>0.958477</td>\n",
-       "      <td>0.956405</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>lgb1</th>\n",
        "      <td>0.954899</td>\n",
        "      <td>0.958201</td>\n",
        "      <td>0.956518</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>xgb_cat</th>\n",
-       "      <td>0.954893</td>\n",
-       "      <td>0.958117</td>\n",
-       "      <td>0.956490</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lgb_cat</th>\n",
-       "      <td>0.954890</td>\n",
-       "      <td>0.957568</td>\n",
-       "      <td>0.956399</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lgb_all_fe</th>\n",
-       "      <td>0.954839</td>\n",
-       "      <td>0.958407</td>\n",
-       "      <td>0.956436</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>xgb_cont</th>\n",
-       "      <td>0.954825</td>\n",
-       "      <td>0.958233</td>\n",
-       "      <td>0.956314</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>xgb_all_fe</th>\n",
-       "      <td>0.954811</td>\n",
-       "      <td>0.958360</td>\n",
-       "      <td>0.956428</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr3</th>\n",
-       "      <td>0.950505</td>\n",
-       "      <td>0.950816</td>\n",
-       "      <td>0.951911</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>cb2</th>\n",
-       "      <td>0.946906</td>\n",
-       "      <td>0.948648</td>\n",
-       "      <td>0.948643</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>lr1</th>\n",
@@ -3957,34 +3902,19 @@
        "      <td>0.945591</td>\n",
        "      <td>0.946846</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr2</th>\n",
-       "      <td>0.938139</td>\n",
-       "      <td>0.938318</td>\n",
-       "      <td>0.939891</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "               valid  train_sub  valid_sub\n",
-       "cb1         0.955224   0.956834   0.956806\n",
-       "xgb1        0.954915   0.958066   0.956418\n",
-       "xgb_freq    0.954906   0.958477   0.956405\n",
-       "lgb1        0.954899   0.958201   0.956518\n",
-       "xgb_cat     0.954893   0.958117   0.956490\n",
-       "lgb_cat     0.954890   0.957568   0.956399\n",
-       "lgb_all_fe  0.954839   0.958407   0.956436\n",
-       "xgb_cont    0.954825   0.958233   0.956314\n",
-       "xgb_all_fe  0.954811   0.958360   0.956428\n",
-       "lr3         0.950505   0.950816   0.951911\n",
-       "cb2         0.946906   0.948648   0.948643\n",
-       "lr1         0.945429   0.945591   0.946846\n",
-       "lr2         0.938139   0.938318   0.939891"
+       "         valid  train_sub  valid_sub\n",
+       "cb1   0.955224   0.956834   0.956806\n",
+       "xgb1  0.954915   0.958066   0.956418\n",
+       "lgb1  0.954899   0.958201   0.956518\n",
+       "lr1   0.945429   0.945591   0.946846"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3992,6 +3922,11 @@
    "source": [
     "e_aml.collectors['AUC'].get_metrics_agg()[0].sort_values('valid', ascending = False)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: 베이스라인 모델 성능\n\n| 모델 | valid AUC |\n|------|----------|\n| CatBoost (cb1) | **0.955224** |\n| XGBoost (xgb1) | 0.954915 |\n| LightGBM (lgb1) | 0.954899 |\n| LogisticRegression (lr1) | 0.945429 |\n\n- 세 트리 모델이 0.9549~0.9552에 밀집\n- CatBoost가 근소 1위 — 인코딩 없이 범주형을 native 처리하는 강점\n- LR은 트리 대비 약 1%p 낮음 — 선형 결정 경계의 한계, FE 탐색 대상"
   },
   {
    "cell_type": "markdown",
@@ -4003,7 +3938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 66,
    "id": "013f6772-324d-4964-afb1-650b85881284",
    "metadata": {},
    "outputs": [
@@ -4026,7 +3961,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4037,7 +3972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 67,
    "id": "103981e2-4970-402b-bea9-738c73a4c6de",
    "metadata": {},
    "outputs": [
@@ -4060,7 +3995,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4071,7 +4006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 68,
    "id": "6cb09e49-efb2-488c-9788-1fd13a055803",
    "metadata": {},
    "outputs": [
@@ -4094,7 +4029,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4105,7 +4040,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 69,
    "id": "68d397c7-cd3b-405e-8d67-6423dd31bdd8",
    "metadata": {},
    "outputs": [
@@ -4128,7 +4063,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4139,7 +4074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 70,
    "id": "87e18d04-673f-4c10-823b-ab624663234a",
    "metadata": {},
    "outputs": [
@@ -4170,7 +4105,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4181,7 +4116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 71,
    "id": "61b296cf-a4bd-4c46-91fa-c50d46f9df9b",
    "metadata": {},
    "outputs": [
@@ -4204,7 +4139,7 @@
        "dtype: float32"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4215,7 +4150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 72,
    "id": "e38d2ef0-cac1-4507-b7d7-b20eb4306c76",
    "metadata": {},
    "outputs": [
@@ -4243,7 +4178,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4264,7 +4199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 73,
    "id": "lrsgglxzi8",
    "metadata": {},
    "outputs": [
@@ -4451,7 +4386,7 @@
        "FBS over 120              0.150000   1.20  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4471,6 +4406,11 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: Feature Importance 모델 간 비교\n\n| 변수 | LGB(split) | XGB(gain) | CB(PVC) | SHAP | 공통 |\n|------|-----------|----------|--------|------|-|\n| Thallium | 3 | **61.8** | 17.9 | 상위 | ✓ |\n| Max HR | **23.9** | 1.7 | 21.1 | 상위 | ✓ |\n| Chest pain type | 5.2 | 12.8 | **16.6** | 상위 | ✓ |\n| Number of vessels fluro | 4.9 | 5.4 | 10.2 | 상위 | ✓ |\n\n- XGB gain은 Thallium에 61% 집중 — split point 수 편향으로 과장됨\n- LGB split은 Max HR 편향, CB PVC는 상대적으로 균형\n- SHAP이 모델 의존성이 가장 낮은 중립적 기준\n- 공통 상위: **Thallium, Chest pain type, Number of vessels fluro, Max HR, Exercise angina, ST depression**"
+  },
+  {
+   "cell_type": "markdown",
    "id": "xcgtqye9b5k",
    "metadata": {},
    "source": [
@@ -4479,13 +4419,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 74,
    "id": "xf5svexwvrj",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwgAAAKUCAYAAACg1h+bAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3gU5drA4d9s3/RCD026NAEj2EBUUKQpShMLTcBeEBUbosfzWQ4iKKjIkSZyRBCkiYhSrDRBRKr0EAiQXrfOfH9sssmSSkiySXju69oLduadeZ/Z3ezOM28ZRdM0DSGEEEIIIYQAdP4OQAghhBBCCFF5SIIghBBCCCGE8JIEQQghhBBCCOElCYIQQgghhBDCSxIEIYQQQgghhJckCEIIIYQQQggvSRCEEEIIIYQQXpIgCCGEEEIIIbwkQRBCCCGEEEJ4SYIghBBCCCFEISZPnkxQUFCx644fP46iKCxduvSi9l/a7cqTwd8BCCGEEEIIUdXVrVuX33//nRYtWvg7lEsmCYIQQgghhBCXyGw2c+211/o7jDIhXYyEEEIIIYS4RAV1FXI4HDz55JNEREQQFhbGuHHjWLRoEYqicPz4cZ/tbTYbjz/+OOHh4dStW5cJEybgcrkq+Cg8JEEQQgghhBCiGC6XK99DVdUit5k4cSKzZs3ihRdeYPHixaiqysSJEwss+/LLL6PT6fjqq694+OGHee+99/jvf/9bHodSLOliJIQQQgghRBEyMjIwGo0FrgsMDCxweWJiIh9//DGvvPIKL7zwAgC33347PXr0ICYmJl/5Ll268MEHHwDQs2dPNm7cyNKlS3n44YfL6ChKThIEIYQQwg+cTidz584FYOTIkYWefAghyohyd9HrtWWFrrJarfz000/5ln/66acsWrSowG327NmDzWajf//+PsvvvPNOfvzxx3zlb7vtNp/nrVu3ZsOGDUXHXE4kQRBCCCGEEKIIOp2O6OjofMtXr15d6DZnzpwBoGbNmj7La9WqVWD5sLAwn+cmkwmbzXaRkZYNGYMghBBCCCEuA0oxj7JVt25dAM6fP++z/Ny5c2VeV1mTBEEIIYQQQogy1rZtWywWCytWrPBZ/s033/gnoIsgXYyEEEIIIYQoY5GRkTzyyCP8+9//xmKx0KFDB5YsWcKhQ4cAT7elyqryRiaEEEIIIUSZqdguRgBvv/02Y8eO5a233mLQoEE4nU7vNKehoaHlUmdZUDRN0/wdhBBCCHG5kVmMhKhgysCi12tLi15fRh544AF++eUXjh07ViH1lYZ0MRJCCCGEEJeB8mklKMrmzZv59ddfufrqq1FVldWrV/PFF18wderUCo/lYkiCIIQQQgghRDkICgpi9erVvPPOO2RlZXHFFVcwdepUnn76aX+HViRJEIQQQgghxGWg4lsQrr76an777bcKr/dSySBlIYQQQgghhJckCEIIIYQQQggvSRCEEEIIIYQQXpIgCCGEEEIIIbxkkLIQQgghhLgMVPwg5apKWhCEEEIIIYQQXtKCIIQQQgghLgPSglBS0oIghBBCCCGE8JIWBCGEEEIIcRmQFoSSkhYEIYQQQgghhJckCEIIIYQQQggv6WIkhBBCCCEuA9LFqKSkBUEIIYQQQgjhJS0IQgghhBDiMiAtCCUlCYIQQogqJ3CKi8wLlp0YAw1D5WdNCCEulXQxEkIIUaVcNy9/cgDQaHaFhyKEqFKUYh4ihyQIQgghqpQt8YWvO5/hqrhAhBCimpIEQQghRLWRbPN3BEKIykpDKfIhckmCIIQQotqwGv0dgRBCVH2SIAghhKgy2s8pugtRqEmuAgohxKWSBEEIIUSVsSex6PU2l1YxgQghRDUmCYIQQogq4XBC8QOQUxwVEIgQQlRzkiAIIYSoEk6mFV9m2aHyj0MIUVXJNKclJQmCEEKIKiEqqPgyL/wCmU7pZiSEEJdCEgQhhBBVQo2AkpXrttBdvoEIIaokmea05CRBEH6xY8cOoqOjWbVqVZnve/LkyURHR/ssmzVrFtHR0Zw+fdq7bNWqVURHR7Njx44yj0EIUfY0rWQ/4H8kQFKmJAlCCFFaBn8HIKqHC0/Ii7Jy5cpyjEQIUV21nVvyrkMRH2loE8oxGFE8hxNe/QJ2HoE0OySkwuFzBZfN6QLeMAIOfgQmU0VGKoS4gCQIoky88cYbPs937drF8uXLGTBgAB07dvRZFx4e7nMl31969+7NbbfdhtEod1YSorL7cp+Lsxd5l2RligttgvzMVSinE66fCDuOXdx2WvbjeCKYh3qWvTEYXh1a1hGKy5p0Iyop+eYUZaJ3794+z91uN8uXL6d9+/b51lUWer0evV7v7zCEEMVwqRr3flu6bZUpnqlRZ90K97cBNNDpFAx6HQbd5X2yoGkaiqJ4/+9MzkLRwBBuxW13kfDyRpTEZLR0B4aoAPR/n4KDx7FoNrQ6kZgbh6DbcQjiksFeDl26Jn3leRiB90bCyB4QZC37eoQQ+UiCIPxu5cqVLFy4kJiYGCIjIxk0aBDDhw/3KbNlyxZWrFjBvn37iI+Px2g00qZNG0aNGsXVV19dqnpXrVrF66+/zieffOLtIjVr1ixmz57NypUrqVevnk/5fv36UbduXT799FPvsujoaPr27UufPn346KOPOHToEKGhoQwePJgRI0aQmprKtGnT+Pnnn8nMzOSaa67h5ZdfpmbNmqWKWYjLRWyayq1fqRxMKpv9jfvR8/DQAN8TWr0CoWZ4/hodL3Sp+sPzMr74m4TH1qGl2EuxtYYeG6GcxYCdLEJJoxZ6XISTipFkdLFxKH+UedgFcwJPzvU8crw5DF4eWEEBiOrj8r4ocDEkQRB+9fXXX5OYmEj//v0JDg5m7dq1fPjhh9SuXZtevXp5y61atYqUlBR69+5N7dq1OXfuHCtWrODRRx/lk08+ydeNqSIdPHiQn3/+mQEDBtCnTx/Wr1/PjBkzMJvNrF69mnr16jF27FhiYmJYvHgxr732Gh999JHf4hWiKrjxfyrHUyuuPrcGiTaY+LNKhBXGtK+6SYJjVxzx91/KWC+FIBIJJh4AK2kYcGAmHTOZZRPkpXplEXRqAnd08nckQlRLkiAIv4qLi2Pp0qUEBXkmOL/zzjvp27cvixcv9kkQXnnlFaxW36ble+65h8GDBzN37ly/JgiHDx9m7ty5tG3bFsg9hqlTpzJ48GCee+45n/KLFi3i+PHjNG7c2A/RClH5ZTm1Ck0OLvTlAY0x7f1X/6XKWHLgkvdhIxg4430exHl0VLL7S3z6vSQI4qLIVKYlV3UvkYhqoV+/ft7kAMBisdCuXTtOnjzpUy5vcpCZmUlycjJ6vZ62bduyd+/eCou3IO3atfMmB4C3+5OmaQwd6jvALieRiYmJqdAYi5KYmIjdntsNIT09nbS03FvWOhwOEhISfLY5c+ZMkc/j4uLQtNyTCalD6riYOox68OfwgAhLxb5W4eHhZVqHLsJS+MGVkAGnz3MFrbKlB1A7rNJ9dqWOS69DVA7SgiD8KioqKt+y0NBQUlJSfJadOnWKmTNnsmXLFp8vH8A7yM5fCjqGkJAQgHzjGIKDgwHyHZ8/RURE+DzPm7ABmEwmIiMjfZbVrVu3yOd16tSROqSOUtdh0Cnc3Uxh6T8Vf0pq0sGEa3InL6iI1yopKQmz2VxmdQQNb0fKv39FSy7N+AMAjSB8pyNNpwYKGkEkFLJNBTPoYMKdle6zK3Vceh3lS1oQSkoSBOFXJZlFKDMzkzFjxpCVlcW9995Ls2bNCAwMRFEU5s2bx/bt28ssnqKSDbe74Fk6ijqGwtblvQIjhMhvyZ163t3qZuYujZPp5VvXFSGeuzS3q6EwPlpHmxpV+yRCXzOQqAPjSHx+I7bvjqAmZoHr4r5zEmlIKHEYsGEjiFRqomLCgZUQzqC/YJB3hb5iXZrB/56FK2pXZK1CXFYkQRCV3rZt2zh//jyTJk2if//+Pus+/vjjMq0r58p/amqqz9V/u91OfHw89evXL9P6hBCFe76Lnue7eP5vneLiIm+D4PXlHTCkzeX1c6evHUTN+f3KZF9mILS4Qm8shtcWl0l9PgL0kPolyJTUQlQoGYMgKr2cq/AXXnXfsmULf//9d5nW1ahRIwC2bt3qs3zRokWoqlqmdQkhSi756Yv/uVreF7QJhssuOfCLSUNAW5b76NG2+G2KYjVA2heQsUSSA1FmtGIeIpd8a4pKr0OHDkRGRjJt2jTOnDlDrVq1OHToEN9++y3NmjXj8OHDZVZX586dadSoEbNmzSIlJYV69eqxe/du9uzZQ1hYWJnVI4S4OGaDjk97qIz9oWTlm4fCXa3kJ85v1r9R8PIsOxyMgdv+Beezx5OdnAUN5N4wQlQm0oIgKr3g4GBmzJhB27ZtWbx4MdOmTePo0aNMnz6dVq1alWlder2eqVOncvXVV7N48WJmzJiB0+nk008/zTfNqhCiYg1qWfKyh8ZIclApWc3QoRmcm5/b2iDJgagwSjEPkUPRZLSkEEKIKmBfvIs284ov1zoc9o6u/AmC0+lk7lzP3YFHjhyJ0Wj0c0RCVG8u5aEi1xu0/1ZQJJVf5f8GFUIIIYDQEp4/73hQGseFEPnJjdJKTr5FhRBCVAlHSnD7kN/vBatRftqEEOJSyLeoEEKIKuHqOsVf/WsZKT9rQghxqeSbVAghRJUQaCp+usvYVJmOWAhRGBmkXFKSIAghhKgyvuxb9PpwS8XEIYQQ1ZkkCEIIIaqMIcXc2yAyQK4CCiEKpqEU+RC5JEEQQghRbegU+VkTQohLJdOcCiGEqDZMerkKKIQojHw/lJRcahFCCFGlvHNjwcsbBlRsHEIIUV1JgiCEEKJKef5aA5/29F02rDmceFQaxYUQhZMxCCUn36ZCCCGqnDFXGRhzlb+jEEKI6klaEIQQQgghhBBekiAIIYQQQgghvCRBEEIIIYQQQnjJGAQhhBBCCFHtyUDkkpMWBCGEEOJydeIcrNkGp+L9HYkQohKRFgQhhBDicqPcXfDyhPkQEVyxsQhRYaQFoaSkBUEIIYS4nBSWHAA0GFtxcQghKi1JEIQQQlQ7GWczOf7jKRzpTn+HUrms3Fb0+kx7xcQhhKjUpIuREEKIauPEptP88NAWn2W6QBi5u4ir5peT17/0dwRC+I0MUi45aUEQQghRbVyYHACoGfDbv3b5IZpKyKD3dwRCiCpAEgQhhBDVwq5P96MVsm7//GMVGkul9ddJf0cghB8pxTxEDkkQhBBCVAv7Fx6Vn/hiFZZCCSFELkkQhBBCVAtn4+xy+lucBpH+jkAIv9FQinyIXJIgCCGEqNI0TeO9tw/zT70a/g6l8rPJrE5CiOLJLEZCCCGqpIPfxTJp5hmuP3KaMIeLThTei1haFrLFp/k7AiFEFSAJghBCiCrn+I4E/vXhaW49GEPOvDzFdRD44akt9Jh+bXmHVrkZ9MBFtCL8fRzaj8+fYVkMkLoIjHIaIUR1JF2M/Kxfv36MHSt3rgSYNWsW0dHRnD592t+hCCEqudmjt3LdkdOUdNJOBTixRr5buDKq+DIvzPf8e9ur0K6A5ADA5gLTYM9dmdMyyzREIYT/SepfDmw2G8uWLWPDhg0cPXqUjIwMQkNDadWqFT179uSOO+7AYKgcL/2sWbNo2bIl3bt393co5ebgwYNs2rSJfv36Ua9ePX+HI4S4RG90WcdfrRrQ5I9/Lmo76WYEHDlbfJl3V8CUFaCWcJ8h94O27JLCEqIiyEDkkpMWhDIWExPDsGHDmDp1KiaTiREjRvDyyy8zbNgwXC4Xr7/+OjNnzvR3mF6zZ89m06ZN/g4DgNGjR/Prr79St27dMt3voUOHmD17trRMCFHF7YhxMajvNk4FB3P9oVMsvq4Nzz5wG68OvpnfWtTHpZMf/yLtPwkJ6SUrW9LkIMfoDy86HCFE5VU5LmNXEzabjaeffprY2FjeffddbrnlFp/1I0aMYO/evezbt89PEVZuBoOh0rSsCCGKFp+p8fnfbqwGSHNBQgYcS4FDiXA+C2KzLn6f9SwQbIYaFqgbBP8kwl9JKppbQ3G5uXPXYTqcTaZ2SgbfdL6S9Vc1BSAl0MKcWzoRkZ5Fq9MJhe5fAXZ+so/2w1tgsF6G3zVdXy6/fc/ZCPM2wrvDoXMzuKYZWMzlV58QpSIXEUrqMvyGLD/ffPMNJ06cYPjw4fmSgxxt2rShTZs2+ZYfP36c999/n127dqEoCl26dOH555+nRg3fafvS09OZM2cOGzZs4OzZswQGBtK5c2ceffRR6tev7y1nt9uZN28e69at4+zZsxiNRmrXrs3111/PU089xenTp+nfvz8Aq1evZvXq1d5td+zYUegx7tixg4cffpjXXnuNjIwMvvrqK+Li4qhTpw6DBw9m6NChPuX//vtvli5dyl9//cXZs2fR6/U0a9aMBx54gJtvvtmn7KxZs5g9ezYrV670dgXKWbZ06VLWrFnDmjVrSEpKonHjxjz22GPceOONhcaad3uAhx9+2Lu8b9++3HTTTTz33HO8/PLLDBgwIN+2gwcPxuFwsHz5chRFYezYsZw5c4aPP/6YqVOn8scffwBwzTXX8PTTT/u8/uCZevHrr7/mm2++4dixY+h0Olq3bs2YMWOIjo4uMm4hKqtDiRpd/+fmXCkSgOKctgE2OJgCeHvC6EAPml7PN9e25qYDJzGqGtua5e9Lv71pVJEJAsCuKQfYNeUAke3D6Pu/mzCYSzqKoYp7dZEniytPKjBhfu7zp/rAtNHlW6cQolxIglCGNmzYAFDgyWZRzp8/z7hx4+jevTtPPvkk//zzD8uWLSMjI8OnO1J6ejqjRo0iLi6O/v3706RJE+Lj41m6dCkjRozg888/93bPeeedd1i5ciV9+vThvvvuw+12ExMTw/bt2wEIDw/njTfeYNKkSXTs2PGiY168eDEJCQncfffdBAQEsG7dOqZMmUJqaqrPoOtNmzZx/PhxevToQd26dUlJSWH16tU899xzvPnmm/Tq1atE9U2ePBmDwcD999+P0+nkf//7HxMmTGDZsmVFjiu45ZZbiI+PZ/ny5YwcOZIrrrgCgPr169O6dWsiIyNZuXJlvuPfs2cPR48e5dFHH0VRcq84ZGVlMW7cONq2bcvjjz/OyZMnWbp0KXv27OGLL77wSegmTZrEunXruPXWW+nXrx9Op5O1a9fy2GOP8e6773LTTTeV6NiFqEyGrSmf5KCkLA4XAEE2B0lBVp91gTZHifeT8Fcyf0zdS5cX25dpfJXSgVPw5tKKr3f6GrivG1zTvOLrFqIAMgah5CRBKENHjhwhMDAw35Xk4sTExPDWW2/Rs2dP7zKdTseSJUs4fvw4jRs3BuCTTz4hNjaWuXPn0qJFC2/Zfv36MXToUGbNmsXkyZMBz4n59ddfz+uvv15gnVarld69ezNp0iSioqLo3bv3RcV88uRJlixZQu3atQHP1fbRo0fz2Wefceedd3qXjx49mscff9xn26FDhzJs2DA+++yzEicIYWFhvP/++96T9ejoaIYPH86yZcvy7T+v5s2b0759e5YvX06XLl3yXbnv378/c+fO5ejRozRp0sS7fMWKFej1evr16+dTPjk5mXvvvZdnn33Wu6xTp04899xzfPrpp7z00ksAbNy4kbVr1/LSSy9x9913+xz7yJEjee+99+jWrZtP8iFEZZdk0/ijBGNcy1NMZAhNzifTe9c/fNrjarTsvyFF1TgTHkRCkJWwDBsOvQ6ry13kvo6vO315JAiLfvZf3fM3SYIgRBUkg5TLUHp6OoGBgRe9Xc2aNX2SA8B7IhsTEwN4uqusXbuWjh07UqtWLZKTk70Pq9VK27Zt2bJli3f7oKAgjh49yuHDhy/hiArXq1cvbxIAYDQaGTZsGG63m59/zv0xslpzr/DZbDaSk5Ox2Wxcc801HDt2jPT0kg2YGzp0qM/JdJs2bQgICODkyZOXdBx33XUXiqKwYsUK77KsrCzWr1/P9ddfT82aNfNtM3z4cJ/nN998M40aNWLz5s3eZd9++y2BgYF0797d571KT0+na9eunD59+pJjLyuJiYnY7Xbv8/T0dNLScm+m5HA4SEjw7bZx5syZIp/HxcWhablzxkgd1aOOYBNEWvCraX26kGw1EX3kNBO/+YXue46CpqEpsKtJPV64vyf/7X4VlmKSA4Dg+oGV4v0IDw8v3zqim+IvWa1zJ52o7n8fUkfZ1CEqB2lBKENBQUFkZFx8H8+oqPx9aUNDQwFISUkBICkpiZSUFLZs2UKPHj0K3I9Ol5vvjR8/ntdee42hQ4cSFRVFdHQ0Xbt2pVu3bj7lSiunq05eOVfgY2NjvcsSExP5+OOP2bx5M4mJifm2SU9PJygoqNj6CmqVCQ0N9b4+pRUVFUXnzp359ttveeKJJzAYDKxfv56MjAzuvPPOfOWDg4PzjQsBz+uxadMmsrKysFqtHD9+nIyMDG677bZC605MTKRRo0aXFH9ZiIiI8Hl+4fthMpmIjIz0WXbhTFMXPq9Tp47UUU3rmNJdx8jvLnaKmzKiaWRazPyn/w3oNI1hv+zhln3H+alNY9Q832tBDleJOhJcPb41tev6Hqc/3o+kpCTM5twBvWVeR79roEktOHqOClU/EuvYO7xP/f3ZlTqqRh3lSboYlZwkCGWoadOm7Ny5k1OnTl1UN6OiTthzMvWcfzt37pzvCnZBunfvzsqVK/n111/ZuXMn27ZtY8WKFXTs2JGPPvoIo9FY4vhKS9M0Hn/8cY4dO8bQoUNp3bo1QUFB6HQ6Vq1axXfffYeqluxEo7DXKO+VjNIaMGAAEydOZPPmzdx6662sWLGCyMjIYgdAF0XTNMLDw3nzzTcLLdO0qf+u6glRWiPa6riunsKDa9zsOHvxs2GWiqoSmmGj165/qJmexfzuHUgLsPBe/xtodC7JJzkA+LVVQ+779e98u9HwzGFSr2tNbnzzaoKjAioiev9TFDj8MRjuqZg3rHYIPNUfnr8T9JfJIHAhqhlJEMrQLbfcws6dO1mxYgWPPfZYme47PDyc4OBgMjIy6NKlS4m2CQ0NpXfv3vTu3RtN0/jwww9ZsGABmzdvLrQVoqSOHTuWb9nRo0eB3BaRf/75h0OHDjFmzBjGjRvnU/abb765pPovRnH9/Lt3705ERAQrVqygadOm7N69m+HDhxc45WpaWhrx8fH5WhGOHTtGRESEt0tVgwYNOHnyJO3atSMg4DI5CRGXjZYRClsfuPifj4MJLs5lwrbTnq5K97bRYzaU7IrekSQdAyeGUe9AOnWS00kLsGB2OImNCMlX1lDIhQcFGH347gLXVXuKAv93P0xcWE77B1S5WZoQ1YWMQShDd911F40aNeLzzz8v9OZj+/fvZ8mSJRe9b51OR69evdi7dy8//PBDgWVyuvC43W6fPoDgOUlu2bIlgE+3nICAgFJ10/nuu+84ezZ3tKLT6WTRokXo9Xrvlfecq/4XXuU/fPhwhd6cLeekPTU1tcD1BoOBvn37smXLFu+UqAV1L8oxf/58n+cbN27kxIkTPrMS9enTB1VVmTFjRoH7uLBPphCXg5aRBro2MPBsFwMjrjKUODkAaBpuYNesptz8SFNu++Mgiqbh1OtxGfJfoW51Kr4sw64+JhT+vXbJXH6YJUkIUW6kBaEMWSwWpk2bxlNPPcWECRO49tpr6dKlC6GhoSQlJfHHH3/w+++/8+CDD5Zq/4899hi7d+/mxRdf5Mcff6Rdu3YYjUbOnDnDr7/+ypVXXsnkyZPJzMykV69edOvWjZYtWxIeHs7p06dZunQpISEhdOvWzbvPtm3bsm3bNubNm0edOnVQFIXbb7+92FgaNmzIiBEjuOeeewgICOC7775j3759PPTQQ94+ildccQVNmjRhwYIF2Gw2GjVqxMmTJ1m2bBnNmjVj//79pXodLlabNm3Q6XTMmTOH1NRUrFYrUVFRtG3b1ltmwIABfP7556xbt45OnTrRsGHDAvcVFhbGhg0bOH/+PFdffbV3mtPIyEifVpIePXrQr18/vvrqKw4cOEDXrl0JCwvj3Llz/PXXX5w6dcpnYLQQomT6Da1P38FRrH/6NHERoWg6SAvIHTmtc6s88PNuP0ZYien10CACYvKPB/Mtp8DeadDqqZLt9+k+UAZj24QobzIGoeQkQShjDRo0YNGiRXz99dds2LCBOXPmkJmZSWhoqPcEvqRTe14oKCiIOXPmsHDhQtavX89PP/2EXq+nVq1adOjQgbvuugvwJCr33nsv27ZtY9u2bWRmZlKjRg26devGyJEjfWbmmThxIu+88w5z5871DrAuSYIwZMgQMjIyWLx4sfdGac8++yz33nuvt4xer2f69OlMmzaN1atXk5WVRdOmTZk8eTKHDh2qsAShTp06TJo0ifnz5/P222/jcrno27evT4LQoEEDoqOj2b59e5GtB1ar1XujtBkzZqBpGtdddx3PPPNMvm5Hr732GtHR0Sxfvpx58+bhdDqJjIykVatWZd4FTYjLiaJTeDwqixfsoWRZzVgcTmwmI5FpmYz54Q+Cbc6Ct5Mb+0Ld0OITBNfXnn+1ZXDLq7Bxb8HlerSF71/3dF8SQlQrilYWozzFZSPvnZQvvEdAVffkk0+yZ88e1q5di8WSfy7HnDspr1q1yg/RCSEudNNjRzluDSS2Zhhd9x3n/l8LOZHFM0B5+J47MVorz6BZp9PJ3LlzARg5cmSFTB5Bg4fgVDEJglbAWAKHE2avg293waQh0KVF/jJCVHKpyrNFrg/R3qugSCo/aUEQAs/9JrZs2cLAgQMLTA6EEJXP5plNsLtU3njjCAE7/ymyrAaVKjnwm+w7UV80kxEe6+t5CFFlSWtXSUmnQXFZ+/vvv1m1ahUTJ07EaDRy//33+zskIcRFMBt0/PuN5jyy6TakObwE2vn/3itCiMpPWhDEZW3p0qWsWbOGqKgo/vWvf1GvXj1/hySEKIWISBOm2kYcZ50FXiOUq2HZzBXQjUmISkoGKZecJAjiokRHR7Njxw5/h1FmJk+ezOTJk0tU9tNPPy3fYIQQl6RW2whi80y/LAqglxMkIUTx5KKKEEKIaqH729GFrqvdObwCI6nEUjP9HYEQfqOhFPkQuSRBEEIIUS1Yws3oCpljoO+imys2mMrKWcpBykKIy4okCEIIIaqNkX/fzdUvtvY+7zC+BaMP3+3HiCqZ4CB/RyCEHynFPEQOGYMghBCiWukwuhUdRrfydxiV03vDYd0uf0chhKjkpAVBCCGEuFy0aQg3tS58/bcvV1wsQohKSxIEIYQQ4nKy6U2ImwMP3ZK7rHYInPgE7rjaf3EJUc60Yh4il3QxEkIIIS43tcNg9uOehxBCXEASBCGEEEIIUe3JVKYlJ12MhBBCCCGEEF7SgiCEEEIIIS4D0oJQUtKCIIQQQgghhPCSFgQhhBDCz2xnMjnx1UlMQQZ0mXZqjWiFKaKQ20ILIUQ5kwRBCCGE8BMlCxr8S8dvzy4jw2xCQyHEnsWZF35BaR5B9L5h/g5RiGpDBimXnCQIQgghLhvaqh3YT2eRsS0B4+lzWIZ1wPRAZ7/E4jifRcfxDoJUBwDJbjMHo+qRrAtEPZ9IxOFEjr+9i8YTO/olPiHE5UvRNE3uDSGEEKJac0z5jqTnNmMjkNzhdypG0gi1pBGQPgNFX/7D8s5/dYSDo3/BluHGgoMaWiYAiYEB7LjyCjRddgyaxtUHjpEYHkb/E0PKPS4hLgfxStF3Cq+h/buCIqn8pAVBCCFEteR8bx3q88tAVckgABN6bATnKaHDQSjxNiu1H5iNZdE475rMTcc433sxuiwHBiuYu9XHPOgqAkZ1QlFK103BGZ/F3iGbcOp1qHodJpeKHSMu9ByvXTM3OQBQFP6Jqk2N5PRSHr0QQpSeJAhCCCGqHfvdH8Py3XhaC3QEYCeDYMxkEUwSBpzYCCCVCFyYSF16DGPPX9FSs8g4nELijP2AARUTzixwrYuBdXuxP7OCsJMvoguzXnRMsdP2YMGBEyt6VcWt6HFpnmTDrdfnPwajkYBgmWxQCFHx5JtHCCFEtaKdSoLlO8k757mCQgDpRHAWEw50aASQQTjnUNBwOQ0kjVrBwed38seCBGKCamLX6bO3BR0aLiy40+ykP/xNqeJyHExCRcHodmM3GtHn6eFbIzEtX3lrqp2sBCfbhm8kcX9SqeoUQojSkARBCCFEteJ681sU8g+v06Hmm8PEjB0LGYCbY9Z67IlsxLnAUE4Hh/F3jSgc2UmCExNGXBgAdfEfJCkTiDe/jO2rPSWOK+vPc9gNekBB1YOavVxBJSohiWYn4jDZneidbkLjMwhJykTTFHbvzGB1v438/uZfpXk5hBDZNJQiHyKXDFIWQghRrWS0/xfGPf+gEZi9RENPBqChEeBTVkPhNA0B2F2zPgoate0JZBqsnDVFEJWeTP30ZBTchJHsaW1AhwMLKmDDhBsj6QYLOtWFVXOSaA6GlrW4+sd+mCItnN9wmr+e24Z7fyI2nYGQDBfo3BhVlQCcWHB4T01UINYURobFTKDTTr2sZGyKidga4TjQccf+uwmMNJf7a+h2qkyfEcOyXS6cRiNOvZ7zRj1Zio4EqwlCzGDQUdOk8utwE81r5O8iJURlc155pcj1NbU3KyiSyk/GIAghhKhWXEdTUTCjy25FMJKMHgca4MJE3p8+FR1m7NgxUMceT4fUQ97tMgkgTqkHqISSjC77mr8RN2BHB9h1Jk6aa9AgKxEdGnqggS2ek/s1fmj8JXW6RbLvryw0nQI1g0HVCMpMxaq60aNixOVz3VIHhJBFmsFCUJoDHRCoOah3Ppksg4lj8w7R9tl2ZfI6HduawI8fHCH5nAOzwU1aeDDGSCsDR9bhsQ/Ps6FRFFfWyEJzuDhoNGJTdJ5YFQVsLggycV4z0mKWk4zndASY5AqsENWFJAhCCCGqPM2t4np9JY5Pf8OYkUIGYQSRjhuw4LnPgAIYSEHFjJtAVIxo6LGSiREdtdLOeJMDgAAyCdHSsBGAig69t1MQ6HGTRSDnjCHUz0rK7q+r4EaPDQuNHPEYVTeH/zCimU25geoUNItGaFYWCloBHaHA6FbRdApOo4LiyF6GG7uqkbH0EBSTILgdKi63iuoCp10lKNyITu85ec9McXJw83mSTtv4ffFpjDYHDosZfYqT4LPncOr1fHgojfBgK8/+vJvY8GAWNaiHU/EcoQbgUsGgeJ44VRSnSqOJidhdGtddaeDbcaHodZIsiMpHuhGVnCQIQgghqjxbq8noD8cQQBpOgggiE9Cjx+1TTkFDjw0XAdnX+z0nDS4MGDV3vv0acAIKDiwYSffZD0CAy4n+gtN8DR0aOuq6kvnHUNt3f243dbPSPK0Pej1xgSFkGUxYXE7qZKRicbtINZgxp7vJ0syk6FRC1CyyjEY0VUFRVVxpDk7/GIcrw8m5NCeH1p/DkeZCdWlosWkYXJ7jyLKYOF+/Nmhw850RZMRmsOu3NBS9Dk1VUTQw2+0EZNkge4pVk9vNFecTUfU1sSoKFofLmxz4CDCBSQ9ONzq7C4dbo67Dyfk/bAS9qJH1TvjFvH1CiEpGEgQhhBBVmvvYOZTDcRhJzW4dCEDJMyDZQQQGUtHhAkBFj4oF8FwEzyQQB2bcJPq0EgDYyZnOVM0ur2QnAAoGXAS67agY88eEDicGgmwOUgJzp0QNzbKhy673REgETr0Bo9uFxe0kyWzFaneQ6bagVzRU9CTqg8gyGvm7bQNqJKRSc1caP9T8gtNRITgNelwWIw6LGdWgJyAlA7MrN8kJsDmofyQGt8HAX5+cwx5gxaBTUHQ6bAEW0CmkRIQSkZjqE7sC1EzPBJOBUIcLnaahXnjvB70CmobxfAaKqmFTFI5bTNRwuqiZZmf5HjsD2pX/WAkhLo60IJSUzGIkKtSOHTuIjo4mOjqad955p8AyiYmJXHvttURHRzN27NgKjjBXTqyff/55oWWio6N5+umnfZaNHTvWe4zR0dF06dKFXr168eKLL3L48OFyjlqIqkfTNDS7q9TbqzM3o8OZfVVfQ0+WNxkA0DDiJAI3RtxYcRCOAxM2zCQRjgsDelxkEIwDT3cgFR3JROLEhJks3Ci40Ge3OigogBEXRly4Lzjp0OPihLkmxwNqEZmUTqAtu4uTqmG0uVFRyDCYcOoNBDrsNEs6T52MNOpmpmFVXb4tEpqG6lDouOsE4fEZOPUaCZGegdZGlxtruo2Q+BQMdidGuzP7eEFVFFTPgAGygqyca1AXnaoRkZBCxPkkasecxWRzoOn13pN/m9FARnZ3KCW7B5HDbObKjCyf4wswKGDUo9hcKKpv60m80UC62cC9/01DPz6RtlPTcLllLhQhqhppQRB+YTabWbduHc888wwmk8ln3bfffoumaegLuHFQVWEymXjlFc9sCXa7nf3797Nq1Sp+/fVXFixYQOPGjf0boBDlTN16GPfhRJQraqDbdQjnpmPojC7UPXGoZjPmIyfBe5dgJwo5/YNVcjvweEYN0KExyrZ/ocQmwr5TcH1LCAtC/fM47gEfoh4/DZjR0KPHiYILJzUuiEjBRYR3r3bMmHBQkzgUwIUBOxbOUR8dLtTsG6zpcRKU3bXIjY4Lr0AGkkkWVpzos8cUKMTrAogLDcVhVDDbTGjo0LlUjHY3IZl2HBhRNc/1udqZaT5X6syam1ruFJJ0gdh1JiwuBxbcKBqEptvRgCSXm7w/3wpgzsj0vO6K4hkQnb1GA5IjQjFn2QlJ8dxrQcveKDQ+mfh6Ncm0mjlcqwanI0JBUQjOzCIyIwsTEBcaQlu7k9rudBIMesJdbjAb2FwzkIJoQBI6apgUmqdnseeEiul1hSZ1jdzRTM+/u+kJMXvic6kahuxYs5waaw+5OJOu0aGOjui6esyXMOj5QIJKsEkj1KxgMSgYdAppdhWLAYz63Fc8bwyi+pNUteQkQRB+0b17d9atW8fmzZvp2bOnz7qVK1dyww03sH37dj9Fd+n0ej29e/f2Ph8wYABNmjRhypQpfPXVVzz//PN+jK4cZNphx2G4ojY0uODEbM8Jz/prmnn6OR+Ng9hE6NIcTEbQNPjqV9h9Avp2Aocb2jWCyOCLj+NIHHzxEzSuCXd2htA8JzHxqfD3SWjfCCLy7PvvE7Dpb8+ypnUgyw6rdoDJADdeCedTwWKEIAuEB8GV9eG3g3A+Gcwm6NEeaoX5xnA6z/GlZsIPf8Gh01AnFJIyPL9Sw7pCsBXW/gF7T0HXKz31rf8LziZBj6s8da7cDruPg0EPj9+Bei4N+6IdOFcfwH7CgebUADcqehQcGLo0Rn8uAZ1BhVrBqFluDIdjCSAZXVQoHI4DtxvMRs/rEx4IMQme9yj7arCmU9BUDS3Qii7EjJKUDk4XBFrBqAe7E+qEQ80QqBUK7RvD/E2QZUc9nwrocGFEw4AbI07MmMjCSGb29XcVDTNgwnN6a0LDiYITz8+SO/tkW4eCA/48BKYh3pdYBVQsqFiznwWhx4aCiifN8KQbF57M67CjYkbDc0+EQHJvTmbAhZ50MgnCnj0VqoJKIBl5tlezkxjPibcTI250mHCQogvEqGrocROoujBnuQg/5+nuY7doJEeasWouzNldlUxulUC7HaM7/7gHq+bC6k4hQQ1A1etR8hRRgDpJmRwLyu2+Y7eYUPU6jA4b6gUnuwpgybSjz64nPSSQpMhwVIMeo82BTlU5VTOC05G5n+G0AE+XKGOesQc1XW5q5nRfcrm5+eh5DkYEclavoMvTQqACKArxKCSFBXlaGMwGjmTombEbZuxygeomJMNBuqJHNeg8g55RPM0WAHoVTCroFHC6UexuNEVBp2qEOF2YNJXzARY0c3bCpmpgyI7V7aZBchY6ICbUiqrTefpKKNn71zx/Lz5ywvfmVYr3vwWdUFr1UMMMsZl572UBDQLBqUGyPftlUj3b6xVw5Om5ZtJ5Dq1Gds8zVYOELE8Zow661AabBvviwa1BoMHzdXRlOIRboX0N6NdMYd95jWm7PPV0qg3pTqgVAI931BFhUTiaAvGZKgeT4IHWCjUCPK/RzrMa/yRpNA5VMCoaSXZoFQG/n9ZQUbipvkLtQIUsp8b2OLgiFBqE+H6uTqRonEiFznXBYpAEqzqSBEH4RatWrTh69CirVq3ySRD+/vtvjh49yqOPPlpggrBlyxZWrFjBvn37iI+Px2g00qZNG0aNGsXVV1/tLXfgwAFGjRpFhw4dmDlzJkr2D4/b7ebhhx9m3759zJ8/n2bNmpX/wWa75pprAIiJiamwOivEhj0w6D+QmO5JAJ7tD+8+6DnhvOttWL/bU651fc+J5OJfPT/SdcPho7Fw/zTIyP5Ffetrz78WE3wwGsb0LKjGgo39CGb/kPtcr4NFz8DgG+CTdfD0HM+JrdXkqffB7nDPu/DNtiJ2ujz/opxzz7z1vPsgPN0XxnwMczfkHt9L98CE+Z56L/TsPM9JjSvPmYNO8Z6kF/Rcm7ICF1ZULDionefKsx494CCArK1JkH31m38y8XSHiUBHGtbU2NxT5iwnZCVDXHL+Q1Sz5/rIyPI8cqTm+f/hOM8DYEXu36onJhUTdsCeG3v2i6egZY8OyPsiejrsaJi8pRVsKBdMAZq3Dh02VJw4iQAUdHlO5D2jBLJQ89zzQMGJgTQcKKRQBwsZ2a0E+IxXqEkcdsy4s7sdqZjy7IPsFEHBgQk1e5CzBScmNcV7qyUVsKUZSCXIs96mEpLsIFDz/RzUTkvHqdNh0HzHPeQI07I4awzF6L5gfZ7xABqQGRJAcFL+OzHnMDid2AMsOI0GEmpFerd3WkwoqkqqJf9YAZvJiObWCu2HXDPTgWJ3EW4wcMRqwqkouBUFLcQMgZ7XzK1TUNLsGM5n4Kwd5EkuFdBluch0aChG1XPmm/d8XcFzBp5zjEY9msPzWVF1CslmEw3SMlE00GzZSYQ5+4wbQNGjGXSctphRFZ3n7Dzv+IkLx1Lk1HmBoq40Z7khJjN/+ZMZBRbHdcHO7NlvZ0x6/rJ2FX46k78+7HA6e/9L/4FJv/vudNf53P9/uEvN91Xy7CaN/7tRZek/8MfZguPMORK9Ak90VFiwTyPR5nlpx1+t8J/uns/7kz+6mbHLMwNXDSssv1PPjfUlSahuZAyC8Jv+/fuzZcsWzp075122cuVKIiIiuPHGGwvcZtWqVaSkpNC7d2+ee+45hg0bxvHjx3n00UfZtWuXt1yrVq148skn2bZtG/PmzfMunz17Nrt27WL8+PElTg5sNhvJyckFPi7GqVOnAAgJCbmo7So1VYXRMz3JQc7z/3wDWw/BzLW5yQF4uoZ8+Uv2FTzgTBLc935ucpCXzQFP/BfOp5QsjuPnfJMDALcKo2bAsbPw5Ge5J+lZDnj0U09LQ5HJQSEuPHNwq/DcfPjsB5jzo+/xjZ9bcHKQw3XBid8F/bkvfK5iwEgWmdTKd07juS564TUfT6lwYgggxa/D83Kvu5M9x48NhSzyX74lu6QFjcAiT9R0uNGTmV3e9yTXQBoGUtCRiZ40jNnHr8OGHSsGVFSMqBhxY0LN0+6goiOLAFwX7FNFIZVQsrB4k4PcWHInUNQBdUgg74fFbFOxGX3fHwVwqXqyDAaf43QpCnGBwZwMCScpxJo9liBXepAFu9WcPc5AAZ0OVacr9P21ZmThMhhIjgzNd4Ks6XQE2h35tnEaDGQZfOdnyvt/FajhVmljd9A1LRNNUdCCTBBs9pxRZp+wa0EmMOjQZ3r+DvRJWRhS7OjsLvTpDkznMnL/ZsCTNOeN8cK/EeBUkNXzp6HhucSe5c7dh6JwKjQAp76A5OAycuFXiQa8/EtxyYGHW4PpOz3JQc6+puzQ+P20xsaTKh/uyp2eNz4LxnyfvxWsspI7KZectCAIv7njjjv44IMPWL16NaNGjcJms/H9999z1113YTAU/NF85ZVXsFqtPsvuueceBg8ezNy5c+nYsaN3+dChQ9m2bRuffPIJ0dHR2O125syZwy233MI999xT4jhnzZrFrFmzLvr4chIIm83GgQMHeO+99wDPcVcb51M9J+cX2voPbPun+O0z85+YeNmdnq41Pa4qfj/rdhW8PMMOa3d6usfkleXwTV4ularBd3/mX+4s2x9ON+bsq9p67027vCEU0D8+h5XkMo2jrCi40XBBAbMAeY6liOTKW6rgwc0KCnps6HGQ93VR0BFKAjas6FAxY0NBQcWADic2AkigDgAuzASRig4NNzoyCEbFgA29d7vCGFEx4cKRfWwug0JygJHIFD2m7GHNbhTsGHFY9Oxs1JgOe4+TobeQFByAy5CdgKgQFxlMnYQ0QOFs7RBwadgCzOhcboxOF6gqtiArRocTnaqhKaDl6S5jdjipd+I0GcEBZAYH+QaqadROzyA+KNA7QDmHW68jNDGZtOAg0vR6fg0OwAQ0tdmp53Sjyz4pD3er3JaczvoatfK/G4qC5u3+o6LLvOA9VTUUlxstJ3nSikoJs4tceNKfkyjkdHXJHYIh8ii4napgBb0L285o2Ar4czuQCKl2zTu2RFQPkiAIvwkLC6Nbt27eBGHjxo2kp6fTv3//QrfJmxxkZmbicDjQ6/W0bduWv//+O1/51157jWHDhvHyyy/jcrmoXbs2r7766kXFOWDAAHr06FHguscee6zA5VlZWfm2qVGjBpMnTy60dcRfEhMTCQwMxGz2XC1NT09H0zSCgz399B0OB2lpaURGRnq3OXPmDHXr1vX0QW9UE06c99lnwhVhRGQ2RVn6e9GVW4xgK/gkUDMZUNo3yl9ntri4OGrXru3pPnZbhwJ6nIMWYELp1RGMBt8kwWKCOzrB55uLjq+kdAr0vAqWbfFdbtSXaZKg4MruP+9EQ+9zvLrs/vcFnRW5MWTP518ZFRa3O/vk30hRiYKnC5AbHXlbojxtBRfyTGkaRjI1vPUlWAM4GxCMpkCTzFjqZSZ6yzsxEauvg0XLQqfqvftU0DDgwl1gYpO9raLHphjRqZ57KYQ4HUSdUXGjkIkJFR1uIIxMLOkuwuMzOWcMx60nNznwxq2w86rGOM0GQpMzCU3OwpJpx+DyfKYDUjPJDA0kpUYYJpsdUHCYDQQlpfucK1sybeidTtzG7Lg1DaPLhU7V6Hg0hl9aNcl3xT0400atlHS+aXkFydkn8Vc4HPwTYEZ1q2TqdKQY9FhVjaBMB8nmC04rNA2cbtxhVm8cF9KrWm5i4dLQuVXUnIHEBh2KzZ0/KShCcJaTNIOhsD+Hy5bO272veBd2AgSIrqNw+lwiEOqzvHmYRnB2bnlRvx+FPC9P0kpQcpIgCL/q168fTz/9NH/++ScrV66kTZs2NGnSpNDyp06dYubMmWzZsoW0NN8+t0oBPyChoaFMmjTJeyL/3//+1/vFVVINGzakS5cuF7WN2Wxm6tSpAKSmprJmzRq2bt2KVoKrYxUtIiLC53lQkO8VRpPJ5PPlDuR+met08OkjMGiKZzCuosCTvYnsdwPcnAXf7YLNez1lm9eFdg1h2VbP85ohMHWkp4uS44LLUiYDyvsjfQb/XvgDUqdOndwnV9RGGXmLp/9/DkVBmf0oNKkD7w2HZ+d7kgSTwTO+YeiNsHoHLPq5ZC+Ud7/4/nLqFPi/+2BsT/j1ACzcnHt8rw/1dDMqKAlS8Lx+efuX5+04rOAZmJwnwTBix0EAYZwkkSuyB/zmFjfhyL5ircuehd+Gg0DSqEU4sRd3nGWgoM5D+al4xiro8CQDnl78CjY8pzTm7D35jkfwdAUyARoGkrMTJnf2RKe6fOmBhoKDcFLzJgeWQA6F5X6O/gxtiaLtx5rlwo2Bc9ZgjoV6+uwHOTJpnBZPTUcyZuwoaDhQSdSHkmoIRK+6qONM8bYMHLfUQlHc1MlMwo0RTfVEpEcjAEd2lzAdTvSYcRF5Ph2HYsBdyOxtTY6eRTXoONysDkmRnr9RW5CF4IRUzDYHBpeb9NBA7IFW7+ueGRqINS0Tnarh1imgQNTx09gCLDiNRvQuF3q3m/SQQFJCgmiSkMSpsBAc2S24OlWlbmISSUGB1HG6aJaYylmjgb+DLDg0T1eovPdHUDJdEOT2JMbgSQ5SbZ6PuNMNFgOq2YAuz5S2OqBNahaxQRpZeh2RdidpWToSQq2e7xO3ismtUsvmwK7X0Sg9i9gAC6cDLbkvTk4+qGkE25zcfeAUByJD2FkrFKfFkDs4+TLtbgSel+idbgqf74O/4osua9LDU50UZu3WSHV4tn2ik8INUQpERTIu3s2s3Z5PWZgZPr1N7/39vajfj0Kei8pBEgThV9dddx21atXi008/ZceOHUycOLHQspmZmYwZM4asrCzuvfdemjVrRmBgIIqiMG/evEJnPfrpp5+8/z906BAdOnQo68PIR6fT+SQVt956K08//TT//ve/adWqFc2bNy/3GCrMbR0gdjZsOQRNantOyAGCrLDpX7DziKerz/UtQa+HA6fgdJLnucUEA6/z9N8/EgdDbvQkGu0bQ+2wi4tjzuPw/F0wf6NnJqWhN+bOVvREHxh0vWdGpQ5XQM3sK2BfPAP/utfT3chihMa1PLMM/bwfagRDWAAcP++Jp1ENz6xD9SI8YyySMz39pbu2hqjsH8DPn4KX7/E9vpG3wNe/w++HPPuMioDIELi5rWeA86odnmPv0R46NfHMeJScAbdd5Yn/m62wcQ+kZMHYHigHEnF88guhGSk4DyWiea5PZ8/4o2KINGDtHIHxZCzGw2fArMdwZW04U8PzPtgcnlmMFMUzA1FqJqR4RlxqKtlXGPUoOg1CrOjsDkDznGDlzAhjNHhiC7R4Bp87NU/ip2nZp/JGdLiyr5HnvWqX93/kmckoZ2aZdBR05N6UzEzOvY9zWk9y8jPPOaEbHVneZXYiAAM6HCjZMxR51ulwEpK9Re7P3nlr/osFJwLq0SVrL4nUJCYk3HtSmW4K4O/IhrRLdNPA7umcbcZBXfd5MrUAzpvDOGcOx6I6yNBbcCt6DG43AdhIvWAsg+KNX0UFMrEQpDrQk4XbrRBrDsWZZ7yC0ekiIjWLfa3q4c7TuqDq9dgCLASkZ6F3udG7VdTsxgG3QY/boMdlNKBoYEnPxJQ9HsaaacOKDQ1IrRGKajET7HAS7HBSIyOLP+vUxG3QE5xpI81q5UiDetTInsEoyK2SPWY4X5cVTVFQ4jPRQi2ez0umExxuNE1Dl5SJFmxGsxpw60Bn93SzUi0G7JpGq5RMVOB0gIm66VkEOV2cDApA0ynYTXpOmyw0Sssi2WrkfM44BzX7pF+nZQejkmY08L8rG2BAw+kdAK2BonnGJIDPeIU80ZM3lQ00QJar8G45eiDEBAFGsOjhSGrue2sB9AZwucCB52si2AiZLjBlf1jT3J6x1XWDINwMe+LBoXlS5BoB0CAI9id5Qo2wQLIDGgRDi3BoHAwtIxWSbRprj0FcpqdMqAlaRMDTV+twqgoHEjVcqsbpdIX7W0OYRcez12hsPQMHEjWahHpmPUp1KEQFaWw5o2HWK9wYpRBmUZh0nWdZk1CFJmG5r80nPfVMiNY4nqpxfT2FAGNVSryqUqz+JQmC8Cu9Xk+fPn2YO3cuZrOZ22+/vdCy27Zt4/z580yaNClfN6SPP/64wG02b97M4sWL6devH6dOnWL69Ol06tSpQmcvAk/CMGHCBAYNGsS0adOYOXNmhdZf7oKshY8V6NTU93mr+p5HDosJHutNmWhVH956oOB1dcI9jws1qQPj6vguu6uYFqO+1xQdw4XHd99NnkdB7ut2wb6jfZ8PvN7zyGbsBsaxnm0slC1PanDp+zAC7tgU1NMJ6NLS0Rb+AjsPQ7NauPefxx2bjD4tHZ1qB1w4CAAsKBgwYkNBl31DMg2wQagR5eUH4bFecDgOpUltz8DcV7/GPXU9OpzkTR1UDNlX8nW4CPE+VwAzWTgwE0wKVi2YJHzn8zeqLjT0OHUmXLrcV6NB5lkaZp7D4naS92RSA4yqSojTxjljCA5dnm5HLoWzRGDFRWEnJk6dAYOqYsWOLvvaf/OU88RYw8gymzA7XQRnj9WxWfJ3aVKzEwa3XuftmqTguR+C3WgkyOUGBe9N1PLSFAW71fdTZFRVQp1OzptNJAcHsr3lFQS63Oizz6mzirlngOJW0QwKmIwodheapmEONtK3ocLk3ibaRpnybaOqGttPusl0QYYG7UI1aobosZqVC1qGA/JtW5BUu0a6U8OqhzMZGrUDFCKzp/i0uTQ0TUWn6DDqQVfFWxVeuLbwdS0i8h+boihcWw+urXfhOoV7LsiXg0wKPRoV/Po0C1doFl61XztRNEkQhN/dc889GAwGoqKi8jVP5pVz47QLu+ls2bKlwPEH586d44033uCKK67ghRdeIDk5mWHDhvHSSy+xYMECLJayPr0qWsOGDenVqxdr1qzhzz//rJCWDCH8RR8VClGelhrllvbe5Try//B4/xJdbk+3Koq4zte+cW4d7w1D/94w1I/XoT76ObnjDnSo6HEQQU7Ko2W3UoRyDgUdRpy0ylA5Y6mBljPfv6bRJOMUTkwYVZUAp51Mo5kGmefokHLUJ4ycm6Z5kg47uBSctgxSTFY0RcHodKO3QwYBmEmhoDmGzoSGUCM1EwMub3KQc+y1bWm4s/S40HunYw1LziAr4ILWCLeK06DH4HITGp+C02QkJTyYTKvVcw8CVcudAvQChXV4VPJ+xyoKDp0Oa3ZXuJouF3pNw63kbevJ2aFnWlTV5kKX5iDcrDFnVDj9mxU9YaJOp9ClcdmdjoSYFe+A2XDfOS2y5+yvujfhFJdGxiCUnExzKvyuTp06jBs3jr59+xZZrkOHDkRGRjJt2jQ++eQTli1bxttvv83zzz+fr0VAVVVeeeUVbDYbb731FhaLhTp16vDqq69y9OhR74xCFW3kyJHodLpSzYokRLVnKN2Jm+6hWwE1e8pTz023sojE90TQ01XJgANj9qDnSGcKt8Zv5YrMUzTIPMsNCXup5UhFye4a1SzpPAFOO40z4vLVmXPSrqIQSCZGnIQ7MrkiPZ46aSkYbLltDAmEkIKVDEw4s7dzo3CmdhipwRaf5CCHWXMTgINgsjBlx9voZAJGm8PT70TNHsyrUzC43d7THpPDSY2ziTQ8fJJ6J09jSMtAcblxWHyv3GsAOjBdMMWpU6cjIcD3Sn3eUyqzBg2yWyP0moZeVVE0DZ2mYdQ0z43JLAbcb4UQPzm02ORACFE5SQuCqDKCg4OZMWMGH3zwAYsXL8btdtOqVSumT5/OihUrOHz4sLfsZ599xs6dO5k4caJP8nDzzTczaNAglixZwrXXXsutt95aocfQuHFjevTowffff88ff/zhc3M3IUQpGQ3o3hoKLy5Ajx07waQTRQgp2QW07PsiZKChQyO3L0W4K43olH3YCURDh4pCVvYNzqxuJ+3iT2MtYBYlNwYSCcaKAwWFENK9p/mJRHnLee7urMeJAScGjDjIxISGhqYoHGlUk6ADWYQ6s/LV4dkerDhwYMBhNPDI+ptIOp3J8Y1xmINNJJxxkJbugvgM7MdTSTxhw2Y14bBayAiwEJieSWh8MrXah+G2hnLuzySceh3nQoOpk5pOUEoamdkJRJrVwtngINz6PCf1moZRVXHhuVGZS1EI1DSMqoZTp6DT5Xa4cul0aEEmBkpSIESVp2iVcVoVIYQQ4mK53bhHfkLK5wdIow6RnEePGz3pmLKTBc/sR6HkbUBX0eEgENDIwkIavmNVTNgIJdlngHUSEaQQShDpmPMkEMn6AE4rNTC73BhxoeAklRByxkjUI5EEggGN+IhgTjarAZpGm6OniErIrcONb/tHnCWEpCArd50bVuCMbXk50p3YkhyYQo3g0tBb9BgDfK8H/vCf/WxcHU9ySDBWlwudXo9J8wxGT9PrOBXuidnqdFMvKRm3prK/oSfxcQB/1ggkIdAKZr3nZmZON4pBx6ir9Py3T+HTvwrhT7HKG0Wuj9ImVVAklZ+0IAghhKge9Hr0Cx5D+/kdOO4miUgCSCeUBG8Rz+xBabgJBAxoKLizZz7KJIA0wvLt1oGFFMKx4LnKn0kAmVgBjTSsnDGFEqB5Zi9K0QdSJzMVIypuRaPma104Mvkv7NkzGSlACFlo6HAnZcKRBBJqBqJ3+/aO1gM2nR6L6ibLZERFISIpwzOmQF90gmAKMmIKKvokvcdzV9K+bwo/f3yEg/uzyMJMoKJSv5GJOydfybT5SfyzPQkly85PEWFowQGEqhrJeh0Og56EiCDvLED6LCcZkwIxG6R/txDVhSQIQgghqhWLLZkMrKgYSCcUC/EYsHnXK6i4UXESgAk7oJFKBJkUfo8UB2YcmDFhw4gDHVbMOAA3Lgc49Ho0NOo4krCYFALbhRH1wxD0oRYCuzfiwJD1ZJ2148y+wZ0KZOmNWFMcNEi2E6Zm5KtTQ8Gh15OlGrE6XOhrmFD0Zdd9p9aVodzzQacC1736fF2+XGrkm1XpBBn0HNYbiDNAXYeTFL0eXZodVafQLlxj9+uBxbZqCFEZyCDlkpMuRkIIIaoVW/OXcR5OwYYFFT1BnCfAp4uQgp0a2AkklWB0qLgwo+a5ZqbHjhsTeYfoGnAQQSIpBONGwRxsIGjxvQTcUbL7muy4fhnu3+Mw4wYU4gzB3hmUwtwZhKuZPuUTDAG4VB06RcGgqVwd9yCmmtYC9iyEKIlTyr+KXF9fe7WCIqn8pAVBCCFEtWIcfzPao18ThA1wYyIDJ0HZk5KCmwA0DJhwEsZZ0qiFmQw09KjoMWPDShoOLKQRhoYOEw6CSMeBEQWNBlrRJxoFyYwIRI8eY/YcSEGqnTS954Q/SR+AWXMRoHlmFcpUTCRYgghw2eiw+FZq9L+irF4eIS5j0oJQUjLVgBBCiGpFP+ZmdDX0kD2DkIOaqFhwEYKLEDTvtTENM+nYseCqV4uaKwdR8/5GuK9rSAZB6NGIIJEaxBNAOi4891MI+3JIqeIKvbYWJlRSsHo6KakOgt1ZKKi4DApnjKGcNERw0hDBaUsYTpOCzq1JciCEqHCSIAghhKheDHrMMVMxvXYLSqgON5BJIJrvbb0wkIEbM6AQ/NwNGPpdhenzUdT+7THC9jyLrVMLMs3BOC1mXIGBaJ2aErL7WaxD2pUqrLbPtyc1xEIATtKxYMeACRdmnJhxYgvWkxFkIj3YhD1QDzodDrM09AshKp6MQRBCCFHtpb+yFvXfqzFjy75lmgMNjXNcgdqmIfX/HlsxccRmsHPQD7h2J6DYnUS6szChogKHImrj1vlet6vdKpAbf+5fIbEJUd3FKP8ucn0D7eUKiqTykwRBCCHEZcX+2ELU34/jGtwVy70dMDYK9UscsV8f5uDgTVhwY9TcpJrNJAdavdOHWh12eiU8iM4gjf1ClAVJEEpO2i6FEEJcVswz7/d3CADU6t+I3a3duPcbcems4IKgVAcWvR2dplLrzeskORCiDMkV8ZKTBEEIIYTwk1NPKOjSnPTKbA1ODaV7AzJP27niroYYirnZmRBClBdJEIQQQgg/UoMVaj95NUajJARClCe5UVrJSdulEEIIIYQQwktaEIQQQgghRLUnLQglJy0IQgghhBBCCC9JEIQQQgghhBBe0sVICCGEuAQ2l4uQaeDE86O6dyS0iJSfVyEqH+liVFLSgiCEEEKU0uzdLqzTPMkBgAtoORdm/uHyY1RCCHFpJEEQQgghSmns+oKXP76xYuMQQhRPK+YhckmCIIQQQgghhPCSTpJCCCGEEKLak2lOS05aEIQQQgghhBBekiAIIYQQQgghvKSLkRBCCCGEqPaki1HJSQuCEEIIUQLLDrm49X8uVv7jmcI0eErRU5mOWitTnQohqiZpQRBCCCGK8E+iixZzcp9viAXPHQ+KNncvzLmj3MISQlwkaUEoOWlBEEIIIYqQNzkQQojLQbVNEKKjo5k8ebK/wygVm83Gf/7zH/r06UPnzp3p16+fv0OqMKtWrSI6OpodO3aU2T6Tk5OZNGkSvXr1Ijo6mrFjxwLQr18/7/+FEEIIUb3JjdJK7qK6GO3YsYOHH34YgJdffpkBAwbkKxMdHc2NN97ItGnTyiTAy9H8+fNZvHgxDzzwAM2aNSMwMNDfIVVp77//PuvXr2fUqFFERUURERHh75CEEEIIISqtUo9B+PTTT7njjjuwWCxlGY8Atm7dSrNmzXjqqaf8HUq1sHXrVq699lrGjBnj71CEEFXMLzHVY6DxvKuX4U4pZKUJRv51FzpDte1UIEQ2GYNQUqX6NmjdujXnz5/nf//7X1nHUyW53W5sNluZ7S8hIYGQkJAy29/lLiEhgdDQ0Aqpy+VyYbfbK6QuIUT567rY3xFcGtWl8lmzIpIDAAfMbfUNnzVbxu5P95ZvQDPXgHJ34Y9B78Dxc3A0DtIzyzcWIUShStWC0KNHDzRNY/78+QwYMICwsLAiy0dHR9O3b998YwJWrVrF66+/zieffEJ0dDQAs2bNYvbs2Xz11VcsX76c77//nvT0dNq3b88LL7xA48aN2bBhA5999hnHjx8nIiKCkSNHcvfddxdY99atW/n444/5559/CAoKomfPnjz66KMEBAT4lEtPT2fOnDls2LCBs2fPEhgYSOfOnXn00UepX79+vphnzpzJnj17WLVqFXFxcbzyyitFjhVwuVwsXLiQNWvWEBsbi9VqpWPHjjz88MM0a9bMZ98AsbGx3tdkzJgxjBs3Lt8+09LSuP3227nhhhv4z3/+k2/9jBkzmDdvHl988QUtW7a8qOO02+3MmzePdevWcfbsWYxGI7Vr1+b666/3adn45ZdfWLBgAUeOHMFmsxEWFkbr1q15/PHHadSokbdcfHw8s2fP5pdffiEhIYGwsDC6du3KI488UmyXn5LGcqGczxLA6tWrWb16NQCvvfZaoe9VaT6rixcvZsWKFfzwww/Ex8fz0UcfER0dTXJyMrNmzeKnn34iISGByMhIunXrxrhx44r9mxFC+N/ney699eDtLS4mXluxEwae3HCG/YuPcurHsxe97Y53D7Lj3YO+C3XQclBDWg9vzrk/EgiKCiTqxloouuyrsXYnLNsCs9bBXycgPQucaumCX7rV8yipOsFgMIHFBB2bQEq6pzP5E72h3zWwLwamrQarCSbcCQ1qwP5TsOlvaNMAurUpXZxCVHOl+tZSFIXHH3+cxx57jDlz5jB+/PiyjovJkydjtVoZOXIkycnJLFy4kCeeeIKHH36YDz74gIEDBxISEsKKFSv4v//7P5o0aUKHDh189nHgwAF+/PFH7rrrLvr06cOOHTv48ssvOXLkCDNnzkSn8zSgpKenM2rUKOLi4ujfvz9NmjQhPj6epUuXMmLECD7//HPq1q3rs+/p06fjcrkYMGAAgYGBPifDBXn11VdZv349Xbp04Z577iEhIYElS5YwcuRIZs+eTatWrejYsSNvvPEGU6dOJSwsjFGjRgHQvHnzAvcZHBxMt27d2Lx5MykpKT5XyVVVZe3atTRv3twnOSjpcb7zzjusXLmSPn36cN999+F2u4mJiWH79u3eOv744w/Gjx9P06ZNGTlyJEFBQcTHx7Nt2zZiYmK8r0lcXBwjR47E6XRy5513Ur9+fWJiYvj666/ZsWMHn3/+OUFBQYW+diWJpSC33HILDRo0YNKkSXTs2NE7ZqZ9+/ZFbnexXn31VcxmM/fddx+KolCjRg3vax0TE0P//v1p1aoVBw8eZOnSpWzfvp358+fL2BIhKrGNJ1UeXHfp+3nxF9hw0sX3gysmSdjw1FaOrYkt252qcHDxSQ4uPuldVO+GWtz+2fXoktPhuhfh8JmyrbOk4tJy/583hvW7oX0jT8KSY8a3MKYnzPo+d9n9N8Hn0p33ciHTnJZcqb+xunTpQpcuXVi6dCn33ntvvhPoSxUZGcnUqVNRFM+bGRYWxpQpU3j33XdZvHgxderUAeC2226jT58+fPXVV/kShMOHDzNlyhS6d+8OwKBBg5gyZQpffvkl69ev5/bbbwfgk08+ITY2lrlz59KiRQvv9v369WPo0KHMmjUr3xVlm83GokWLSjQGY8uWLaxfv56ePXvyf//3f95j6tmzJw888ABTpkzhv//9L/Xr16d+/fp8/PHHRERE0Lt372L33bdvX3744Qe+//57Bg0a5F2+Y8cOzp49y7333utddjHHuWnTJq6//npvi0ZBNm/ejKqqzJw506cV4KGHHvIp9+677+Jyufjiiy+oXbu2d3mPHj0YOXIkX3zxRYEtJDlKEktBmjdvTvPmzZk0aRJRUVElej1LIygoiI8++giDIffPaebMmZw8eZIXXnjB531p0aIF7777LgsWLOCRRx4pl3iEEJfunm9KeQW8AOtPFl+mLGQl2Mo+OSjE6V/PcfLHMzT+/Wf/JQfFyZscAKgafPq977KFm+HxO6BLC4QQuS5pRNITTzyB0+nk448/Lqt4vIYMGeI9kQa8J//dunXzJgcA4eHhNGrUiJiYmHz7aNSokTc5yDFixAjAc9IJoGkaa9eupWPHjtSqVYvk5GTvw2q10rZtW7Zs2ZJv3wMHDizxAO2cukaNGuVzTC1atKBr1678+eefJCUllWhfF7r22muJjIxkzZo1PsvXrFmDXq/njjvuKNVxBgUFcfToUQ4fPlxo3TlX/Tds2IDLVXBTfHp6Or/88gvdunXDbDb71FuvXj3q16/P1q1FNyeXJBZ/GjZsmE9yAJ73PDw8PN9MX3fffTfh4eFs3LixIkMsUmJios+4ifT0dNLScq/KORwOEhISfLY5c+ZMkc/j4uLQtNxJ46QOqaOq1ZHkoAxpuNXcuC88jvDw8DI5jpRj6WUZdLFO/XUG7dDpCq3zkhUwl2Xytv3V6rNb1esoTxpKkQ+R65LaPFu1asXtt9/Od999xwMPPFBoV5jSyNsfHvAO2q1Xr16+ssHBwcTFxeVbfsUVV+RbVqNGDYKDg4mN9VxlSUpKIiUlhS1bttCjR48CY8npipRXw4YNiz+IbKdPn0an0xUYT5MmTdi0aROxsbGEh4eXeJ85DAYDvXr14osvvuDEiRM0atSIrKwsNm7c6E0e4OKPc/z48bz22msMHTqUqKgooqOj6dq1K926dfOWGzx4MJs3b+btt9/mww8/5KqrruL666/n9ttv9x7L8ePHUVWVFStWsGLFigLrjYqKKvIYSxKLPxX0WTh9+jRXXnllvsTBYDDQsGFDDhw4UFHhFevCMSAXdvcymUzez1GOC1sML3yeN4mXOqSOqljHNbVh+8V34S+Egl6Xe/Jx4XEkJSVhNpu9z0t7HGpNFZ1BQXVVzIzuLXs1RamRAv/7pULqKxMWI9icuc8NesIG3AB5Lt5V9c9uVa9DVA6X3CnykUce4ccff+TDDz/kgw8+uKht3W53oesKO/ErbHnejPZi5GzXuXNnhg8fXuLtKtP0rn369OGLL75gzZo1PProo2zYsIHMzEz69u3rLXOxx9m9e3dWrlzJr7/+ys6dO9m2bRsrVqygY8eOfPTRRxiNRsLCwliwYAG7du1i69at7Nq1i6lTpzJr1iymT5/u09f/jjvu8Iknr7w/jKWNpbwV9VmtTJ8FIUTZWDFAT71PCv+7vxh/3F8muymWzqCj25RofnruD9TSDhIugj5AjzvTjTHIQKenWlOzXTi0uRn+OAIffVe57jRl0MPkITB9NZxP9SxrUQ/eHwlPz4F/zkDNEM/z+jX8G6uoMJXpI1rZXXKCEBUVxcCBA/nf//5X6N1vQ0NDSUnJP8dazlX88nLs2LF8y+Lj40lLS/NetQ4PDyc4OJiMjAy6dOlSLnFERUWhqirHjh3L18qSE2NxV9GL0qJFC1q0aMHatWt55JFHWLNmjXcAc47SHGdoaCi9e/emd+/eaJrGhx9+yIIFC9i8ebO3FUKv1xMdHe2d2eeff/7h/vvv57PPPmP69OnUr18fRVFwuVyX9PqWJJayUFaf1aioKE6cOIHL5fJpRXC5XJw8efKS3m8hRPmrG6Sw837otPDS9uN+Vo9OqbiuC037NqBJn/ok7E8h43wGP4y+iBmBLmCua6Rm23CiOtei1dAmGKwGMs5mYQ41YbDoPYV0OpgxFv7vfjibBL8dgqa1PDMH7ToCR+PL6Miy6QGrEUIDYWxPuP1qsNk9CUHDmpBphwyHZ4CyQQ8vD/SMkbCaICr7SvYdneB0oidBMJX/BSYhqqIymVZh9OjRrFy5stAWhIYNG7Jnzx5sNpv3amtqaiorV64si+oLdeLECTZt2uQzDmH+/PkA3HTTTYCnRaJXr14sWbKEH374ocCTzcTExEu6++5NN93EkiVLmDt3Lv/+97+94xAOHz7MTz/9RIcOHUrVvSivPn368P777/Pdd9+xY8cO7rrrLp8r8xdznG63m8zMTIKDg73rFEXxzoaUcwKdnJycb7rOxo0bY7FYSE31XLEJCwvjhhtuYMOGDezZs4d27dr5lNc0jeTk5EKPv6SxlJWy+qzedNNNzJ07l2+++YaBAwd6l3/zzTckJSUVOi2vEKLy6FjHAFzaVKcVmRzkUBSFGq3DqEEYow/fzbwuy3EnFH/tVB+scN+W/hjN+kLLBNa2FrwiJMDzaJ598ePGIqYPzbLBZz9Achbc1BrqR8Kh09C1NQSUQ4tsswu6sChKbrIghChQmSQIYWFhPPDAA3zyyScFrh88eDCvvvoqDz/8ML179yYtLY1vvvmGunXr5hu8UpaaNWvGq6++yl133UXDhg3ZsWMHP/74I506deK2227zlnvsscfYvXs3L774Ij/++CPt2rXDaDRy5swZfv31V6688sp8sxhdjGuvvZaePXvy/fffk5aWxo033uid5tRkMjFhwoRLPtY77riDDz74gLfffhtVVQvszlPS48zMzKRXr15069aNli1bEh4ezunTp1m6dCkhISHelok333yTc+fO0aVLF+rWrYvdbmf9+vVkZGTQp08fb70TJ07koYceYsyYMfTp04eWLVuiqiqxsbH89NNP9O7du9BZjEoaS1kpq8/q8OHD+fHHH3n33Xc5ePAgLVu25ODBg6xYsYJGjRrx4IMPlmncQojykfmUjoDpZd9dpyKN2DqAU7/GsW74b74rgkGv6Yke35q2D5bdGMJiWS3w+AW/UVfUKbisEGVIBiKXXJlNzHz//fezdOlS4uPzNyfecccdnD9/nq+++or333+fqKgoHnroIXQ6HX///XdZhZBPq1ateOaZZ/joo49YtmwZgYGBDB48mMcee8xnLENQUBBz5sxh4cKFrF+/np9++gm9Xk+tWrXo0KEDd9111yXH8q9//YuWLVuyevVqpk2bhtVqpVOnTjzyyCPeG6VdioiICK6//np+/vlnGjZsWOBc/yU9TovFwr333su2bdvYtm0bmZmZ1KhRg27dujFy5Ehq1qwJQO/evVm1ahVr1qwhKSmJwMBAmjRpwjvvvMOtt97qrbdOnTosXLiQ+fPns3nzZtauXYvJZKJ27dp07dqVnj17FnpcJY2lrJTVZzUoKIjPPvvMe6O0lStXEhkZyT333MO4cePkHghCVBFWow6o2gkCQP0b6jD6sLRcCiFKRtFKO7pXCCGEuAwoU0rfzUibUPh1OKfTydy5cwEYOXJkhUy4IMTlbJ8yrcj1rbWnKySOqsD/c0QKIYQQQgghKg1JEIQQQogiFNUKIISoOrRiHiKXfOsJIYQQxSgoSdh/3kXr+YVvk/GUXIMTQlRNkiAIIYQQpXBlzaKnQQ0wSoIgRGUisxiVnHx7CSGEEEIIIbwkQRBCCCGEEEJ4SRcjIYQQQghR7UkXo5KTFgQhhBBCCCGEl7QgCCGEEEKIak+mMi05aUEQQgghSunY6IKXZz4lXRmEEFWXtCAIIYQQpdQ43IA2AX487mLzKRjSSqFNDb2/wxJCFEDGIJScJAhCCCHEJbq1sYFbG/s7CiGEKBvSxUgIIYQQQgjhJS0IQgghhBCi2pMuRiUnLQhCCCGEEEIIL2lBEEIIIYQQ1Z5Mc1pykiAIIYQQZUDVNGp96CbB4Xk+pDl8eaf8zAohqh7pYiSEEEKUAf17uckBwOJ/IGKay38BCSF8aChFPkQuSRCEEEKIS/TrqYITgSTJD4QQVZC0fQohhBCX6In1/o5ACFE8aSUoKWlBEEIIIS7R0WR/RyCEEGVHEgQhhBDiEqW4C19ndxaxUgghKiFJEIQQQohyZJkukysKURnIIOWSkzEIQgghRCksO+jinlX+jkIIIcqeJAhCCCHERbK5VEkOhKhipC2v5KSLkRBCCHGRrNNUf4cghBDlRloQhBBCCCFEtSfjDEpOWhBEPmPHjqVfv37+DsOvZs2aRXR0NKdPn/Z3KEKISiZLZiUSQlRz0oJQhnbs2MHDDz9c6Hq9Xs/WrVsrMCIhhBBlLcNWDXsyK3cXvPy7V+D2ThUbixDC7yRBKAe33347N9xwQ77lOl3VaLCZOXMmmlYNfwAvwujRoxkxYgQmk8nfoQghKpmas/wdQRkrLDkA6PWm599zc6BmWIWEI0R5ubzPbC6OJAjloFWrVvTu3dvfYXhlZGQQGBhY4vJGo7Eco6kaDAYDBoP8eQghysY/SSrNwyvhRaKoESUrV2tU7v/7dYL/TYBAS7mEJITwPzkD8pPp06fz+eef8/rrr9OnTx/v8n/++YcRI0bQtm1bPv74Y2+rw9atW1mwYAF79+7F4XDQsGFDBg4cyMCBA332269fP+rWrcv48eOZMWMGe/bsITQ0lJUrVwIQExPDnDlz2Lp1K4mJiYSFhdG6dWvGjBnDlVdeCXjGIJw5c4ZVq3Ln8Dty5Aiffvopf/31F8nJyYSEhNC4cWMeeOABbrzxRm85h8PBwoUL+e677zh16hQmk4mOHTsybtw4WrVqVezrcv78eRYuXMj27ds5c+YMdrudqKgo+vTpwwMPPIBer/eWXbVqFa+//joff/wxBw4cYOnSpZw7d466desyatQo+vbt67Nvt9vN3Llz+eabb0hMTKRhw4aMGjWKY8eOMXv2bFauXEm9evUAzxiEwpYtXbqUNWvWsGbNGpKSkmjcuDGPPfaYz+sAsGTJEjZt2sTRo0dJSkoiNDSUzp0788gjj3j3KYSoOjRN4/oFpRt/cMdXKofH+TFB0DR4ZRHM/gES08B9CbMwrdoJQcN8l4VZ4ZoW8P4oaNPg0mIVopyoMki5xCRBKAc2m43k5OR8yw0GA0FBQQA89thj7Nq1i3feeYd27drRsGFDbDYbL774IhaLhX/961/e5GDZsmW89dZbtGvXjlGjRmG1Wtm6dStvv/02sbGxPPXUUz71nD17lkceeYQePXpwyy23kJmZCcC+fft45JFHcLlc3HnnnTRt2pTU1FR27tzJ7t27vQnChZKTk3nkkUcAuOeee6hTpw7Jycns37+fv//+23ti7HK5eOKJJ/jrr7/o3bs3gwcPJj09neXLlzN69Ghmz55N69ati3zt/vnnHzZu3Ej37t2pX78+LpeL33//nRkzZhAbG8vLL7+cb5uZM2dit9u5++67MZlMLF26lMmTJ1O/fn06dOjgLffuu+/y9ddfEx0dzf33309ycjLvvPPORZ+sT548GYPBwP3334/T6eR///sfEyZMYNmyZT77WrhwIW3btmXIkCGEhoZy5MgRvvnmG7Zv386XX35JWFjYRdUrhPCvfl+72XK+dNseSYO4DI06gX46QbnpFfh5f/ntPzkL1u+Gq56BvdOhZVT51SWEKHeSIJSDWbNmMWtW/k6qN954I9OmTQM8ycK///1v7rvvPl566SXmzp3Lu+++y/Hjx5k6dSq1atUCID4+nilTpnDbbbfx73//27uvQYMGMWXKFL744gvuuece6tev710XGxvLK6+8wl133eVdpmkakydPxul0Mn/+fJo3b+5dN3LkSFS18KtJu3fvJjExkbfeeouePXsWWm7x4sX88ccffPjhh1x33XXe5QMHDmTIkCFMmzaNTz/9tPAXDujUqRMrVqxAUXJ/RIcNG8arr77KihUrGDduHDVq1PDZxuFwsGDBAm/XqFtvvZU777yTr776ypsgHDlyhK+//prrrruO6dOne5OvHj16MGzYBVfCihEWFsb777/vjTE6Oprhw4ezbNkyHn/8cW+5L7/8EqvV6rNtt27dePTRR1mxYgXDhw+/qHqFEP5zNkNjzfFL28d/tqu8111ffMGydj6lfJODvNwqPDcfVr5UMfUJcRFkmtOSq4QdIqu+AQMGMHPmzHyPRx991KdcVFQUL7/8MgcOHODhhx9m5cqVDB06lG7dunnL/PDDDzgcDu68806Sk5N9Hl27dkVVVbZt2+az39DQ0HzTlB48eJCjR4/Sr18/n+QgR1EDqHNaPX777TfS09MLLbd27VoaN27MlVde6ROny+WiS5cu7N69G5vNVvgLB1gsFu+Jt9PpJCUlheTkZK677jpUVWXfvn35thk0aJDPuIlatWrRsGFDYmJivMt+/vlnAIYOHepzrM2aNePaa68tMqYLDR061CeBadOmDQEBAZw8edKnXE5yoKoq6enpJCcn06JFC4KCgvj7778vqs7ylJiYiN1u9z5PT08nLS3N+9zhcJCQkOCzzZkzZ4p8HhcX5zPQXeqQOqp6HUlFf3WVyPEUrcA6wsPDy/c4EtKoUOdTgar/nksd/qlDVA7SglAOGjZsSJcuXUpUtmfPnvz000+sXbuWpk2b8uSTT/qsP378OEC+5CKvxMREn+dRUVE+ffUB78lyy5YtSxRXXldffTV9+vRh1apVrF27ltatW9OlSxd69uxJkyZNvOWOHTuG3W6nR48ehe4rOTmZOnXqFLre5XIxb948vv32W2JiYvLNppSamppvm6io/E3ZoaGhxMXFeZ/n3M+gUaNG+co2atSI3377rdCYLpS3tSZvfSkpKT7Ltm/fzuzZs9m7d6/PFyjg8wXqbxERET7PcxLCHCaTicjISJ9ldevWLfL5he+x1CF1VPU6WpkhWA9pl3ALhMc76gqsIykpCbPZ7H1e5sfRqj6EBUJyRqljvyiP3QFU/fdc6vBPHeVJZjEqOUkQ/CwtLY0///wT8HQnSkxM9PkDzDlBfv311/N1rclx4QmyxVL2M0u8/vrrPPDAA/z222/s2rWLhQsXMmfOHMaPH8+QIUO85Zo1a8YzzzxT6H7Cw8OLrOf9999n8eLF9OzZk1GjRhEeHo7BYODAgQN8+OGHBU6/WljrR3lN1VqS+vbu3cvjjz9O/fr1efzxx6lXrx5msxlFUXjppZeK7NIlhKicdo/U0+S/pc8Qbm7ox0b7n96E216HuOTyq8NshEduh/tvKr86hBAVQhIEP3vjjTc4d+4czz33HB988AGTJk3i448/9rYANGjgmQ0iLCysxK0SBWnYsCEAhw4dKvU+mjVrRrNmzXjwwQdJS0tj+PDhzJgxg8GDB6MoCg0aNCApKYlrrrmm1Pd8+Pbbb+nUqRNvvfWWz/K83YVKI2fw8IkTJ/K1AJw4ceKS9l2Q7777DrfbzQcffOCTwGVlZVWq1gMhRMldEaZgf0aP+f2LTxKuLbzhtGK0awRn5vgu+2AVPDW39Pv8ZAz0iYba4WCU0wkhqhMZg+BHS5cuZePGjYwaNYohQ4bw1FNPsXPnTj777DNvmZ49e2IymZg1a1aB/ffT09NxOBzF1tWiRQuaNGnCypUrOXLkSL71RV1tT0lJyXfFOzg4mKioKGw2m7f7TJ8+fUhISOCLL74ocD8X9kMsiE6nyxdLVlYWixYtKnbbonTt2hXwDBzOeyyHDx9my5Ytl7TvguQkeBcey5w5c6T1QIgqzKQv3SDHX+/zw+Dk4jzZD9SvS15+42ugLct9jLsD6teU5EBUGRpKkQ+RS/6qy8GBAwf49ttvC1zXvXt3AgICOHz4MO+//z6dOnXioYceAmDw4MFs3bqVzz77jM6dO9OhQwdq167NxIkTefPNNxk0aBC9e/embt26JCUlcfjwYTZt2sSSJUuKnapTURRee+01Hn30UYYPH+6d5jQtLY2dO3dy3XXXMXTo0AK3XbNmDYsWLeLmm2+mfv36GAwGdu7cye+//07Pnj29XZruvfdetm7dyvTp09m+fTvXXHMNgYGBxMXFsX37dm+iU5Rbb72VZcuW8eKLL9K5c2cSEhJYtWoVoaGhxb3sRWratCkDBgxg+fLlPProo3Tv3p3k5GSWLFlCy5Yt2b9/v8/A40vVvXt3Fi1axFNPPcWAAQMwGo1s3bqVw4cPy/SmQlRxr3SGN7cVXy4vXRl+v5QpRYGdU6DThMLLaMsqLh4hRKUgCUI5WLduHevWrStw3fLly9HpdLz00kve+x3kHVA8adIkhg0bxiuvvMKiRYsICQmhf//+NGzYkIULF7Js2TLS0tIICwujUaNGPPLII/kGABWmTZs2zJ8/n88++4wffviBr7/+mrCwMNq0aeNzv4ALXX311Rw8eJCff/6Z+Ph49Ho99erV4+mnn2bw4MHecgaDgWnTprF06VK+/fZbbzJQs2ZN2rRpk+/GZQUZP348gYGBrF+/ns2bN1O7dm0GDBhA69atixyoXRITJ06kZs2arFixgunTp9OoUSMmTpzI3r172b9/v88gwUvVoUMH3n33Xf773//yySefYDab6dy5M59++iljxowps3qEEBVvcKuLTxAqtY5NPEnA9S/A7/94lvXuAGsm+TUsIcqatBKUnKKV10hOIaqIZ555hu3bt7N58+Z8sz8JIcSFUmxuwmZc3E+nNiH/9Tin08ncuZ4xACNHjvSZrlkIUfZ+Uf5b5PobtYcqKJLKT8YgiMtGQWM4/vnnH3777TeuueYaSQ6EECUSapHvCiGqIq2Yh8glXYzEZWP16tV8++233HDDDYSHh3P8+HGWL1+OwWBg3Lhx/g5PCFGFvHwN/Hu7v6MQQojyIQmCuGy0atWKTZs2sXjxYlJSUggMDCQ6OpqxY8fSqlUrf4cnhKhC3rzJwLvbXTj9HYgQQpQDSRDEZaNt27bMmDHD32EIIaoJxwQDJ1JcjFwLG0/5OxohRHFkkHLJyRgEIYQQopQahRrYMLToa23Pd6ygYIQQooxIC4IQQghRjt65VX5qhagMpAWh5KQFQQghhLhEnWr4OwIhhCg7kiAIIYQQl+hR6UYkRKUn05yWnCQIQgghxCUafZV0IxJCVB+SIAghhBBl4Nu78y87IjdmFUJUQXLJQwghhCgDdzQxoE3wdxRCiMLIIOWSkxYEIYQQQgghhJe0IAghhBBCiGpPBiKXnLQgCCGEEEIIIbykBUEIIYQQQlR7Mgah5KQFQQghhBBCCOElLQhCCCHERZq2w8VrP0OqO3fZRz3gkQ7ysypEZSUtCCUn32RCCCFECZ1OcxM1q+Chjo/+AE2DXdzWVH5ahRBVm3QxEkIIIUqosOQgx+3LKygQIYQoR3KZQwghhBBCVHuqvwOoQqQFQQghhCiBdIfL3yEIIUSFkBYEIYQQogSCP/B3BMVISoOI4b7LEuZDRLB/4hGiktF01W+QcmxsLD/99BPnzp3jnnvuoX79+rjdblJSUggNDUWv15dqv9KCIIQQQpSh+Ew/dGRIy8yfHABEFrBMCFHlaZrG+PHjueKKK7jvvvsYP348hw4dAiA9PZ3GjRvz4Ycflnr/kiAIIYQQxfjxeMm7F83Z44cEofGYwtcpd1dcHEJUYppS9KMq+c9//sP06dOZMGEC69evR9NyJ1AIDQ3l7rvv5uuvvy71/iVBEEIIIYrRY2nJy+6LL784CnQuGRKzii7zv80VEooQomLMnj2bBx98kP/7v/+jQ4cO+da3b9/e26JQGpIgCCGEEEU4nnRxg5O1omdCLXv1RhVfZtj08o9DCFFhYmJiuP766wtdHxgYSGpqaqn3LwmCEEIIUYQnf7i48i0iyieOQrmLLwJAh6fKNQwhKjtNpxT5qEpq1apFTExMoev/+OMPGjZsWOr9S4IgitSvXz/Gjh3r7zDKzcGDB3nkkUe4+eabiY6OZtasWf4OSQhRyaw5cXHlD1ZkF6PNe0pedncMqDITvBDVwd13380nn3zC0aNHvcsUxZPkfP/998ybN49BgwaVev8yzell6NSpU8yfP5+dO3cSFxeHyWQiMjKSNm3a0K9fP6Kjo/0dYoVwuVw8//zzuFwuHn74YYKDg2nevHmR2xw6dIh58+axb98+zp07h9VqpWbNmrRr14577rmHVq1aMXbsWHbu3FmiGF577TX69etXFocjhCgnF3tK/fkhWFAukRSg+2sXV946EOzLyicWISo5rRpdFn/99dfZuHEjHTp0oGvXriiKwjvvvMOrr77K77//TseOHXnppZdKvX9JEC4z+/btY+zYsRgMBvr06UOTJk2w2+3ExMSwZcsWAgICLpsEITY2ltjYWJ5++mmGDBlSbPmff/6ZCRMmEBYWRp8+fWjQoAFpaWmcPHmSX3/9lYYNG9KqVStGjRrFXXfd5d0uOTmZqVOn0rFjRwYMGOCzz/bt25f1YQkhytCy/ZX45mhnEi9+GweQkAqRIWUejhCi4oSGhrJlyxbee+89li5disViYfPmzTRt2pTXXnuN5557DqvVWur9S4JwmZk9ezY2m41FixbRokWLfOvj4yt6+g3/SUhIADx/ZCUxY8YMzGYzCxYsoHbt2j7rVFUlJSUFgGuvvdZn3enTp5k6dSpRUVH07t27DCIXQlSUe9b4O4Ii1HuodNvVGAHXt4Rf3yrTcISo7DR91RpnUByr1corr7zCK6+8Uub7lgThMnPy5ElCQ0MLTA4AatSoUaL9bNq0iQULFnDo0CEURaF58+Y8+OCDdO/e3adcv379qFu3LuPHj2fatGns3bsXo9FI165deeqpp4iI8B3N53A4WLhwId999x2nTp3CZDLRsWNHxo0bR6tWrUoU2+nTp/n444/ZunUraWlp1KpVi9tuu43Ro0djsVgAfLoBvf7667z++usArFy5knr16hW435iYGJo2bZovOQDQ6XSEh4eXKD4hROX3wiYX7+4o/fbKFBdj24HNDXGZCgOaKYy7SvH2ES4xpwumrYavf4fEdMiwwemk0geW47eDufdHUIDoplArDIbfDIMKnxlFCHF5kAThMlO/fn1OnDjBhg0buOWWW0q1jyVLlvDOO+/QuHFjHnrIcwVr9erVTJgwgZdeeom77/a9Kc+5c+d45JFHuOWWW7j11ls5cOAAK1euZP/+/SxYsMB70u5yuXjiiSf466+/6N27N4MHDyY9PZ3ly5czevRoZs+eTevWrYuM7cyZMwwfPpz09HQGDhxIw4YN+eOPP5g7dy67d+/mo48+wmAwMGrUKK666irmzp3LgAED6NixI0CRJ/n169fn6NGj7N69m6uuuqpUr50QovKbu+fSkoMcn3rHD2t8f1zjVLrCmzfqL24n4z6BuRsuPZiiaMD2I57/r/kD5jwGI28t3zqF8AO1is1UVJRRo4qf3lhRFD777LNS7V8ShMvM6NGj2bp1K88//zwNGzbkqquuok2bNlx99dVcccUVxW6fmprKBx98QP369Zk3bx5BQUEADBw4kPvuu49p06bRs2dPgoODvducOnWK8ePHM2zYMO+yJk2a8P777/Pll18yYsQIABYvXswff/zBhx9+yHXXXectO3DgQIYMGcK0adP49NNPi4xv5syZJCUlMW3aNG688UYABg0axPTp0/n8889ZvXo1d911F9deey0Gg4G5c+fSvn37EnX9GTt2LC+++CKjR4+mWbNmtG/fnjZt2nDNNdcU2uoghKh6XvipfPY7c5fGmzdexAapmfC5H25w9tF3kiAIUclt2LAhX4uk2+3mzJkzuN1uatasSWBgYKn3X43Gc4uSaN++PQsXLqRv376kp6ezatUq3n77bQYNGsSYMWM4depUkdtv3bqVrKwshg4d6k0OAIKCghg6dCiZmZls3brVZ5vAwMB8U20NGjSIwMBANm7c6F22du1aGjduzJVXXklycrL34XK56NKlC7t378ZmsxUam6qq/PTTT7Rs2dKbHOQYMWIEOp2OTZs2FfcSFapHjx7Mnj2bW2+9lbNnz7Js2TL+9a9/0b9/f8aPH09SUhk0+/tBYmIidrvd+zw9PZ20tDTvc4fD4R2vkePMmTNFPo+Li/O57bvUIXVUqTooH24tTx15jiM8PLzg49A0P9x1DXB75m2qNO+H1HFZ1SFK5vjx4xw7dszncfLkSTIzM/nggw8IDg7mxx9/LPX+pQXhMtSsWTMmT54MeP4w//jjD1asWMGuXbt49tlnWbhwIUajscBtY2NjAU8LwIVyluWUyREVFZVvfyaTiaioKJ+yx44dw26306NHj0JjT05Opk6dOgWuS0pKIjMzs8DYQkNDqVGjRr7YLlaHDh3o0KEDmqZx8uRJduzYwdKlS/npp5949dVXmTFjxiXt3x8uHAeSN/EDvNPg5lW3bt0in1/4HkkdUkdVquOtG12MWU+ZG9te8daRV1JSEmaz2fvc5zgG3wD/+7nsgynK2NuAyvN+SB2XVx3lqTpNc1oYo9HI448/zr59+3j88cdZs6Z0My1IgnCZq1u3Ln379qVPnz489NBD7N69m71799KhQwe/xNOsWTOeeeaZQtdXloHAiqLQqFEjGjVqRN++fRk8eDBbtmzh7NmzBQ5iFkJUHQ9dZeDvBBfTS3Y7k0INaQkON5zNhAHNdTxzdSn6P895DJrX9QxSTs0CuwPOpV5aYAVpXR9qhsLw7tK9SIhq4KqrruLzzz8v9faSIAjAc8Lbtm1bdu/ezblz5wotV79+fQCOHj1K586dfdYdO3YM8LQY5BUbG4vT6fRpRXA4HMTGxtK4cWPvsgYNGpCUlMQ111yDTnfxaX54eDiBgYE+dxXMkZqaSnx8fKGzN10Ks9lMixYtiI2N5fz585IgCFENTLvFwLRbPLMRlYY2oYx+Xi0meH2o55GXqoJ+YOn3O/QGWDQeLnZWJSGqMK0aDVIuzvr16wkICCj19pIgXGa2bNlCdHQ0BoPvW2+z2diyZQtQcPehHF26dMFqtbJ48WL69evnHQCTkZHB4sWLCQgIyHcfgIyMDJYsWeIzSHnJkiVkZGT4TIvap08fpk+fzhdffMEDDzyQr+6EhIR8TZV56XQ6unbtynfffcdvv/3G9dfnTtU3b948VFXNNw3rxfjtt9+47rrr8g0KSkpK4q+//kKv19OgQYNS718IUflsHAQ3L/F3FAXQ6eDsHKhd/Ewm+ex9H1o3KvuYhBAV5o033ihweXJyMj/99BM7d+5k4sSJpd6/JAiXmalTp5KSkkK3bt1o1qwZFouFs2fP8t1333Hy5En69OlDs2bNCt0+ODiYJ598knfeeYcRI0bQt29fwDPNaUxMDC+99FK+Poj169dn9uzZHDlyhCuvvJL9+/ezcuVKGjduzNChuVfF7r33XrZu3cr06dPZvn0711xzDYGBgcTFxbF9+3ZMJhOzZs0q8vgee+wxtm7dyoQJExg4cCANGjRg586drF+/nk6dOnnjLY0XXniBiIgIbrzxRq644goMBgOxsbF8++23JCQkMGbMmBLfdE0IUTV0b2QAKundlGuFlW47SQ7EZUqrRg0IOWNJLxQeHk7Tpk355JNPGDNmTKn3LwnCZWb8+PFs3ryZP//8kw0bNpCenk5QUBDNmjVj+PDh9OvXr9h9DBo0iBo1avD5558ze/ZsAFq0aMGUKVMKvEJfq1Yt3n77baZNm8a6deswGo306tWLp59+2uc24AaDgWnTprF06VK+/fZbbzJQs2ZN2rRpU6KT+7p16zJv3jw++eQT1q5dS1paGrVr12bkyJGMHj06X8vJxXjttdf49ddf2b59O99++y2ZmZmEhobSqlUrxo8fz623Sr9dIaojPeC+iPIjriyvSArw42tw6+slL5/+RfnFIoSoMKqqluv+FU3zxxxq4nKRcyfl4u5fIIQQldXV81zsjC95+Xubw6I7i78Y4XQ6mTt3LgAjR44sdPa4Yil3F18GICwAkhaWrg4hqoFvIhYVuf6uxGFFrr+cSAuCEEIIUYR3ukPPpSUvH2QuvoxfnJ3r7wiE8KuqPEj55MmTpdquYcOGpdpOEgQhhBCiCD0aX9w4BJO+/GIpUMI8iBxRdJkPRoOplC0UQgi/a9y4cb5JUkrC7b6YDpK5JEEQQgghirGkLwxaXbKyfQqfCK58RIRAg0iISSi8zBN9Ki4eISopteo2IDBnzpxSJQilJQmCKFerVq3ydwhCCHHJBrYywOqStSLc0dQPP60nZxc+FkFbVrGxCCHK3IgRIyq0vsvgptNCCCHEZcCxOP+ys3MqPg4hKilNpxT5ELmkBUEIIYQogayn9Vinla4/b4UwGqW1QIjLzK+//srOnTtJSUnJN/Wpoii8+uqrpdqvJAhCCCFECVgMcoVRiKqsOt0oLTExkT59+rBt2zY0TUNRFHLuXJDz/0tJEKSLkRBCCCGEEFXIc889x19//cWiRYs4evQomqaxbt06Dh06xMMPP0yHDh04ffp0qfcvCYIQQghRQodHFb1+sUwWJISoAN9++y3jxo1jyJAhBAcHA6DT6WjWrBkzZ86kcePGPP3006XevyQIQgghRAk1jTCgTTDwShcIuKC7wv/dAIOvlJ67QlRWmqIU+ahKkpOTadOmDQBBQUEApKene9ffdtttrFu3rtT7l28yIYQQ4iL9q6uBf3X1dxRCiMtVvXr1iIuLA8BsNlOrVi12797NnXfeCUBsbOwl3TdBEgQhhBBCCFHtVeUbpV2oW7durF+/npdffhmAIUOG8O6776LX61FVlWnTpnH77beXev+SIAghhBBCCFGFjB8/nvXr12O32zGbzUyePJm9e/d6Zy3q1q0bH374Yan3LwmCEEIIIYSo9qrTzdDatWtHu3btvM/Dw8P54YcfSE5ORq/Xewcul5YMUhZCCCGEEKIK2bdvX4HLw8LCLjk5AEkQhBBCCCGEqFLatm1L+/bt+b//+z8OHz5c5vuXBEEIIYSoCrpMBOXu3EfzR/wdkRBViqYU/ahKPv74Y2rWrMmkSZNo2bIlV199Nf/5z384ceJEmexfEgQhhBCisvtxF2w75Lvs8Fl4bq5/4hFC+NW4ceP48ccfiY2NZfr06QQGBjJx4kSaNGnCddddx/Tp0y/pTsqKpmlaGcYrhBBCiBJwOp3Mnes5wR85ciRGo9G3QEoGNBwLqVlF70hbVk4RClG9fNFwSZHr7zs5qIIiKR+xsbEsWbKEr776im3btqEoCk6ns1T7khYEIYQQorKpMxzCHig+ORBCiGx169alTZs2XHnllQQEBKCqaqn3JdOcCiGEEJXJ1oNwNs3fUQhR7VSnG6Xl0DSNTZs2sXjxYpYvX058fDzh4eEMHTqUIUOGlHq/kiAIIYQQlcm1L15c+YRUiAwpn1iEEJXSzz//zFdffcXSpUs5d+4cISEh3HXXXQwZMoQePXpgMFzaKb4kCEIIIURVNngK/PiGv6MQotLTlOrThHDTTTcRFBREv379GDJkCL169cJkMpXZ/iVBEEIIIaqyDX/7OwIhRAVbsmQJffr0wWKxlMv+JUEQQgghhBCiCrnnnnvKdf+SIAghhBCVhcw8LkS5qWo3Q/MnmeZUCCHEZWPvORe3/c/Fx7tc/g6lYNWoj7QQouqSFgQhhBDVnqZp6N5ze5+vj4VHf/QkCdoE+SkU4nKgSgJeYvKtKC57p06dYv78+ezcuZO4uDhMJhORkZG0adOGfv36ER0d7e8QhRCXKG9ycCFliovvBsDtTSvBT+Il3NhICCHKSiX4NhTCf/bt28fYsWMxGAz06dOHJk2aYLfbiYmJYcuWLQQEBEiCIEQVp0wpvjtRr+VwXS0Xvz3o559FGYMgRLmRMQglJwmCuKzNnj0bm83GokWLaNGiRb718fHxfohKCHGpNE2j/X/d/J1S8m1+P5ebTBiB1hEw7ioY21GPXldBZxa1h1dMPUKIKi81NZWPPvqIjRs3cu7cOWbNmkXnzp1JTExk3rx59O/fn2bNmpVq35IgiMvayZMnCQ0NLTA5AKhRo4bP861bt7JgwQL27t2Lw+GgYcOGDBw4kIEDB3rLvPjii/z444989NFHPq0Pv//+O08++SR33HEHb7whNzUSojTWHFF543eVMxlwxxVgdyusP6GBBqczyq4eJ7A7ER7dCI9u9HRPCvp/9u47PIpy7eP4d7Zk0ysBAqFXpYiIIlJEDohKEQWODUVUFFAU6+uxoseKBayIqKiAR0VUEAEFkaYCUlVUihBqaAkpm2STLfP+EbKwJIQAIQnJ73Nde5GdeeZ57lkgO/c8ZWww/UqDSxtYS6+ho6Vkn9xxxtUw+BJ4/VaIDC3dmESkwtm5cycXX3wxO3bsoEmTJvz99984nU4AYmNjmTBhAtu2beO11147qfq1ipFUaYmJiaSnp7NgwYLjlv3yyy+56667yMnJ4ZZbbuHee+8lMTGRF154IeA/4KOPPkpCQgJPPPEEaWlpQH5PxJNPPkmdOnV4+OGHT9fpiFRqf+w36TfDx4o9sCMT3v0NPlpvsttZusnBsTg9cPmXJtszKugwoI9+hKFvl3cUIhWWaRjFvs4kDz74IJmZmaxdu5ZFixZhHjU8sV+/fsyfP/+k61eCIFXarbfeis1m46GHHuLqq6/mqaee4osvvmDr1q0B5Q4cOMDLL7/MpZdeygcffMBNN93EwIEDefnll7n22muZOnUqO3fuBCA8PJxnn32W1NRUnnrqKXw+H0888QSZmZk899xzhIbq7p7Iyfh8gw9POc/h9Znw5abTlCDMWX3qdUxfBq68U69HRCq077//nrvvvpuzzz4bo4jkpmHDhuzYseOk61eCIFVa69atmTJlCr1798bpdPLNN9/wwgsvMHDgQIYOHeq/6J8/fz55eXlceeWVpKWlBbw6d+6Mz+djxYoV/npbtmzJ8OHDWbJkCUOHDmXFihXcddddNG/evLxO9ZhSU1PJzc31v3c6nWRmZvrf5+XlkZKSEnBMcnJyse/37NkTcDdDbaiN0mjDkuekIgg2Xf6fS+OziomJyf+s6sSdenDhwWCzVpq/c7VR9do4nSpTD0JOTg7x8fHH3H/k38PJMMyj+yREqrDk5GRWrVrFjBkzWLNmDY0aNWLKlCm88sorfPHFF8UeO2zYMG677Tb/e9M0uf3221mzZg0XXnghb7zxRpFZvoiUzP5skzYfe9ldjnlCXAgkDbUSHnTq/5fdbjeTJk0CYMiQIdjt9vy5BKfi6Wvh8X+fcmwildF7Tb4qdv9tm64qo0hOXbt27WjWrBlTp04lJSWF+Ph45s+fT7du3QDo1KkTVquVRYsWnVT9mqQscoSEhAR69+5Nr169uO2221i3bh3r16/33zF56qmnCk1cLlC7du2A97t372bTpk0A7Nixg+zsbMLCwk7vCYhUYvGhBr8OsvLO2vxJylc3MXC6Ye5WE6th8tUmOOA6fj0na0BTGN+9dJKDUhcXBhPvhKsuLO9IRCqsyrTM6ahRoxg8eDCtW7dm4MCBAPh8PjZv3sxTTz3FL7/8wvTp00+6fiUIIkUwDIOWLVuybt069u3bR506dQCIjo6mffv2xz3e4/Hw6KOP4vV6eeCBB3jllVd44YUX+O9//3u6Qxep1GqFGzzdKXAVoYHN8v98t2dgWZ9pYi3mAWnH8r+eMLBFGS5teqQnBsDTxfdWFunA5NKPRUQqrEGDBrFt2zYee+wxHn30UQAuu+yy/KfGWyw899xz9OvX76TrV4IgVdqyZcto164dNlvgfwWXy8WyZcuA/Ik+55xzDm+//TYTJkzgvPPOIzg4OKC80+kkKCiIoKAgAMaPH88ff/zBk08+SZ8+fdi7dy+TJ0+mffv29O7du2xOTqSKsxgG5gO2Ej0oDWDNDdAmoZy/Fh85yQRBRI7LLI+k/zR69NFHufHGG5k+fTqbN2/G5/PRqFEjrr76aho2bHhKdStBkCrt1VdfJT09nS5dutC4cWOCg4PZu3cvc+fOZfv27fTq1cv/kJGHH36YZ555hoEDB3LFFVeQkJDAwYMH2bx5MwsXLmTatGnUqlWLZcuW8fHHH3PZZZfRp08fAO68805WrVrFmDFjaN26NXXr1i3P0xapUkqSJHjvt2LRHCEROQNkZ2fTuXNnhg4dyrBhw7j33ntLvQ0lCFKl3XfffSxatIi1a9eyYMECnE4n4eHhNG7cmMGDB/sv8AH69u1L3bp1mTJlCl9++SWZmZlER0dTr149hg8fTlxcHKmpqTz55JPUrl2b//znP/5jbTYbzz33HDfccAOPPvooH3zwQf6ERBEpE777rYS96iXnqGU5pl4O17eoQF+Fee4TP8ZRgeIXkdMuNDSUrVu3ntaFT7SKkYiISDkochUj0wRL/xOvzPyylKMTqXwmnDWj2P13/HVlGUVy6q6//npcLhdffnl6/u/rOQgiIiIVhYY5iUgJPP7442zcuJEbb7yRpUuXsmvXLlJTUwu9Tpb6JUVERESk0qtMk5RbtGgBwJ9//sknn3xyzHJe74mv5AZKEEREREREzihPPPHEaZ2DoARBRETkTNayTnlHIHJmqERD+EaPHn1a69ccBBERkYrktn+dWPk1r5yeOESkylIPgoiISEXy7gh474eSl7fpq1ykqnn66aePW8YwDB5//PGTql+/VURERCoSw4C5j8Flz5R3JCKVSmWapFzcECPDMDBN85QSBA0xEhERqWh6ts1/tsH+D+DjkeUdjYhUMD6fr9DL4/Hwzz//cO+999KuXTv27dt30vUrQRAREamoqkXDjZfAz88WvX/L22UajsiZzDSMYl9nOovFQoMGDXj55Zdp0qQJI0ee/M0FJQgiIiIVXYezYO5RQwVWjoEGNcsnHhGp0Lp06cLs2bNP+njNQRARETkT9Dw3f9iRiJwU06g698VXrlyJxXLy56sEQURERETkDPLxxx8XuT0tLY3Fixfz5Zdfctttt510/UoQRERERKTSq0yrGN18883H3FetWjUefvhhnnjiiZOuXwmCiIiIiMgZZOvWrYW2GYZBTEwMERERp1y/EgQRERERkTOIYRjEx8cTEhJS5P6cnBz2799P3bp1T6r+qjNbQ0REpAzsy/LxzUY3eR5feYciIkeoTMucNmjQgK+++uqY+2fOnEmDBg1Oun71IIiIiJSCbQfdnDsul0Yp2YS5vTwebGN/jVB2PRJW3qGJSCVjmmax+91ut1YxEhERKW+N3/Rwwd5MDkQ42BMZTHSOm4TkLJ7+0cYTlzjKOzwRObM6CQrJyMggLS3N/z4lJYXt27cXKpeWlsann35KQkLCSbelBEFERKQURHh9LG8Qh9eaf9duJxCTlctLi91KEETklI0dO5ann34ayJ+DMGrUKEaNGlVkWdM0eeaZZ066LSUIIiIip2DFLjftJ5tYQ+z+5KDAwTAHFo+3nCITkSOdafMMjnbppZcSHh6OaZo89NBDXHfddbRt2zagjGEYhIWFcd5559GuXbuTbksJgoiIyElKy/HQ/mMTbAbHSgN8lWjtdREpPx06dKBDhw4AZGVl0b9/f1q2bHla2lKCICIicpIaT/CBFfCY+eObbUclA6YJxc8lFBE5YU8++eRprV8JgoiIyEnYleEhJdsHNith6TmE5Hk4WD0Mr82aX8A0wZkHofbyDVREgMr1JOUCP/30E6tXryY9PR2fL3BpZcMwePzxx0+qXiUIIiIiJyHxDS8EWTHcXlxRDnJNB9Y8H4bXxObx4QqyglvPQhCR0peamkqvXr1YsWIFpmliGIZ/6dOCn08lQdCD0kRERE7QZ6tz/cOJzCAbXrsVT5CVvFA7HocNV1gQ2CwQE5zfkyAi5a4yPSjtwQcf5LfffuOTTz5hy5YtmKbJd999x8aNGxk2bBht2rRh9+7dJ12/EgQREZETdO1cE6wWKO6iwjAOvcouLhGpGmbPns0dd9zBNddcQ0REBAAWi4XGjRvz1ltvUb9+/WMugVoSShBEREROlN1a8rJn2J1JkcqqMvUgpKWl0aJFCwDCw8MBcDqd/v2XXnop33333UnXrwRBChk9evQprZ1bGbRr147Ro0eXdxgiUgkE53m5eVLGSR+fmZzFljk7yE7OwpPrKcXIRORMVatWLfbs2QOAw+GgevXqrFu3zr9/165dGKeQ9GiScgWyc+dOPvroI1avXs2ePXsICgoiLi6OFi1a0KdPH/9F66xZs0pU39ChQ7njjjtOc9QiIlVLjTfc+UuXlvC795x9B/nRGXzC7ZimyTstvyHPEUSe3Y7V58Pm8hCUl4ctN4/aYV4SaofittuIbRdHg8fPx2LTfT+RYznTegmK06VLF+bNm8ejjz4KwDXXXMOYMWOwWq34fD7GjRtHz549T7p+JQgVxJ9//sntt9+OzWajV69eNGzYkNzcXHbs2MGyZcsIDQ2lXbt2XH311VxwwQUBxz7xxBPUr1+fW265JWB7kyZNyvIUKpWffvoJq/UEhhCISJXg9Znsy/IdSg6O8zvCNAnK82L1QHKYg8VLUrmoQzS2ElzE7/7rIP+7YQWEh5ITGozVhBybhbi8DBr/k4rNa+KxGhz804kdL6mzt5Py9GrMUIPzU27DElyKX+85LjxfrsQ1+y9I2kfIuIFYWjfA8PkgxFF67YhIid13333MmzeP3NxcHA4Ho0ePZv369f5Vi7p06cIbb7xx0vUrQaggJk6ciMvl4pNPPqFp06aF9h84cACA1q1b07p164B9TzzxBLGxsVxxxRVlEmtZyMrKIiwsrNzadzj0pScih/l8Jrv3uDn/Mx9YrFCS9dQNgzyHja1xEXTYmcFTH3mxT3IS5PYQ682hSZgXX2hNYhseYP/uXHyZWayespm/5x0gNzIce6gDu9dLdHr+uGITSI8NZ3vD6jTctBeb18SHhWyLBa/PhwlYsmFlyHg8GDjIwbQHEXJRLeLODSPiqrPITvHiTkojvGEI7tXJuFfvxLosCdOVS7DzIGBg4sBGHiYe8ggnlP3YMQjJfyIcxgX/wQTyCMbEggUfFnLxYXDk86TtMSHQugFm3WpQuxpGfAR0ag6/J4HDAX3awW/bwTAhPASyXNAoAYKDIDIEth+AEBsYFqgWCZZDiVV2LiSnQEYONKkFdht4fRB61O/tPDfkefLrLkpObv78kOCg/JWmMrIhqvy+d0RORKtWrWjVqpX/fUxMDPPnzyctLQ2r1eqfuHyylCBUENu3bycqKqrI5ACgWrVqpd5mbm4u77zzDnPmzCEzM5NGjRoxYsSIYmOcOHEiK1asID09nfj4eLp3787tt99OSMjhX8AFw6DmzZvH2LFj+emnn8jNzaVVq1bcc889NG/e3F929+7d9O3bl6FDh9KgQQM+/vhjtm7dSo8ePfxzAJYvX87HH3/M+vXrycvLo27dugwYMIABAwYExLdu3Tref/99NmzYQGZmJlFRUTRp0oShQ4f6/xOlp6fz3nvvsXjxYvbv309ISAgJCQlceuml3HTTTf662rVrR+/evQvNQ/j666+ZNm0aSUlJ2Gw2WrZsydChQ2nTpk1AuYLjr776at58803+/PNPHA4HXbt25f777yc0NPRE/qpEpBzN/z6Ne3/wsr5aJKZpOXZy4Dn0zAObhbBcD432OwnP9ZARbCPXAtEuD9EeNxYTnBYHSU4fjoONSN/egFd/3EJoVjbVUtLwRoTiC7KTZ7Nid+b4qzeAsIwsdidGE5aRSXCOh4jMPIJ8XsLJxcAkhyCyCSGMbKIwwZ0Li7ZyYJGNlHF/EssuqrMLK15yiMBCNSz4COYAXiyk0pCCsVMOcohgN3ZsHJ6yGIQPG+AiiBwMDj8o2spRo64O5sCiPwPKnLT4SHjnDhg3C5b8FbjPcmi1qAEd4P07ISwYnv4cXp4BTld+IvLhSIjJn8hJnhvunAgfLcwPuFtL+HsXJO2HFnVg0l1wvnrgK6PKNMToWKKjo0ulHiUIFURiYiLbtm1jwYIFdOvWrUzafPTRR1m4cCGdO3emQ4cO7Ny5kwcffJBatWoVKvvXX38xbNgwIiIiuPrqq6levTobN27k008/Zd26dbz77rvYbIH/nEaOHElkZCRDhw4lJSWFzz//nNtvv50PPviAxo0bB5RdtGgRn332Gf3796d///7+3oMvv/yS559/nlatWnHLLbcQEhLC8uXLeeGFF9i1axf33HMPAElJSdx5553ExcVx7bXXEhsbS2pqKmvXrmXjxo3+BOHhhx9m9erV9O/fnyZNmpCbm8vWrVtZtWpVQIJQlNdff52PP/6YFi1aMGLECLKzs/nqq6+44447eOWVV+jUqVNA+Y0bN3LvvffSp08fevbsyapVq5gxYwYWi8U/ZlBEKrasLA9PfuvijzqHbtIc60rX64OM3PwHp4XaabUrHYc3P2GIy3bjA9KDHaTjINztpporF7dhYNjt2Mw8bF6TuNT0/F6HYAcYBqbVijMqHK8zm9BsFwB2t5c6W/fhsdnICQGvzSA2NZdMDt90MPARRW7AxXoIHrKxU50dWPEdKheEFRMbThw4SaYFR17i5xJCLHlA4B14AwsW3P6SJbnkOuXLsv0Z8O9X8j/no/lMwITPfoLasdClBTz56eH9M3+F+ybBpJH571+eAe/NP7x/7trDP6/fAf1fgi3jwaZhplKxbd++neeee44ff/yR/fv38/XXX9OlSxcOHDjA008/zZAhQzj33HNPqm4lCBXErbfeyvLly3nooYeoW7cu55xzDi1atOC8886jQYMGpd7esmXLWLhwYaG75G3btuWBBx4oVP7pp5+mWrVqfPzxxwFDfy644AIefPBB5syZQ58+fQKOSUhIYMyYMf5Z9N26deOmm27itddeKzQu7p9//uHTTz8NONcDBw7w8ssvc+mll/Lss8/6tw8cOJCXX36ZqVOn0r9/fxITE1m2bBkul4tnn32Wli1bFnnOTqeTX3/9lQEDBvDQQw+V/MMiPwGZPHky55xzDu+88w52ux2Afv36MXDgQF588UU6dOgQMG9h06ZNTJo0yR9P//79ycrKYubMmdx7773qRRA5A6xa5mRb5KH/qz4z/3V0D0JWHjjd+VfBFojKMf3JQYEjZx047XbCPB58QJDbg8diITzbhdU0yQlxFFoW1RUaTGi2C1uel1rb07B687MUnwE5YTa8FgOr73DmYmIhkxCiyQ6oJxgPacQRx34A3IQdis2NiYGXoCI+gaIyIvMY20+zopKDo81eDVm5RW8vMGdN8XXsOAB/bIc2pf/dK+WrMvUg/Pnnn3Tu3Bmfz0f79u3ZvHkzHk/+KmfVqlVj6dKlZGVl8f77759U/VruoIJo3bo1U6ZMoXfv3jidTr755hteeOEFBg4cyNChQ9m5c2eptrdw4UIAbrzxxoDtXbt2pV69egHbNm/ezKZNm7jssstwu92kpaX5X23atCEkJIRly5YVauOmm24KWGLrrLPOon379qxYsYLs7MAvrk6dOhVKhObPn09eXh5XXnllQJtpaWn+/xQrVqwADq8BvGjRInJzi/hyIH9eQVBQEH/88ccJP11w0aJFmKbJTTfd5E8OAOLj4+nTpw/Jycls2LAh4JhWrVoVSlbOP/98vF7vKT3dsLSlpqYGfGZOp5PMzEz/+7y8PFJSUgKOSU5OLvb9nj17/I98Vxtq40xuIzo2l4i8I5YWzfOB94iL4zxvftIQGQTxoRAdgsdy/K/WHKvVf41t8Zl4Dx1T1AWMaRiYQHRqtj85ALCYEJTrxSziYt1dxP0/Lxbs5PnfG4d6Ejw4MDAJwlnoGB8WIHBpVRMvRnkkCCXgqxdPVo3wwjsaVPf/mF2z+LHZpt1KbrXDdZyp/3bP1DakZB566CGio6PZuHEjU6ZMCfh7AejVqxdLliw56frVg1CBNG7c2H83Pzk52T8kZc2aNdx///1MmTIl4OL0VOzatQuLxVIoGQBo0KAB27Zt87/funUrABMmTGDChAlF1peamlpkPUVtW7ZsGcnJyTRq1Mi/vW7duoXKJiUlARQ7L6Kg3UsvvZTZs2czadIkPvnkE1q1asWFF15Iz549SUhIAMBut3Pffffxyiuv0LdvXxo2bEi7du3o2rVroZWhjlZwQX9kzAUKtu3atYuzzz7bv7127dqFykZFRQH5cyEqitjY2ID3BclWgYLldo9U8Jke633NmjXVhtqoFG20PrcGV3y1i62eMHJthy7qXd7822s2C9gtEBQ4OdYZYic11E5stptj8QERXi9Wrw+7z4c7yE62IwiHK5ecsJCAXoTgLBcGYHMXvoNu+CAn1E6EM7AtxxGJAOSHnY2dEA7PaQgijVyq4SUEF+HEsJ0UGuAhBPARwQHAi5NIwsjAwMCDnTyiCMOJpayThCsvgFkrj92TEB6M5enrCGtcEz5dBhsP3YgJDoJnb/AXC316EPz4F6QcupB12CH38Odn/N9VOBLjD1d7hv7bPVPbOJ0qUw/C4sWLeeKJJ4iPjy+UhEH+ddWuXbtOun4lCBVUQkICvXv3plevXtx2222sW7eO9evXF5oMWxYKstJBgwbRoUOHIstERkaeUhvBwYXXCC9o96mnnjrmJO2Ci/CgoCDefvtt/vjjD5YtW8bq1auZMGECEydO5JlnnuGSSy4BYMCAAXTt2pWlS5eyatUqfvjhBz7//HN69OjB888/f0rncLTilkk9OtMXkYrrladr02VuGu+u8TLbHgZu8q/wDY75lOQ/EqKokekiItdDrs1CvZQsLIdG4lu9XiJduYTm5RHk8WLYvMRH2snJcOBzWQg/mEluqAO3IwjDZxKekYNpNckOsxNyVNKRE2Il2GUe8VgGEwdu0gkm12ohwpu/upAPgxBcrOIiYtlHBE68hBJMHnYgm2qYQBj7sOHBgps8QjhAfQwMMokhjHTCOYANC9nUIJhUrIcSERPD36tQEMuRj4o4cpu/fyXMAR4vuL35n6PNAs1rQ9dWEBcO89ZBTh6cUx9u6AKXtII9B+GBj+CH3/KP69gMLm2T34szoAMkHLpgXfMKfPEzHMyCq9pD3cMX/JyVCBvehGk/5wc1oAOs2gLrkqDTWdCh2Qn/GxEpaz6fr9ihyvv37z+lFRmVIFRwhmHQsmVL1q1bx759+0qt3tq1a+Pz+di2bVuhu+IFPQYFCu7uWywW2rdvX+I2tm7dGrAEV8E2q9VaojsGderUAfJn5Je03ZYtW/qH9ezZs4cbbriB8ePH+xMEyB+b169fP/r164fX6+WJJ57gu+++Y9CgQf7Hlh+tIBH5559/SExMDNi3ZcuWgDIiUvlceVk0V14Gf6Z4aDHRm58gWI99N9K0GOyJCmHPofcNDmQQ4fIQmZfH44/UoHnrRNxuN5MmTQJgyJAhAT3EY7osIDTZiS/ETqgzl5AsF65QO84wO6HZbgwTckJtOCPs+Ow2IjPyDg0Z8hHWvy4dvjj5Za89y7bgWrEDe2IUocM/xrov/ynQuYRzkERCOYCDDDxRUbj7dcBuycX2/LVQPQYMo8jJyycyodnv8X8X3lYzBqaMOv6xoQ646ZJj74+LgGFHPETq0jb5L5EzRNu2bfn222+LHGXh8Xj49NNPufDCC0+6fs1BqCCWLVvmn1xyJJfL5R/f37Bhw1Jr7+KLLwZg8uTJAdsXLlwYMLwIoFmzZjRq1Ijp06cXORfC4/EUOWTm448/DrhT/vfff7NixQrOP//8Ek3Q7dGjB0FBQUyYMAGXy1Vov9PpJC8v/+5VWlpaof01atQgJibGH5vL5SpUj9Vq9T9QLiMj45ixdOnSBcMwmDx5csDf04EDB/jmm29ISEigWTPddRKp7M6Os+VPUraX/OszLM9DnsXgm48bMPXTZjRvHX3cYx5a3I2rX2tFaHo2NnceVp+PyHQXmD72V3OQGheEOwgSdmVQe1cKQeQQ0zmWrubttD6F5ADAdmFDwu++mOCr2xC191XCzfcIN98jzhxHdfMVws2PsJvTCE57j5APb8X2wQioEXvM3hSRisK0GMW+ziT/+c9/mDt3LsOHD+ePP/4AYO/evcyfP59LL72Uv/76i4cffvik61cPQgXx6quvkp6eTpcuXWjcuDHBwcHs3buXuXPnsn37dnr16lVoadBT0aFDBzp37sysWbNIT0/noosuYufOnXz55Zc0atSIf/75x1/WMAyefvpphg8fznXXXecfv+9yudi5cycLFizgrrvuKrSKUXJyMnfddZd/ya3PP/8ch8PhX5r0eGrUqMHDDz/MM888w8CBA7niiitISEjg4MGDbN68mYULFzJt2jRq1arF+++/z7Jly+jUqRO1a9fGNE2WLFlCUlKSf/nSbdu2cfvtt3PJJZfQqFEjIiIiSEpK4osvvqB27drFLgVWv359brzxRj7++GOGDh1Kjx49/MucZmdn89///ldPXhapIjbeZqHpRB9Yj58kWL0+wlx57A898fljdS9J5NZVNfjk/NnsDw/GFerAZ4F+L51D4641TiZ0EakkLr/8cj788EPuuece3n33XSB/KLhpmkRGRvLxxx/TpUuXk65fCUIFcd9997Fo0SLWrl3LggULcDqdhIeH07hxYwYPHlzo4rs0PP/884wfP565c+eyYsUKGjVqxEsvvcTcuXMDEgTI70WYOnUqkyZNYvHixUyfPp2wsDASEhLo06cP559/fqH633jjDV599VXeffddXC6X/0FpBXfsS6Jv377UrVuXKVOm8OWXX5KZmUl0dDT16tVj+PDh/slPF198MQcOHGD+/PmkpqbicDioU6cOjz32GFdeeSWQn3D07duXVatWsXDhQtxuN/Hx8Vx11VUMHjy4yHkQR7r77rupU6cO06ZN480338Rut9OiRQueeeaZk15nWETOPE1ibWA59gRkIP/JvG4fXquFg1YrW5+PL778MdjD7Az+88qTOlZEAlWmScqQvxLl1Vdfzffff8/mzZvx+Xw0atSInj17nvKTlA1TsyWllBU8SXnlypXlHYqIyGlhjMkDiyV/RR2rJX+SbMGkZa8Jud78Gbl2Aywm5sOFb0AUNwdBRErfi12LX/bz/xZ2LqNITs4jjzzCtddeS+vWrU97W5qDICIicoKiCvrfC+6xWYzDY/BN83ByYIK+akUqBtMwin1VdC+88IJ/vgFASkoKVquVBQsWlHpb+q0lIiJygtLuC8rvPbBZDycJBWwWCLFCkDV/pSOvOupF5PQ4XQOBlCCIiIichM/6WvKTg6LuPFqM/H1WQ9+0IhXEmd6DUJb0a0tK3ejRozX/QEQqvX+fZQPMwj0IBYxDw4401U9EzjBaxUhEROQk3XCWhal/FZMAmGb+BGYRkVKQlJTE6tWrAfzPedq0aRPR0dFFlm/btu1JtaMEQURE5CRN6W3jm015ZLjNwz0GR4lyuYGQsg9ORAJUhmFEjz/+OI8//njAtqKepmyaJoZh4PV6T6odJQgiIiKnIP3eINbt9dDm46J7CqJzT+4LWkTkSAXLIpcFJQgiIiKn6JwaNvDl5c/sO/Iupc8kyHHm37UUqQzO9B6EwYMHl1lbmqQsIiJSCrokgDXXmz/nwDQx3D6a7M1k6QPh5R2aiMgJUQ+CiIhIKVh0UxD7MzzUez2XMJeXSDusejaaiBBreYcmIpz5PQhlSQmCiIhIKYmPtJH9mL5aReTMpiFGIiIiIiLip9scIiIiIlLpmRphVGLqQRARERERET/1IIiIiIhIpadJyiWnHgQREZEzhCc1mwP3zCXz47XlHYqIVGLqQRARETkDJDV9G++mdPLv7a1j3+A51P7tFoJb1Sjv0ETOCOpBKDn1IIiIiFRwmSt2kr3JiRcDLyYphJFJKLtav1/eoYlIJaQeBBERkQpuZ/upVCONYPIAqM4BMrGRRjS+1GwssaHlHKGIVCbqQRAREanAcn7ZRhhOTKy4CMFJOHuogZdgzuZXUuqMLu8QRc4IPsMo9iWHqQdBRESkAku+bwnBGLixsY8Y8rATTjYHiSOEOlTL3orP6cISHlzeoYpIJaEeBBERkQrM3J2GgclWapFBOC4cHCCGPKykUBMrXra3Gl/eYYpUeCZGsS85TAmCiIhIBWbbvpcMwvBiDdieg4NQcsgljLCk3XjzvOUUoYhUNhpiJCIiUkpeH7KG/cluTMPA6vNh8fnoO6o+5/ZKOKn6NrefRBAmFsxC+wwgBC+Z1MEgj9wVOwntVO8Uz0Ck8tIypyWnHgQREZFS8MyVK9h1AHJCQvDYbHitVkyLhZljt5Kb5TmpOsNX/E4oPiLJwkZgHdFkYMUEDGxAXucXTv0kRERQD4KIiEiJZOZ4uOBtF9vTvDTIc1PH5uOR/mF0bhvG6sUp7DMchJte7Lm52H2+/IMMA6xWXrniZx5Z1CWgvux9Loz3IyHTwvaGyTTqXjdg/x/2MdSweMFnYMWkITtJIZpc7ISTQxzpGPj846dDyMHjzMUW7iirj0TkjKIehJIzTNMs3G8pIiIifg1fzWJriolhQuPMHJpm5RBsmviAdKuVBmlpJDqzjznN0Z7npudd9Tnv6toAbJ61nUWjVh4uYJrgdXPL7/0wIoJZn/AWznQfNb1bCcsLhiNqNg+lBCFkYcWLCfiwkIsPX2wE1VLUkyBSlMd6rS52/zPfti2jSCo+9SCIiEiVdsecPN5de/h9fCgsHmSheZyN7DwvYf91gcUCdjA9PnbbrTjDQ7D7INznpVG2i9rFJAcAJrDonX/8CUJAcgCHehrsfNBqJvUOHKB2VjapcTEE58QRn5dENvHkJwk+3BhEHkoOOLTVio8soohPTSq1z0VEqi7NQZAqLyMjg44dO9KuXTu+/fbb8g5HRMrQeR8cSg7yr7LBAvtz4Kx3fRgvuAh7xgVWC1iM/It4u5WsMAfJjiDSbAbbg4PIdXswoIhpxIf5DAPfQRfuHC+5Ge6iCxkG2Gxsj6lGrs2Oze3FmRvLb7QhlWBspOLERio1/MnBkeLYj4Ncss5++JQ/F5HKyDSMYl9ymBIEqfLmzJlDXl4etWvXZubMmeUdjoiUAa/PR/jLeaw+YOR/E1oAL+Dj8JW+aQG7Nf/CHQ4NA/Ll77dbyQgNxm2zUs3nJTkqit3RUaSEhfqfyHpkwuCz2zCDbLzVcR5J87cXG5vVYmAzcwnOMHB7HbgIYTeJbKEJLqIAcBNU6LggsnETStBfyXiMa/Ea1+MNGYL3tTn4nK5T+LREpKrRECOp8mbMmEG7du24+OKLeeWVV9i5cyeJiYnlHZaIHMHjM1m9F2qGQd3Iou/0/bbPxy+7TeKCTULtBhtTTeYlwYEccPlgZzqkusm/yPcVHGUWjNwp7Mjtpgke3+Gr/kNJQM1cN2EYmIdut7mCgkg3ITInB4/VisPjyT8WsHl8WIHvnt5ACMe+Q2fFQ5Q3nQPEB2zPIJpEfmcHDdlBAg1Jwjg0sMkgDys5WLECQf7afS5g1OeYoz7H6x8EdegkbGDWj8NXrwbWNrUxYkIwwhxwdgKGyw1148GVh9mmAfyZDBHBGE1qQFoW/LkDWtSBqLBjnIVIxWOqk6DElCBIlfb333+zceNGRo8eTadOnRg3bhwzZ85kxIgRAeW8Xi+TJk3i66+/JjU1lbp163LLLbewdetWJk6cyMyZM6lVq5a//IEDB5g4cSJLly4lJSWF6OhoOnfuzPDhw4mNjS3r0xQ5o63dZ9L3Ky87MvNH+tze2uDt7haMQxfpeV6Trp96+SWZ/ItxwwDziFWEjuQzCycDxxobZB5Rn88sslyiK7fQthy7DbvPgd3twZGTi9Xny59IbLHgtVqx+nzHnK9g+EwMj4Vl8S2Jzk3HmunA4m/XxEIedtzsJ5ZqbCeONAy8WMj1D3MyAgL1QBG9DeDG4smCzVkYm3dg/vAnJsahhMOLBad/hSSfNQq8hyJum4jlr40YObkQFgxvD4WbLjnG2YjImUoJglRpM2bMIDQ0lH/961+EhITQuXNnvv32W4YNG4bFcvj+3pgxY5g+fTrt2rVj0KBBpKWl8eKLLwYkBQX27NnDkCFDcLvdXHnllSQmJrJjxw6mT5/OypUrmTx5MuHh4WV5miJntGHz8pMDyL9Of2edSa+GJr0b5V+0vrPOF5gcQOHEoMCJLNxnmoEJQhEybdZC2wzyxzqH5ORgPbTcqQH4bFZ8NiuYZtEJgmkSnOvBYoLXZiXFFkuo1UXkwfz5BuFk4SWGWqRQkxQyqUZ1dh/RL2BgcHQ8RfVTGEAQPvKw4gZCMALKWfERihUnJo7DyQHA6p2HkhAgywXDJkCf8yFGv9Ok4vNpnkGJKUGQKis3N5e5c+fSrVs3QkJCAOjVqxc//vgjv/zyCx07dgTgn3/+Yfr06XTo0IHXXnvNnzh0796d66+/vlC9Y8aMwePxMHXqVGrUqOHf3r17d4YMGcLUqVO54447yuAMRc58pmmyPLnw9mXJJr0b5f88P+nQxtL+8jcMsFkg13vMXoZ/QoJpYXUS7vUVBIzd48GWm0ewu+iHo7mDg/AZBpajkhWr1zyityBftsNBoiWZWF86keTgO/S1bQEiySOLWgSRjQU3FsAoNHm5cAJzWBDghiLTlYLLg6JO/Ig6c/JgXRJ0bVlMOyJyptEkZamyfvzxRzIzM+ndu7d/W6dOnYiJiQmYrLxkyRIArr322oBehcaNG3PhhRcG1Ol0Olm6dCldunTB4XCQlpbmf9WqVYvExESWL19+ms/sxKSmppKbe3iYhNPpJDMz0/8+Ly+PlJSUgGOSk5OLfb9nzx6OfMSK2lAbJ9uGYRi0qU4h51Y3/G10qn1oY0l6BywnmERYjWMmB1bTR7DHy5LoSDIMA4fbQ3heHg6fic1X1KSGQwwD8wTiqG3uJQQPOYTiOfTsZAADg1Ti2UQLkmmAD3uxKykV5jlUT1Gx5icaRfd1HE5CzCAbnJ0/Z+tM+nelNipuG1Ix6EFpUmUNHz6czZs38/777/vHMgO8++67zJ8/nzlz5hAdHc1zzz3Hl19+yddff11o8vIrr7zC//73P/8chD/++IObb7652HZr167NjBkzTscpiVRKP+8y6f2Vl4OHFuL5dzODT3pZsB66yM52m7Sb7OWvVI6Yg2AWP8yoqLkIRfH4wHXogtggv0cB/HXbvT4u27aPJhmZhS6l4w6mYfMWbsSa5yEqJb3IuEJcnoBehDrOfdTLPMiRd/mteLAfurjfSxzZhOa3x37qsgUL7kPzEayYxxwo4MVCBvnpgQFEcPieoe/QHARv/hwEIxL/LOxGcVi2bsHw+cBmhVdvhpG9jtGGSMXyf1euK3b/izPOKaNIKj4NMZIqadeuXaxcuRLTNLn66quLLDN79uwihxCVxOWXXx7QM3Ekh8NxUnWKVFUX1TbYcbuVJbtMaoUbtI4PvBQPtRv8eYuN77f6WLjDR7QDYh0Ga/aZLNllkJkH6bmQnncoJ/CZh55rYFLE4wQOM03Ich9+BoLvUGJhzb9YNkyTxhnZ1MnKKvo+u8UamCCYJobXR9jBgxTZgW8YuBw24tPTsRgGCa4UamcdxE1wYL1YseMhBwfZhPi3pxJHHTYD5qGhSEUNEzLJP2kvJg584SF46idiaV4DW/VQjJhwaByH4cqDuvEYgOX8JrBuZ/4qRu0bwq4UWLsVzm0ItbTogkhlpARBqqRvvvkG0zR57LHHipwwPH78eGbOnMn111/vn4i8bdu2Qj0I27ZtC3ifmJiIYRh4PB7at29/+k5ApIoJCzK4rEHxw3IubWDh0gYlGzm7Lc1D/XeOuHAuWALIyuFnIZhAqA2ceYevsd1egjGp5/YSk+vG4TNxFNFLgGnisxp4vBb/ROXUiDBq7j/IeXedzbrX/y4yLgteuqQtZpelGYmeA+RS+IaCiXGo5yCEI3sWDEwMcvERggUnJnZMIwTjmvPhzn9h7dS0iPaOfyFgAHQ/+/CG2nH5L5EzjB6GVnJKEKTK8fl8fPPNNzRu3Jh+/foVWWbLli28++67rF+/ns6dO/Pmm2/y6aef0qFDB/88hM2bN7Ns2bKA46Kjo+nYsSMLFizg999/p1WrVgH7TdMkLS2NmJiY03JuIlIy9aJtmA/D0Fl5vPfHoY2WI5YzNQDLoWFIoTbI9eUPNwJcGKSSPyjHCuRYLIQdNecgyO3GtFrJC7ESnO3CYppEOrO58bMOuA+6jpkgeDHY46tLbd8mvMRgJ49cgjkyEcgi1D+s6EjxJOevOhTkw5I77RQ/IRGpypQgSJWzbNky9u7dy5VXXnnMMt26dePdd99lxowZPPLII1x11VV89dVXjBgxgq5du5KWlsa0adNo1qwZf/31V8AchocffpjbbruNoUOH0qtXL5o1a4bP52PXrl0sXryYK664QqsYiVQQE3sHkRiTx+gl+JcyDbHB5F7Q/+xgPF4v9ufy8m+1B1nAl58o7Lfb2G+3gQF/hju4evseoj1eME1sXi8O7+GxSz6LgeE1sdshrlEE+anFMRgWtofUxprjpSEbcBOOF0gnFhMLLhxkHzHkyIKHYLKJYx812E0eDhy5k07LZyVyptMypyWnBEGqnIIJwt26dTtmmcaNG1O3bl2+//577rvvPh5++GHi4+OZMWMGr732GvXq1ePhhx9m/fr1/PXXXwHzCmrWrMmUKVP46KOPWLRoEXPmzCEoKIgaNWrQuXNnevTocdrPUURK7smOQTzZseh9NqsV8/EQop9zkp55xMPSzEPzGGwGLtPAlp1DqCsXbFasR16EmCZWb/404FY9Dy/HFNcmipS1hScqD1rTB0dkEIsc46mRt5MIMnARgoeaZBCKeWjughUvoWTTgPU4yMtvCh8Zjuijnr8sInLitIqRyCm49957+fXXX1m0aBFWa3HrjYvImW7Dfi+Xf5jNzgM+wnwe6pgeHu4XzvWdwvh7eSqfPbYBq9eHz2bFtFgwfD6C8tzgMzFMk4cWdwnobdy9cg/fDloCJlzwcCvOGdLcv8/0mSx1vE0zz1Z8+MggAQsmbmyAiQeDaDJx4cBOLnX5AxMTI/kDLDUjy+HTEan47r/692L3v/Jlq2L3VyXqQRApAZfLRXBw4EoimzZt4ueff+aiiy5SciBSBTSLt7LlwaKHBzVvH0tIgoOcvW5Mw8AwTQyfSZ7dhtXjZeTn7QKSA4D4c+Iw7zsIwNmDGgXsMywG5/1xPcnN3yaXIFwEYcXAgkkeNnxYScFGbfaShxcLXrKIJEzJgYiUAiUIIiUwa9YsZs+eTceOHYmJiSEpKYmvvvoKm82m+QQiAsBDH7dl0oN/sH11Btis+Kz5cxZ6jmpIZHzw8Ss4SmizGPLCQ3A5rbgILvQYNDdBeLESTjoHqYVj+SOldSoiUsUpQRApgebNm7Nw4UI+++wz0tPTCQsLo127dtx+++00b978+BWISJUw5KWWpVpf85S7We14rcgnJBv4sODDTQQuLES3rVmqbYtUNkU/GVyKogRBpARatmzJm2++Wd5hiEgVYwTZiK7uxbkvG7CSR5B/XzQZGPiwk0PObT0wbCV7BoSIyPEoQRAREanAXI5oPORSnTRcBOHDQjAu7Hiwk42JhToTe5V3mCIVnpY5LTndbhAREanAYh+8gCDcpBNGCHmE4cIKHCSSINzss1Y/bh0iIidCCYKIiEgFljCyDcE4cRHETqqxj2j2EEMk6ewggQZ/DS3vEEXOCKZhFPuSw5QgiIiIVHDxC24mnExqsYc4UqnBATKIxoKBvUlceYcnIpWM5iCIiIhUcNGX1GVb0zpkb0zDhg8fYMFNjVnXlndoIlIJKUEQERE5A5yzYRA+r49/bv6B4MRQEv/bQSsXiZwADSMqOSUIIiIiZwiL1UKTyT3KOwwRqeSUIIiIiIhIpedTB0KJqW9SRERERET81IMgIiIiIpWe5iCUnHoQRERERETETwmCiIhIKRu/yoP1ZQ/V3/CQ5/GWdzgiAvgwin3JYUoQRERESpHxsocRP4IP2J8LjnEm7631lHdYIiIlpgRBRESklKxL9oBpFto+dH45BCMicpI0SVlERKSUtJkKFDURsoik4bha3gPrdxx+v+ZlaNPwpGMTqeo0Sbnk1IMgIiJSWopJBNbsOYFhRv1fDEwOAM59AKYsOsnARERKTgmCiIjI6WYY/PurEyj/5fKit9/4WqmEI1IV+YziX3KYEgQREZHSUswQhn2uUmrD5yulikREiqYEQUREpBSYx5lnkFFaq502GlZKFYlULT7DKPYlhylBEBERKQUf/FZKGcCMZcXvTzpQOu2IiByDEgQREZFSMHNjKVU05M1SqkhE5ORomVMREZFSMGtbKVV0MLuUKhKRI2mZ05JTD4LICRg9ejTt2rUr7zBEpALS1GERqSzUg1BFrFy5kmHDjj2xzWq1snz54WX12rVrR6dOnRg3blxAuX379nHXXXexbds2Ro8ezeWXX+7fl5uby8yZM/nhhx/YvHkzmZmZhISEULduXdq1a0ffvn2pX79+aZ9auVu4cCEbNmzgjjvuKO9QRKQiM03cXi92q/XU69qxD+pUP/V6RKoQLWVackoQqpiePXvSsWPHQtstluN3Ju3YsYM777yTlJQUXnnlFTp16uTft3PnTu699162bt1K27Ztuf7666lWrRrZ2dls3LiRmTNnMmXKFGbNmkX16pXrS23hwoXMmjVLCYKIFM8wiH/DS9qoYhKEOyeUrK6mwyFneunEJSJyFCUIVUzz5s254oorTvi4zZs3c+edd+JyuXjjjTdo27atf5/L5WLUqFHs3LmTl156iUsuuaTQ8bm5uXzyyScYJzn+Lysri7CwsJM6VkSkokjPO06Bt78rWUWu4pdUFZHCTNSFUFJKEOS4fvvtN0aNGoXVamXChAk0b948YP/XX39NUlISQ4YMKTI5AHA4HAwZMqRE7d1+++0kJyczfvx4Xn/9dVauXElGRgYrV64E4MCBA0ycOJGlS5eSkpJCdHQ0nTt3Zvjw4cTGxvrrSU9P57333mPx4sXs37+fkJAQEhISuPTSS7npppuAw0OvnnzySfr06RMQx+jRo5k1a5a/3WPFunr1aoCAuQkF9e3Zs4cJEybw66+/kpKSQnh4OHXq1OHqq6+md+/eJfo8RKRiSkrz8u9vTH7de2iDaRb7oDQADAPjpTxaxFkY0gLCTTBME+Pd7+Gu908sAONqaFUXfh0DjqCTOgcRkaIoQahiXC4XaWlphbbbbDbCw8MLbV+2bBkPPvggkZGRvPXWW0XOIViwYAEA/fr1K7U4s7OzueOOO2jdujUjRowgNTUVgD179jBkyBDcbjdXXnkliYmJ7Nixg+nTp7Ny5UomT57sP4+HH36Y1atX079/f5o0aUJubi5bt25l1apV/gThVN1yyy2YpsmaNWt4+umn/dtbt26Nx+PhzjvvZP/+/QwYMIC6devidDrZvHkza9asUYIgcgabvsHLgG+Ouotfkh5SwwAM1qfCA0sMoriGDS/dhW1f1skF8vt2CL4W0iZDlHpZRYqjh6GVnBKEKmbChAlMmFB4jGtRE5I3btzIvffeS61atXjrrbeoWbNmkXX+888/hIWFUbt27YDtXq+XzMzMgG3BwcEEBwcfN8709HT69+/PiBEjAraPGTMGj8fD1KlTqVGjhn979+7dGTJkCFOnTuWOO+7A6XTy66+/MmDAAB566KHjtneyLrzwQubOncuaNWsKDd3atGkT27ZtY+TIkQwePPi0xSAiZW/o96UzxCedMH5MOIdr9/18ahUNGAPzniqVmEREtMxpFXPVVVfx1ltvFXodfSEO+RfpbrebuLg4oqKijlmn0+kssvdh69atdO/ePeA1bdq0Esd64403Fmpn6dKldOnSBYfDQVpamv9Vq1YtEhMT/SsxORwOgoKC+OOPP9i9e3eJ2yxNBZ/JqlWr/D0gFVFqaiq5ubn+906nMyCxy8vLIyUlJeCY5OTkYt/v2bMH0zx8AaU21EZlayPjeHMJTsBfNWofv9BxeH4LfAhDRfqs1IbaOJE2pGJQD0IVU7duXdq3b1+isueffz6NGzfmww8/5J577mHcuHGEhoYWKhceHo7T6Sy0vXbt2rz11ltA/t30o3soihMTE0NERETAtqSkJHw+HzNmzGDGjBlFHlfQi2G327nvvvt45ZVX6Nu3Lw0bNqRdu3Z07dqVCy64oMRxnIqEhARuueUWPvzwQy677DKaNm3K+eefT/fu3WnRokWZxFASR87bAAole0FBQcTFxQVsS0hIKPb90b1NakNtVLY2GkR52JxGqei2+Y9TrsM2pFvA+4r0WakNtXEibZxOGmJUckoQpFh33XUXhmEwadIk7r77bl5//fVCSUKjRo1YvXo1u3btChhmFBIS4k9GrCe47ndxw5Auv/zyY47fdzgc/p8HDBhA165dWbp0KatWreKHH37g888/p0ePHjz//PMAxa6q5PV6TyjmoowYMYK+ffuydOlS1q5dy4wZM5g8eTI33XQTd9999ynXLyLlY/G1Bg0mmuSe0q8Jk9a27cTUc2Ju4eTXV4kNhxdKZ16ViAhoiJGUwJ133sktt9zC2rVrGTlyJNnZ2QH7u3XLv3P19ddfn9Y4EhMTMQwDj8dD+/bti3y1adMm4Jhq1arRr18//vvf/zJ79mx69uzJvHnzWL9+PYB/6FR6enqh9nbt2lWiuI63dGtiYiLXXnstL7zwAnPmzKFt27Z8/PHHFXrYkYgULyHciuteG8uuh/vPhWYRxz8GANNkYAOY1Q92DoU7Q39g2bUt8KR8CM9dd2JB3HQxbJsAKR+fYPQiVZPPKP4lhylBkBIZMWIEt956K+vWreOuu+4iK+vwihv9+vWjfv36TJ48mR9//PG0xRAdHU3Hjh1ZsGABv//+e6H9pmly8OBBIH+1JpfLFbDfarXSpEkTADIyMgCoVasWVquVFStWBJRdt25dkW0UJSQkBCicZDidTjweT8A2h8PhXwmqIAYROXO1r2Xj5X/Z+PuOEnbIe7183t9Gr8Y2qh/ZGRsRAv8ZeGKNf3QP1I0/sWNEREpAQ4yqmL///pvZs2cXua9r165FzjEoMHz4cAzD4L333mPkyJG8/vrrhIeHExwczLhx47j33nt58MEHOe+887jwwguJi4sjKyuLpKQk5s2bh9VqDVh56GQ8/PDD3HbbbQwdOpRevXrRrFkzfD4fu3btYvHixVxxxRXccccdbNu2jdtvv51LLrmERo0aERERQVJSEl988QW1a9fm3HPPBSA0NJQ+ffrw9ddf88gjj3DeeeexY8cOvvnmG5o0acLGjRuPG1OrVq34/PPPeeGFF+jUqRM2m42WLVuyadMmnn32Wbp160a9evUIDQ3lr7/+YsaMGbRs2bLIJWNFpBIzTUade5z7chteh2YlGH54QcPSiUmkCvHpQWklpgShivnuu+/47ruin9T51VdfFZsgAAwbNgzDMJg4cSIjR47kjTfeIDw8nMTERCZPnszMmTP54YcfmDJlCk6nk5CQEOrUqcOVV17JlVdeecoXxTVr1mTKlCl89NFHLFq0iDlz5hAUFESNGjXo3LkzPXr0AKBGjRr07duXVatWsXDhQtxuN/Hx8Vx11VUMHjw4YI7Dfffdh2maLFy4kEWLFnHWWWfx6quv8tVXX5UoQejZsycbNmzg+++/54cffsDn8/Hkk0/Stm1bLrnkElatWsXcuXPxer3UrFmTIUOGMGjQoFP6HETkzDS253EeaNY0sWQVffPYqQcjInIMhnnkelUiIiJyUoyXPcUXME3MB+3+t263m0mTJgEwZMgQ7PZD+4yrj9+Y+eXJhilSZV07OKnY/Z9+VL9M4jgTaA6CiIhIKTg7AtA9N5EKyzSMYl9ymBIEERGRUtAk9jgFSnoBckGjU45FRORUKEEQEREpBX2bUvIkoDjT/+/U6xCRQrTMackpQRARESkFt5xjK36IkddXsooSqxW///6+JQ9KROQkaBUjERGRMtDQmgccZxWjknj55lOvQ6QK8mmeQYmpB0FERKQM9G4dfPxCIiIVgBIEERGR0nKsO5SmyWuXnkCn/a/PF719zwcnHpOIAPkPSivuJYcpQRARETndTnRoQ7tmsGoMWA4d16gG+KZDjehSD01E5GiagyAiIlJKXKMMgseV0rMQ2jYG7/TSqUtE5ASoB0FERKSUOGxWeiQW3p55t75uRcqb1yj+JYepB0FERKQUfX+tDY/Xx+wtPs6rDrWj9FUrImcW/dYSEREpZTarhb5N1GsgUpFomdOS028vERERERHxUw+CiIiIiFR6PnUglJh6EERERERExE8JgoiIiIiI+GmIkYiISAXhc3n4pfVUjG2ZYDM4e90NRDeOLu+wRCoFPS255NSDICIiUgGYpsmqsLcJ2ZRJXF4WcdlO9jR5m+Txq8s7NBGpYgzTNEvpkY8iIiJyLINePcCq7SbZNiv4fPg8Ps4P20T/6duwZlkwDZMmu/YShA8bPtzYiSQTEy8NzSfLO3yRM16P23cXu3/eu7XKKJKKT0OMRERETrOX/3eQr1MdZEVZwWeC1UJcdi5Nf3BjdVoxfCZWH4RZcrH7wMDEjo88LAThKe/wRaSKUYIgIiJymr233ENWqB3cBRf7XlIcdpLDgznPa2LzmgR78gj35RGMCwPwYpBFKNtD4mlQnsGLVBJa5rTkNAdBRETkNEsODgKvL2Cb1eXm18R4rF4Ti89H7ax9hBxKDgCsmISRQ7WcDHK2HSj7oEWkylKCICIichp5PCYOtztwowFeq4UIrxcrXlqk/UNjz8ZCx1rxEUEab1+2pIyiFam8vBjFvuQwJQgiIiKniddrMvLfv9EwI/vwRosBRv5rRd0EljSqRaK5ERs5hY43gWrspfH+9LILWkSqPCUIIiIip8mj928m3RHCnuBgCLPnJwdH+bFJHYLJxk42Do5MBExMvPiwU8+5v+yCFpEqT5OURURETpN9u3KYX7sW+x1B4PFBkAXyAuciBHt9ZBFJGBlEsJsQUvFi5yA1cRFBFuEEe7WSkcip8moUUYmpB0FEROQ0eGdOBukh4fnJAeQnCBgQZPX3JAR53Dy08iu2Bjcml2AALOSShwMrdsJwEUouhgdyDxYegiQicjooQZBi9enTh9tvv73U6/3mm29o164dK1euLPW6K7IJEybQrl07du8u/mEtInJm+nmHm2u/yuPTtblMmZme/1A0oHZuHq2zcojP84DNiiXIyjV/L+fXj57iys0rqMUW3jv3Rj45ewCbHW1xUd1fpwWTcHL4PeHN8jotkUrBZxjFvuQwDTGqglwuF19++SULFixgy5YtZGVlERUVRfPmzenRoweXX345Nlvl+KfxySefEBERQZ8+fco7FBGpxJy5PmJfzCbK7SHTEcys37y4EuPxWiz03LKHxulZ/rIrqsfwa40Ygg0frffvACDWlUaILxuLy47LE0KmBSJ8h3sMrJgk5u7ln5inaHRQT1UWkdOrclwFSont2LGDe+65h+3bt3PBBRdw8803Ex0dTWpqKitWrOCpp55iy5Yt3HPPPeUdaqn43//+R0JCghIEETltzhmTTvxff2Nt1IoDEWFgmuRa8zvo43JyA5IDgPP2H+T3uEhcNrt/m9ewUGt7OrHpubgIIcUWRaiZTUP3Hgx8OHBjGmDLyCTVuBdvlIP4tBfK9DxFznRe9RKUmBKEKsTlcjFq1Ch27drFmDFj6NatW8D+m2++mfXr1/Pnn3+WU4RnlqysLMLCwso7DBEpSx4vps+Hy7Bxy1u7SV+1i/VNW+Jt2gYwwGcGFI/MdReqwmpCuNvDLasXApBuj2BraANqHjy8FGpQXg6RZGBg4ih4eJp56AWY6S6cxp1Yoh1Yp9+Oo1vz03G2IlJFKUGoQr7++mu2bdvG4MGDCyUHBVq0aEGLFi0KbU9KSmLs2LGsWbMGwzBo3749Dz30ENWqVQsot3v3bsaPH8/y5cvJzMykevXqXHrppdx6660EBwcfN8a8vDymTJnC3Llz2blzJ0FBQZx77rnccccdNG9++AvQ5/Px6aefMnPmTHbv3o1hGMTFxdGmTRseeeQRbDYb7dq1AyA5Odn/M8DMmTOpVasWAH/++ScffPABa9asITs7m4SEBHr16sXgwYMDhlndfvvtJCcnM378eF5//XVWrlxJRkaGfw7Fpk2bmDBhAmvWrCEnJ4fatWvTu3dvBg0ahNVqPe55i1QWe7JMPvrDJNXlI9RukJkHXesY9G5U9JS3OVt8/LDdpNnObQxa+xPJTeoz+az2mFYrNcNgcxq0ivFx3dqf2LFkKz/Wa86aVq3pvHgJbdOTsfVozefJwdSc/yv/hMQw6byLaZG1n2rp6awPiiYiO5stcTXYHRVDiM9DXJaTRgf28N9F07loy9+Q62FPeCQRuS7sHi/7wvPv7K9LqAsWK7UyDnIwJIx0RzDL6jVlS0w8bouVvxPqszO6OpxVLf+ZBgUC8wN2h4fgNgzs5uEdTpuVVJ/Jh80684+tJUEeK5gm1ezZ1D2Q7n9cUyYRmECNIp6PYCUXsEKaB++/3iSPLEy8mFgIIgsDE6/dhrVpDYxqUXBWbWicADdfAnERp/R3LCKVnxKEKmTBggUAXHXVVSd03P79+7njjjvo2rUrd999N5s2beLLL78kKyuLt956y18uOTmZwYMH43Q6GTBgAHXr1mXVqlVMmjSJdevW8fbbbxc7t8Hj8TBy5Eh+++03rrjiCv7973/jdDr56quvuPXWW5k4cSJnn302AB988AHvvPMOnTt3pn///lgsFnbv3s3ixYvJy8vDZrPx9NNP8+qrrxIdHc0tt9zibycmJgaApUuX8uCDD1KnTh0GDRpEZGQkv//+OxMmTGDjxo28+OKLAfFlZ2dzxx130Lp1a0aMGEFqaiqQn2Tcfvvt2Gw2Bg4cSFxcHEuWLOGNN95g06ZNPPPMMyf0eYucqXZkmLSb4mWf/0Z4/kXxKytNHmhn8lLXwGT5saVenl1WcOFcl7d8PjYdqEn2CguBV9oGUzdG8P373/DATU35v/ee5sLtmwDYPv0nHk5P9ZfstuZXut/xBL7owglJjjWInZGx7IyM5bXMdDr9+TsGUDvz8LMH6mWksrJ2Azpt30StzDT/9t9q1mHQup/5uG1nnu1+EztjosAXuFypw+OlSWomXsPg72qRmIZBrs3KvPrV6bl1D1YMHK5cwlPTqRsWQkymIz85ADAMDkSFEeHKJdbpAsCHBY7xdFcreVjx4cOGh2DAjhUrPrw4qU0EO7G5PbB+F7ALFh3qGX5jDqwaoyRBqiQtFlxyShCqkH/++YewsDASExNP6LgdO3bw/PPP06NHD/82i8XCtGnTSEpKon79+gC89dZbHDx4kHHjxtGpUycABg4cyGuvvcbkyZOZNWsW/fr1O2Y7n332GatWreKNN96gQ4cO/u0DBgzgmmuuYdy4cbz77rsA/PjjjzRo0ICxY8cG1DFy5Ej/z1dccQXjx48nNjaWK664IqBcbm4u//3vf2nZsiXjx4/3Jy79+/enSZMmjB07lpUrVwb0PKSnp9O/f39GjBgRUNfLL7+M2+1m0qRJNGnSBIBrrrmG//znP8ydO5e+fftywQUXFPsZi1QGb6/1HZEcBHp9jcl/2pvEhuRf8GbmmbyyMvB2+7pa9Y9Z97ym5/BBu654LVZ/cgAQ5s4LKDfnrHPxWY6/QN+T8784xqU3rK+RSLtdWwO2NdufDMCgNUt5odt1+RsNg4JEplq2i+vXbyPXaiUzKIhz9qXzY/3qJGTmEJORTYvfN2MzTWweLwZw98FMLEclGAAb69akzeZdOPLcmICTcKqRgpUjy5rYyTv0kwUrbkws5KcUFjzYcBNKEEX8ZWzbD5MWwANXHvczEpGqS8ucViFOp/OkxszHx8cHJAeA/8J5x478FTh8Ph+LFy+mWbNm/uSgwM0334zFYmHhwoXFtjNnzhzq16/PWWedRVpamv/l8Xho374969atw+XKv7MWHh7Ovn37WLt27QmfD8Dy5ctJSUmhT58+OJ3OgPY6duzoL3O0G2+8MeB9amoqv/32G126dPEnBwCGYfh7LX788ceTirGspKamkpub63/vdDrJzMz0v8/LyyMlJSXgmOTk5GLf79mzB/OIIRVqo2q0sSdwLm6APC/sSDlcYH+mG9cJ3s77J64GNZxpAdsiXIHDbw6ERpaortpH9DoczVbEhbvF9B3608TmOxS4YfiHF3XcsZ80h4Ok6ChSQkM4GBJCm70Z/F4rBq8NQtwe7IeSA4DI3DwOhhQedpkeFc7aVnUPpR0GXqzsoDYZhOO0B2HgxUEaBhx6mVjwYuA9VIOBBR9eHMc++T1pZ9S/K7VRtdo4nbyGUexLDlMPQhUSHh5OVlYx3+DHULt27ULboqKigPy76gAHDx4kOzubhg0bFlm2WrVq7Nq1q9h2tm7dSm5uLt27dz9mmbS0NGrWrMmdd97JAw88wG233UZ8fDznnXcenTp14l//+hd2u/2Yxx/ZFsDTTz99zDJH/1KLiYkhIiKwW77geQZFnXeDBg2wWCzHPe/yFhsbG/A+PDw84H1QUBBxcXEB2xISEop9X7NmTbVRBdsY0NTHh+uPGoR/SJvqcE7i4XYaxgVxQU0PK/YcLmP3eHAfYxhiVE4WI3+aS/fbH8dlsxPsyZ/8uy2mGk1S9vrLDfjtFyZdcEmRdRzp65bnc8uvC4vc13LPDg4GhxLjOnwHPimmOk1S9uCy2Yl3HtFrYTPAaxLjymNv2NHDdgzis3L5u2ZMke3Mal6f21b9id2bn3y4gh04o8JxEkEe2wg6dNGfh4N323Tmv3068v3ksXRLOuivw3foPp/FPyTLhwcHERTzrJX+F55R/67URtVqQyoGJQhVSKNGjVi9ejU7d+48oWFGlmK664+8k1AaGjduzL333nvM/QXzB1q3bs3XX3/NL7/8wsqVK1m1ahVz587l/fff57333vMnMMeL+5577qFp06ZFlomPjw94X5JJ1iJVWa9GFl7vBmN+9ZGaA2F2yMiDS+oYvN298O+RaX2tjJjvY36Sj+bp+xjzxQcsbXc+48/titdmI9oBuzKhdaiLF+dPITY3mxHL5nHDzffx5Lef0vzAblwNajK9TkMuW7+a3VExTD6vC9Uy0zEMSA0NxwQMn4nXZsPi8+EzDOxeL+urJx49n9j//pw921mdUI+/7UFUy8og12qn5b6dOO1BzGl2LpviIonLcpESFpzfg2AzSIoOx1FEj4jda7IjJpyfmtWh44Yd/u0/161JhAEHa8RiYuCzWHCF5tcXkpVLBsEsblUbt8PCb3Vr8H2LBvgsFt664BK6JW0AwEv+/AWD/Cc0m/hwEkUIKVjw+M/HsBpgsUBiHDz5b+jQ7FT+mkXOWB51EpSYEoQqpFu3bqxevZoZM2Zw5513lmrdMTExhIWFsWXLlkL7MjIyOHDgwDEvxAvUqVOHgwcPcv755xeblBQIDQ3lX//6F//6178AmDZtGi+++CIzZszgpptuAvKH+hSlbt26AISEhNC+ffvjtnUsBashFXXeSUlJ+Hy+IntgRCqrkW0tjGxbstGrdSMNZl1tBaxAbXjqcS4FCvfrhcOwO4E7GQHkzwLK/3/b6tALoAnwiWkG/L8389xgGOSYFkKDbGCaYNiBq/NfBTc5cnIhIwf3nzvJDQsjd/5m6m9NYtVFF5BdPYa1izaSVq8mU/eHc862TTitIeyIi+Of+JpgGPxUJ57uW/bhMw5PxPYasC88f6jP/zq1onaul5BsF7PrJvBz3Zo8sGo9QR4PGRHheAt6TkyTs1dvxwJc8vsukqPD+KZ1U/+8in2hEeQRggcbHsPEYXrwAd4wB9a29Yi86Xys3c8mJy6akIhihhmJiBRDCUIV0q9fP6ZNm8bkyZNp0aIFXbt2LVTmr7/+4o8//mDgwIEnVLfFYqFz587MnTuXn3/+mYsuusi/78MPP8Tn8xXZ3pF69erFa6+9xtSpUwuN9Yf8IT8FXZVpaWlER0cH7C9YBjUjI8O/LSQkJOB9gQ4dOhAbG8uHH35Ijx49CvU4uFwuvF7vcedsxMbG0rp1axYvXszmzZtp3LgxkN9DMWnSJAAuueT4wx1EpHQcfVPACMofchh6uMDRB+T/GRqMERpMUM0YgoAO7fOHDfYuKNe7HgB3AdDAf/iYb9J5fUke8S4P8xtW5+z9mcS43OTYrWyMjyDXnp8wXLAzheyIMHLCQ2nl9pCbmoEVEwOIzHSSZ7fjs1ionXSAyMxsClYvSkjL4pEvl3HT3b0wDYM7li8niwhsOInIeA1LeNE9myEn8qGJVBGeYy5NIEdTglCFBAcHM27cOO655x4eeOABLrzwQtq3b09UVBQHDx5k1apV/PLLL/677yfqzjvvZPny5TzwwAMMGDCAOnXqsHr1aubNm0fbtm3p3bt3scdfd911LF++nNdee41ff/2V888/n7CwMPbs2cOvv/5KUFAQEyZMAPJXNmrVqhUtWrQgPj6eAwcO8NVXX2G327n00kv9dbZq1YoZM2Ywfvx4GjRogGEYdOnShZCQEJ566ikeeOAB+vfvT9++falTpw6ZmZkkJSXx448/8tJLLwWsYnQsDzzwALfffjtDhw71L3O6dOlSfvnlFy677DKtYCRSiT3UJ4qRl/no/MI+gt1u1tWIyu+VsBpgPdyTUiszG+uh3ooIr5euBw5is9mBXAzA4XZj+Hw02LUfz1FfzQlpWXTcsINr16/msr83YFx3DpGfnNzvaRGRklCCUMXUqVOHTz75hOnTp7NgwQI++OADsrOziYqK4qyzzmL06NFcdtllJ1V3QkICH374Ie+88w5z5swhMzOTGjVqMGTIEG699dZin4EAYLPZGDduHF988QWzZ8/2JwPx8fG0aNEiIMEYNGgQP/30E5999hlOp5PY2FhatmzJkCFDAoYyjRgxgvT0dKZNm0ZmZiamaTJz5kxCQkLo0KEDH330ER999BFz5szh4MGDREZGkpiYyA033BCwKlFxzj77bD744AMmTJjAF1984X9Q2siRIxk0aNBJfJIiciYJsVtY+XhNdqzexZ2v7WRbVBy5Jjgj4tgTFUbt9DTqpjsxjxh+ZADralTDEx9Lo9Q06h1Iof367QS73WRgxX5ogrIbKwYw7rPvweGkmvelYw6dFBEpLYZZ2rNMRUREhGGDVmPLCeK2ZdP5pF2/QsObMmw2fqqZ/zT69z/8mKCsYEzyJx8XlPQBwTgBCw33DCesRigicnIaj9xf7P7Nb8QXu78q0XMQREREToMXX2+FabGwOb4u8c7Cz12I8HjANHF4PERm568lb2IEjJK2AHYMzCBTyYGIlBklCCIiIqdBVKwdnwmLG19A9czCdy5zLRbOSk2j/5+b8ZoODMxD05YDebCxM7hkD4ATkWNzG0axLzlMcxBEREROk5bnh/DHKhe/1mtJsNtNls3Gwuqx7AoNJt6Vx0X7UwnOdeMyggkyfVjw4cMaUIcVNwctxa+oJiJSmtSDICIicprc+X8NiKlhYb/dzu6QYL6sU4O/o8LJtNvYEhHKV3VqErsrleSoCHyAhfwkwQS8hsGqujVwYyXCk3e8pkTkONzHeclh6kEQERE5jZ57oxln3b0Hu9tkX3Dgw8uy7DbW16pG25372OAIItyVy96IMO6+rgehuW5e+mIBmYRw0addyil6EamKlCCIiIicZjtDHNT35B56knPgWOfQvPx7lz6LhYzQEAxg2MI1dP9rK9Wc2WyoG0zHXo3KIWoRqao0xEhEROQ0u7i5jVBMIny+gO3hbjfN9gaucLSxRgytdu/ljzrVuGLUv4nPdZVlqCKVVrZhFPuSw9SDICIicpp9fVM4ib+56JCSwfq4CA7arETneThvRzIJWfs46IjGY7GxrEkNXu1+kf+4K//4k2Z7U8oxchGpipQgiIiInGY2q8GesfHMWZ3FxA8OEGS3cM31Uexf8xMb/xXMTYOuYc9za2jy4jLO27udVYm1ablnL5dt2Eh2r3PKO3yRSiFHnQQlpgRBRESkjFzeNozL2+YvWep2u5m0Jn+71W6h/jMXsnbaZlpuPED7zXsAONi4PmfPGlBe4YpIFaUEQUREpIJos2FQeYcgUmnlFfEgQimaJimLiIiIiIifehBEREREpPJTB0KJqQdBRERERET8lCCIiIiIiIifhhiJiIiISOWnh6GVmBIEERGRMvbQU1uZuceB13Il1TMyuPEGL3a7vbzDEhEBNMRIRESkTD3y4namHwjHY7NjWizsjY6mzYMHyzssERE/9SCIiIiUoWnb7HTbuok7fvmFGs5MljZowEsXX8KPHydxyU31yzs8ERElCCIiImWp/sE0nvpuLjbTBOBfmzdj9/p4Ofs8LrmpnIMTqcw0B6HENMRIRESkDHXZssWfHBTomLQVe2ZuOUUkIhJICYKIiEgZSgkLLbQtPTiYa9etKYdoREQKU4IgIiJSBpJWp/BcjyX80KgxW2NiAvZ9cP4FrGvQuJwiE6kijOO8xE9zEERERE6z53r8gs8Ej2Enx+Fg6MB/c9nff1MzM5Of6jfgt4QE6mRm4dqXzZ9Df6HG9fWpfU2j8g5bRKooJQgiIiKn0d5/svCZ4AN2BjvAMMgOcvBl63MOFzJNskyY1fRr3MFWNi/dR9DNP9H74PXYgvVVLVI61E1QUhpiJCIichr977E/8Bz6OcrjhaMmKANgGNz08++4wvKTgazIINKqhzInbGrZBSoicohuS4iIiJxGGft9WAArYMP0L7Vo93oYtXwGV2xaRaY1hH/yLiAk2wuAz4D9NUPwhuo+nkipUQdCiek3j4iIyGlkzXVjPfRzsNdLeJ4bgAd++Yo7Vn9PncwUotIMf3IAYDEhZr8Lr8VKXnpOOUQtIlWZehBESmjlypUMGzYsYFtQUBDx8fG0bduWm266iQYNGvj3tWvXrlDZGjVq0LlzZ2699VaioqLKJG4RKV92PLixA7AvJJimaRmkBDvos3GFv8xB4gsdF+QxsTjd/NFjBm1XXFtm8YpUWupBKDElCCInqGfPnnTs2BGA3NxcNm3axIwZM1iwYAGffvopCQkJ/rJNmzZl0KBBAGRkZPDTTz/xySefsHz5cqZMmYLdbi+XcxCRslMt5yDJjhByLRZ+i4/hn6hwqrlyef+8q7l72f/YFpNATooDvIHHmYDNBzt+zaJtuUQuIlWVEgSRE9S8eXOuuOKKgG1169bl5ZdfZsGCBdxwww3+7dWrVw8oe+2113LvvfeyZMkSFi1aRPfu3cssbhEpGzt/28+km+YRYvoIIZcgbziG28sXLevzV1x+z+HesBCe6diVFQ1bUisnj04//kn8/syAekwD8uwWch3B5XEaIlKFKUEQKQXVqlUDKFGPwIUXXsiSJUvYsWPH6Q5LRE6GacLEefDZT7A/HawWcLrA5casXx2PJRjr0nUYPh8+8kcteAwr6yJbkRTciMZZm+jrtbAzqDYeIwjT8JLnSePvLpH5ded5Cc7zEOzzsjXYQdO96YWTA+C78xvQftcu7F4vD3dawA9n16fjpt34DFh4dn1+r1cDwzCxYMFigVaZexn/61dcUNOA+/rCWYnw/nyY8SvUioEHroQmtcrjExWpIDTGqKSUIIicIJfLRVpamv/nf/75h7fffpvo6Gi6det23OMLEoPo6OjTGKWInLT/TIEXvypyl7EzBRuHLzMKJh8vj23PXqM28a59BHl8bAppGnBc7X0Z3PDLn0xp24wue1NofzANmwkHguxYct2F2wGap6SSGh0OQMOUTFJ27iPPZuW8rcm02r6P169ozx91a+AFvD5YHVaDPuddx98vjSLm859hcFd4c87hSr/4Bda/BjVjCrUnInIkrWIkcoImTJhA9+7d6d69O7179+aee+7BZrPx3nvv+XsSCng8HtLS0khLS2P79u1MnTqVL774gvDwcC6++OJyOgMROSafD96aU2yRo+9B5hl2djgSsXlNqnv2siuoTpHHXbl2M81SM+iYmp8cAFTLc+OMDMZtC/w6dtsseIMOb/NZLXTYvJt5rRsC+V/eF/+5rVAb+yKimNb6QsjMgYnzA3emOmHq4mLPTaRSM47zEj8lCCIn6KqrruKtt97irbfeYuzYsYwcOZK0tDTuuecekpOTA8ouW7bMn0xcffXVjB07loYNG/Lmm28SGxtbTmcQKDU1ldzcXP97p9NJZubh4Q55eXmkpKQEHHP0eR79fs+ePZhHPAxKbaiNM6aN5D2YHh8nxsQ4FFaWNYwgM7fIUjafSSNnVqHtEV4vm5omkH3EE5MPVnOAJfCKxWO1kGs/fsd/njW/jOkt4jzy8h/Zdsb8faiNKteGVAyGaRb1SEcROVrBMqf33HMPN954Y8C+P/74g5tvvpkePXrw/PPPA/nLnLZs2ZLhw4cD+cucJiQkULNmzTKPXUROwLB3YML3J3TITzHt2WvUwYKXs3LW85ejlf+BaAVcwXa+6NyKptmBzzUIdbq4cOFGTA7fxEyLdXAgISyg3IoGNcm22enx+xZ84B9idKQIVzabXryHGu5sGHAhTF1yREOO/CFG9auf0LmJVBbG/2UWu998MaKMIqn4NAdBpBS0bNmS8PBwVq5cGbA9Ojqa9u3bl1NUInJSXr8VasXmT1JOz8qfMZznhjwPZo1oPARh25Q/vKfgov7CgytYFelhl70uv4e1wObIwHQ7cJsh2D0mrpAgdtaP5+y0DDKCHYT68u/uW7w+mqzfDQSOcIhKzcVrtZAR48BrNVhTrzpLGydy+dp/WFe3Ogtb1OePOtX9ERiYNMpI4Z2F/6PGxY3h4auhfRNonggzVkDtOHikv5IDESkRJQgipcTr9eJ2F55sKCJnmCA7PPHv/NdRDMB+1HvIn6x8waGfZz66kMxP1/LJxefyffNzGPXLH0QfGtqDaeI1wAdUT06n+W87CXIf9QCEQ/XG7c8hbn8OXmDYn30P7UkoVPawmsC9gZseG5j/EhE5AUoQRErBsmXLyMnJ4ZxzzinvUESknPV9tis825UbgMxMNzOnbyAmJ4N1tVsTBATnuVlWPY7qpo3WqwpPNC7Mc3oDFqkqNBG5xJQgiJygv//+m9mzZwP5E7C2bNnCV199hc1m8883EBEBiIiwk2exYTO9+CxWDCA6z80lu/Yyo0EdFreuR6fft2ExwWsxsPoCpwWagDVaX9UiUrb0W0fkBH333Xd89913AFgsFqKiorjwwgu5+eabadGiRTlHJyIVzZaYuuyPDBwaZDNNajizePuSVnzfuh6NUjMYPHttoWMNTFpOvaSMIhWp5NSDUGJKEERKqF27doUmIRfnRMqKSOUVbIDbWvgp69lWKyk2GymJ1dhWL4Jbvl+O6XEUKlfzinplEaaIiJ+egyAiInIaRcUZhZY8zbZaWRMblf/G7WNPaAS/nVt4icWUkKCyCFGkitCT0kpKCYKIiMhpdOPrbSiYWZBjsbCsWgwTmtYn035Er4JpsiUqHvwlTdwGXPJ77zKOVkRECYKIiMhpFVUjBB/5l/7BPh+L42NJcRwxlMhiYDNgU2wCbRb1JKdpFNzUmMu8N1G9UWR5hS0iVZiepCwiIlIGVi/Yx7Tn/2FRjVjWVa9OjtUCNgshNoP4TBcxGU7WfFC/vMMUqbSMR5zF7jefCy+jSCo+TVIWEREpA227Vadtt+qcNWw3CW4PHPVcxeDc7PIJTETkKBpiJCIiUoaaHUwvtM0wTWpmZZZDNCJViGEU/xI/JQgiIiJlqFFaBrHZOQHbmqYcJIS8copIRCSQhhiJiIiUod0R4Vy1YQu/VY/jYEgwtTOdJDizsQ1uWt6hiYgAShBERETKVOpZ8RzIzuG8vfux+EyyHUEsqVWN7wbXKO/QREQAJQgiIiJl6rv/Vqf9Iwa+fS4cXg8pQUFMeTi6vMMSqfw0zaDElCCIiIiUseXPxeN2u5k0aRIArROHlHNEIiKHaZKyiIiIiIj4qQdBRERERKoAjTEqKfUgiIiIiIiIn3oQRERERKTyUwdCiakHQURERERE/AzTNM3yDkJERKQq+XSth+vmB379mg/YyykakarBeCK72P3m06FlFEnFpx4EERGRMnbdfMgf73D4ZbzsKdeYREQKKEEQERERERE/TVIWERERkSpAs5RLSj0IIiIiIiLipx4EEREREan81IFQYupBEBERERERPyUIIiIiZa2oFca16riIVBBKEERERERExE8JgoiISBm64OV0MDQYWqTMGcd5iZ8SBBERkTL0a5a7vEMQESmWEgQREZGyFBZa3hGIiBRLy5yeIVauXMmwYcOOuX/SpEm0atUKgHbt2gXss1qtxMbG0qRJE66//nouvPDCgP0HDhxgypQp/Pzzz+zZswfDMIiNjaV58+b06NGDbt26lf4JVRDz5s3j559/5u+//2bLli14vV5mzpxJrVq1CpVdtGgRCxcu5LfffmPv3r2Eh4fTsGFDBg0axEUXXVRk/bNmzeKTTz5h27ZthIWF0blzZ+666y5iYmJO96mJSIUVVN4BiFRNGtpXYkoQzjA9e/akY8eOhbbXqVMn4H3Tpk0ZNGgQAB6Ph+TkZL7++mvuuusuxowZ47/oT05OZvDgwWRlZXHZZZcxYMAAAHbs2MGqVav45ptvKnWCMG3aNNavX0+TJk1ITExk27Ztxyz73HPPERYWxsUXX0y9evVIT0/nm2++4e6772b48OHceuutAeWnTp3K2LFjadu2Lffffz/79u1j6tSp/P7773z00UeEhISc7tMTEREROWFKEM4wzZs354orrjhuuerVqxcq161bN6677jpmzZrlv+ifPHkyqampvPzyy3Tt2rVQPQcOHCiVuMuD1+vF7XYTHBx8zDJPP/001apVw2az8eKLLxabIDzzzDOcf/75AduuueYarr/+eiZOnMjAgQOJjIwEIC0tjfHjx3P22Wczfvx4rFYrAGeffTb33Xcf//vf/7jllltK4SxF5IyTkwUhYeUdhYjIMWkOQhUSHx8PgN1u92/bsWMHABdccEGRx1SrVq1EdXs8Hj788EMGDhzIRRddxL/+9S8eeOABNm/e7C+TmZnJRRddxIMPPlhkHW+++Sbt2rVjw4YN/m1Op5PXX3+dfv360aFDB7p3784jjzzCzp07A4795ptvaNeuHcuXL+e9997jyiuv5KKLLmLevHnFxl2zZk1stpLlyUcnBwDBwcF07twZj8cTkFwsXLgQl8vFNddc408OALp06ULt2rWZM2dOidoUkQpu617498tQ/w4Y+BIs/RM6PQLG1cd8Of97xzGr89oHQtfHYelfZXgSIiKB1INwhnG5XKSlpQVss9vthIUF3o3yeDz+ch6Phz179vDee+9htVq58sor/eUSExMB+Oqrr7j++usxTnJ83uOPP868efNo3749/fv3JyUlhWnTpjFkyBAmTpxI8+bNiYiIoEuXLixatIj09HSioqL8x/t8PubMmUOTJk1o1qwZkJ8c3HLLLezZs4e+ffvSsGFDDhw4wBdffMHNN9/M5MmTSUhICIjjtddew+PxcNVVVxEWFka9evVO6nxOxL59+wCIjY31b1u/fj0ArVu3LlS+VatWfPfdd2RnZxMaqsmKImcsrxd6Pg2bkvPfb9sPM1aA21vsYWHuPCw+Lz6LtdC+t8/rxshF8+DSp2DDm1CnZDdpRKQENAWhxJQgnGEmTJjAhAkTArb16NGD559/PmDbsmXL6N69e8C2yMhIxowZEzCh9oYbbmD27NmMHTuWTz75hHPPPZezzz6bc889l7POOqtEMS1btox58+bRo0cPnnvuOX+S0aNHD2688UZefvll3nvvPQB69+7N/Pnz+f777xk4cKC/jpUrV7J3716uu+46/7Z33nmHXbt2MWnSJJo2berf3qdPH6699lomTJjA6NGjA2JxuVx88sknxQ4rKk0bN25kwYIFnHvuudSuXdu/vWBoVkGvzZHi4+MxTZP9+/eXSQIjIqfJ8k2Hk4MCx0kOCrTb8Q8r6jUN3GgY/Fmrbv7POXkw/RcY1acUAhUROTEaYnSGueqqq3jrrbcCXkdPjgVo2bKlf/8bb7zBo48+Ss2aNXnkkUf45Zdf/OUSExP53//+579Ynzt3Lq+++io33ngj1157LX/9dfxu7oULFwJwyy23BPRANG3alM6dO7N27VoOHjwIwIUXXkhcXBzffvttQB3ffvstVquVyy+/HADTNJkzZw7nnnsu1atXJy0tzf8KCQmhZcuWLFu2rFAsAwYMKLPk4ODBgzz44IMEBwfz2GOPBexzuVwABAUVXq3E4XAElClvqamp5Obm+t87nU4yMzP97/Py8khJSQk4Jjk5udj3e/bswTRNtaE2KncbESe/0ECmo+hjHZ68w28O1V8pPiu1oTZK2IZUDIZ55N+0VFgFy5zec8893HjjjcWWbdeuHZ06dWLcuHEB251OJ1dffTV2u50ZM2YUOfb+wIEDrF27lm+//ZYlS5YQFxfH559/HjAc6Gh33303y5Yt4+effy5U59tvv80HH3zAhx9+SMuWLQEYO3YsU6dOZfr06dSrV4+cnBx69uzJueeey2uvvQbk/9K59NJLiz1Pi8XCihUrgPw5CE899RTjxo2jU6dOxR53LC+++CLTpk075jKnR0pPT2f48OFs27aNcePGFZqfcO+997JkyRKWLl1aKGF57bXXmDx5sv/8ReQMdtnT8N3aw++rRcKBjOMeFv7Mx2Q5jrqZYZpM+fhVbvhjOdSLh9/HnVISIiKBjKdzi91vPuEoo0gqPg0xqkLCw8Np1aoVixYtYvv27TRs2LBQmWrVqtG9e3e6d+/OY489xty5c/npp59KtHJSSfXq1YupU6fy7bffMmLECBYsWEB2dja9e/f2lynIWy+44AIGDx5c4rrLovcgPT2dESNGkJSUxCuvvFLk5OWCyd379+8vtATt/v37MQyjyOFHInKG+er/4N15sGITnN8Ybr4E3pgNY2fBQWeRh3gMA98xqrvB3A2PDYC7rlByICLlRglCFePxeADIzs4+btmWLVsyd+5c/yTcY6lduzY+n4+tW7fSpEmTgH1bt271lynQtGlTmjZtypw5cxg+fDjffvutfwJzgZiYGCIiIsjKyqJ9+/YlPr/TrSA52Lp1Ky+99BIdOnQoslyLFi346quv+O233wolCL///jv16tXTBGWRyiDEAff0Dtz2+L/zX8dgf9lT9A7DgD9eK8XgRCSAJimXmOYgVCEHDx7kt99+w+Fw0KBBAyB/6FJRY+F9Ph9LliwBKLKn4UgXX3wxkP805yNHrG3evJnFixfTpk2bQk8O7tWrF8nJycydO5eVK1fSo0cP/9h8yB8+dNlll7F+/Xrmz59fZLupqaklOOvSk5GRwZ133smWLVsYM2ZMkQ+sK3DxxRfjcDj4/PPP8XoPT1pcvHgxu3bt4rLLLiuLkEXkTKIRvyJSQagHoZLat28fs2fPBvIv9vfs2cOMGTPIzMxkxIgR/mVRp0yZwrp16+jcuTPNmzcnPDyclJQUFixYwF9//eWfz1CcCy+8kB49evD999+TmZlJp06d/MucBgUF8cADDxQ65vLLL+f111/nhRdewOfzBQwvKnDnnXeybt06/vOf//DDDz/QqlUr7HY7ycnJ/PTTT5x11lmFVjE6UatXr2b16tUA/gnZn3/+OeHh4QDcdtttAfH8/fff9OzZk4yMDP/nW6B169b+ZWNjYmIYPnw448aNY8SIEfTs2ZP9+/czZcoU6tevz/XXX39KcYuIiIicLkoQKqmNGzfyxBNP+N+HhYXRtGlT7rrrLnr27OnffuuttzJ//nzWrFnDsmXLSE9PJyQkhAYNGjBq1Cj+/e9/Y7Ecv6Ppv//9L82aNWPWrFmMGzeOkJAQ2rZty/Dhw2ncuHGh8rGxsVx00UUsWbKEunXrFvm8gPDwcD744AOmTJnCvHnzWLx4MVarlerVq9OmTRv69et3ch/OEX799VcmTpwYsG3KlCn+n49MEAoSiO+++47vvvuuUF1PPvmkP0EAGDRoEFFRUXzyySe8/PLLhIWF0b17d0aOHKnhRSJVmg914ItIRaZVjERERMqQ5dH9mEcNuwTANDEftBfeLiKlwnjmOKsYPaZVjAroFoaIiEgZerF5ruYbiEiFpgRBRESkDD14Y+LxC4mIlCMlCCIiIhWBoTUYRaRiUIIgIiJS1pQMiEgFplWMRERERKTyU2JeYupBEBERERERP/UgiIiIiEjlpw6EElMPgoiIiIiI+ClBEBERKXd6LoKIVBxKEERERMqY+YCN/KSg4FWwTUSk/ClBEBERKQd598CEyElMiJxE3j3lHY2IyGG6XSEiIiIilZ8mKZeYehBERERERMRPPQgiIiIiUgWoC6Gk1IMgIiIiIiJ+6kEQERERkcpPHQglph4EERERERHxU4IgIiIiIiJ+ShBERERERMRPCYKIiIiIiPhpkrKIiIiIVH6apFxi6kEQERERERE/JQgiIiIiIuKnBEFERERERPyUIIiIiIiIiJ8mKYuIiIhI5adJyiWmHgQREREREfFTgiAiIiIiIn5KEEREREREjmH06NGEh4eXdxhlSnMQRERERKTyMzQJoaTUgyAiIiIiIn5KEERERESk8jOO8zpJv//+Oz179iQsLIyoqCgGDBjA9u3b/ftvvfVWOnfu7H9/4MABLBYL559/vn+b0+nEbrczbdq0kw+kFClBEBERERE5CTt27KBLly6kpKQwZcoU3nnnHVavXs3FF19MZmYmAF26dOHXX3/F5XIBsHjxYhwOB2vWrPGX+fnnn/F4PHTp0qXczuVImoMgUoWZpun/5SQiZcvtdpOTkwNARkYGdru9nCMSKT8REREYZ+AcgbFjx+J2u/n++++JjY0F4Nxzz+Xss8/mww8/ZOTIkXTp0oXc3FyWL1/OxRdfzOLFi7nqqqv4/vvv+emnn7jssstYvHgxTZs2pUaNGuV8RvmUIIhUYZmZmURFRZV3GCJV3qhRo8o7BJFylZ6eTmRk5Gltw3yg9C97lyxZQrdu3fzJAUDz5s0555xzWLp0KSNHjqRBgwYkJiayePFif4IwbNgwcnJyWLRokT9BqCi9B6AEQaRKi4iIID09vbzDOGFOp5NevXrx7bffVrml58qKPuOyoc/59NNnXDZO9XOOiIg4DVGdfgcPHqRNmzaFtteoUYPU1FT/+4LEICMjg3Xr1tGlSxeysrL44osvyM3NZcWKFQwdOrQMIy+eEgSRKswwjNN+x+Z0sFgsWK1WIiMj9YV/mugzLhv6nE8/fcZlo6p+zrGxsezbt6/Q9r1799K0aVP/+y5dunDfffexcOFCqlWrRvPmzcnKyuL//u//+PHHH8nNzQ2YyFzeNElZREREROQkdOrUiR9++IGDBw/6t23YsIHffvuNTp06+bcV9Bi8+uqr/qFEbdq0ISQkhBdeeIE6depQv379sg7/mNSDICIiIiJSDK/XyxdffFFo+z333MOkSZO49NJLefTRR3G5XDz22GPUrVuXm2++2V+uefPmVK9enUWLFvH6668DYLVa6dixI3PmzOGGG24oq1MpESUIInLGCQoKYujQoQQFBZV3KJWWPuOyoc/59NNnXDYq++fscrkYOHBgoe2TJ09m0aJFPPDAA9xwww1YrVZ69OjBq6++WmheRZcuXfjiiy8CJiNffPHFzJkzp0JNUAYwTNM0yzsIERERERGpGDQHQURERERE/JQgiIiIiIiIn+YgiEil8ddffzF48GAcDgdLliwp73AqDa/Xy5QpU1i6dClbtmzBNE2aNGnCsGHDOPfcc8s7vDNSUlISY8aM4bfffiMsLIwrrriCESNG6GnKpWT+/PnMnj2bv//+m4yMDOrWrcs111xD3759z8in9Z4JsrOzGTBgAPv27ePjjz/m7LPPLu+Q5BQoQRCRSsE0TcaMGUNMTAzZ2dnlHU6lkpuby4cffkjv3r0ZPHgwFouFr776imHDhvHmm29y/vnnl3eIZ5SMjAyGDRtG3bp1eemll9i3bx9jx47F5XLxf//3f+UdXqUwdepUEhISGDVqFDExMSxfvpxnn32WvXv3cvvtt5d3eJXSe++9h9frLe8wpJQoQRCRSmHmzJmkpaXRt29fPv300/IOp1JxOBzMmDEj4KF67du355prruGTTz5RgnCCpk+fTlZWFi+99BJRUVFAfi/Niy++yC233EJ8fHw5R3jmGzt2LNHR0f73559/Punp6UydOpXbbrsNi0UjrEtTUlIS06ZNY9SoUTz//PPlHY6UAv0PEZEzXmZmJm+++Sb33XcfNpvue5S2gqejHr2tSZMm7N+/v5yiOnP9/PPPXHDBBf7kAKBHjx74fD6WLVtWjpFVHkcmBwWaNWtGVlYWOTk5ZR9QJTdmzBj69+9PvXr1yjsUKSVKEETkjPf2229z1llnVajH1Fd2Ho+H33//nQYNGpR3KGecpKSkQk9MjYiIoFq1aiQlJZVLTFXB2rVrqV69OmFhYeUdSqUyf/58/vnnH2677bbyDkVKkW61icgZbcOGDcycOZOpU6eWdyhVyscff8z+/fu5/vrryzuUM05GRkahByhBfpKQkZFRDhFVfmvXruX7779n1KhR5R1KpeJyuRg7diwjRowgPDy8vMORUqQEQUQqFKfTyYEDB45brnbt2thsNl588UUGDBhQ6I6sFO9EPuejV9ZZtmwZEyZM4LbbbuOss846XSGKlIq9e/fyn//8h3bt2nHttdeWdziVyvvvv09cXBx9+/Yt71CklClBEJEKZf78+TzzzDPHLffFF1+wYcMGkpKSePbZZ8nMzAQgLy8PyJ+XEBQUhMPhOK3xnqlO5HM+Mvn6+++/+b//+z8uu+wyhg4dehojrLwiIyNxOp2FtmdmZhaa6yGnJjMzk7vvvpuoqCjGjBmjycmlKDk5mSlTpvDSSy/5/z0XzO/Izs4mOzub0NDQ8gxRToFhmqZZ3kGIiJyMCRMmMHHixGPuHzx4MCNHjizDiCq3HTt2cOutt9KsWTPGjh2rCeEnaejQoURFRfHyyy/7tzmdTi655BKeeOIJ+vTpU47RVR4ul4s777yTPXv2MGnSJKpXr17eIVUqK1euZNiwYcfc37JlSz788MOyC0hKlX67i8gZq0+fPpx33nkB22bNmsW8efN47bXXqFmzZjlFVvkcOHCAu+66i5o1a/Liiy8qOTgFF110EZMmTSIzM9M/F2H+/PlYLBYuvPDCco6ucvB4PPznP/8hKSmJiRMnKjk4DZo1a8Y777wTsG3jxo28+uqr/Oc//6FFixblFJmUBv2GF5EzVq1atahVq1bAtlWrVmGxWGjXrl05RVX5uFwu7r77btLS0rj//vv5559//PvsdjvNmzcvx+jOPP379+ezzz7j/vvv55ZbbmHfvn289tprXH311XoGQil58cUXWbJkCaNGjSIrK4vff//dv69Zs2YEBQWVY3SVQ0RExDF/z5511ln6vXCGU4IgIiLFSk1NZePGjQDcd999AfsSEhL45ptvyiOsM1ZkZCTjx4/npZde4v777ycsLIx+/foxYsSI8g6t0ih4nsS4ceMK7Zs5c2ahGwsiEkhzEERERERExE/T+UVERERExE8JgoiIiIiI+ClBEBERERERPyUIIiIiIiLipwRBRERERET8lCCIiIiIiIifEgQREREREfFTgiAiIiIiIn5KEEREKpGbb74ZwzDKOwwA/vjjD2w2G/PmzfNvW7hwIYZh8OGHH5ZfYFIhfPjhhxiGwcKFC0/qeP1bKtratWuxWCwsWrSovEORM5gSBBGp8LZs2cLtt99O8+bNCQ0NJSYmhrPOOovBgwfz448/BpStX78+LVu2PGZdBRfQBw4cKHL/X3/9hWEYGIbBkiVLjllPQZmCV3BwME2aNOG+++4jNTX15E60krnvvvvo2LEjPXr0KO9QykRSUhKjR49m7dq15R2KlJG0tDRGjx590knOySru31qbNm3o168f999/P6ZplmlcUnnYyjsAEZHirFy5kosvvhi73c5NN91EixYtyMnJYdOmTXz//fdERERwySWXlFp777//PhEREYSEhPDBBx/QuXPnY5Zt06YN999/PwCpqanMnj2bsWPHMm/ePFatWkVQUFCpxXWm+eWXX5g3bx5ff/11wPYuXbqQk5OD3W4vn8BOo6SkJJ566inq169PmzZtyjscKQNpaWk89dRTAHTt2rXM2j3ev7VRo0Zx8cUXM3v2bHr16lVmcUnloQRBRCq0p556iuzsbNauXcs555xTaP+ePXtKrS23283kyZMZOHAgUVFRvPvuu7z++utEREQUWb527doMGjTI//7uu++mT58+zJo1ixkzZjBw4MBSi+1M8/bbb1OtWjWuuOKKgO0Wi4Xg4OByikqkaujcuTP169fnnXfeUYIgJ0VDjESkQtu0aRNxcXFFJgcANWvWLLW2vvnmG/bt28fgwYO5+eabycrK4rPPPjuhOnr27AnA5s2bj1lm/PjxGIbBzJkzC+3z+XwkJiYG3BX8/vvvueaaa2jYsCEhISFER0dz6aWXlniMcdeuXalfv36h7UlJSRiGwejRowO2m6bJ+PHjOe+88wgNDSU8PJxLLrmk0HCuY/F4PHz99dd07969UE9BUePGj9z29ttv06xZM4KDg2nVqhWzZs0C4Pfff+eyyy4jMjKSuLg47r77btxud5HnuWXLFq688kqioqKIjIzkqquuYsuWLQFlfT4fzz77LF26dKFmzZoEBQVRt25dhg8fTkpKSpHnNX36dLp27Up0dDShoaE0a9aMu+++m7y8PD788EN/T9aQIUP8Q89Kclc5KSmJG2+8kRo1auBwOGjUqBGPPPII2dnZAeVGjx6NYRhs2LCBRx55hMTERBwOB+eccw6zZ88+bjtweNz/Dz/8wNNPP029evUICQmhffv2LFu2DIBFixbRqVMnwsLCSEhI4L///W+RdX399dd07NiRsLAwwsPD6dixIzNmzCiy7MSJE2nevDkOh4PGjRszbty4Yw5/SU9P5//+7/9o3LgxDoeD+Ph4rrvuukJ/hyeqpJ9zcfN4DMPg5ptvBvL/3TZo0ADIv5FR8Hde8H/tyP9f//vf/2jdujXBwcHUrVuX0aNH4/F4Auou6f/TkvxbMwyDnj17MnfuXJxO5wl+UiLqQRCRCq5Ro0Zs2LCBL7/8kquvvrpEx3i93mPOMcjNzT3mce+//z4NGjSgc+fOGIbBueee+//t3XtQlNX/B/A318VdQOQmGLbeQIHAUOMmIakQTYmQjKYomyVYMCORjtfSyQrSJCmTkQbBQPESgjiaChreSMQQnUYlEIEUxZBbXAwc9/P7w98+48Mul8Xsa9/v5zXD4H6es+c85+w+uGfP5UFqaioWLVrU7/OtqKgAAFhaWvaY5q233kJsbCzS09MRFBQkOnbixAnU1tYKU5eARx8IGhsbER4eDjs7O9TW1iIlJQXTpk1DQUFBr9OgBmLBggXYvXs3QkNDsXDhQnR2dmLXrl3w9/dHdna22jl3V1JSgra2Nri7u2tV7tatW9HU1IRFPHU3igAAD29JREFUixbByMgI33zzDUJCQvDDDz8gIiICc+fORXBwMPLy8rBlyxZYW1vjo48+EuXR3t4OPz8/eHh4ID4+HhUVFUhKSkJRURFKS0uFDmVXVxe+/PJLzJo1CzNnzoRMJsOFCxewfft2nD17Vm2K2Jo1axAXFwcnJyfExsbC1tYWlZWV2L9/P9avXw9fX1+sXr0acXFxiIyMFF6ToUOH9lrnmpoauLu7o6WlBVFRUbC3t8fJkycRHx+PwsJCnDhxAvr64v+qFQoFDAwMsGzZMnR1dSExMRHBwcEoLy/X+AFTk5UrV+Lhw4eIiYlBV1cXEhISEBAQgPT0dLz77ruIjIxEWFgY9u3bh7Vr12LkyJGi0bKkpCRER0dj3LhxWLt2LYBH79Pg4GAkJycjMjJSSJuYmIjY2FiMHz8ecXFx6OjowKZNm2Btba12Xi0tLfD29sbvv/+Od955B87Ozrhz5w6SkpLg4eGBX375BXK5vF91fNJ27oujoyM2b96M2NhYhISECH+fjI2NRekOHjyIGzduIDo6GjY2Njh48CA++eQT1NTUIC0tTeu69Pe95uXlheTkZJw9exaBgYFal8P+xxFjjD3Dfv75ZzIwMCAAZG9vTwsXLqSkpCS6evWqxvRyuZwA9PlTX18vel5tbS3p6enRunXrhFhiYiIB0FgWAAoICKD6+nqqr6+n8vJy+uqrr8jAwIAGDx5Md+/e7bVeoaGhJJFIqLGxURSfP38+6evri57f1tam9vy6ujqysLCg1157TRRXKBTU/U/7lClTSC6Xq+VRVVVFAER1zs7OJgCUnJwsSvvgwQOaOHEijRgxgpRKZa91S01NJQCUm5urdqygoIAAUFpamlps2LBh1NzcLMQvX75MAEhHR4f2798vymfChAlkY2OjVk8AFBMTI4qr6rR48WIhplQqqaOjQ+38UlJSCADt3btXiJ0/f54A0CuvvEL3798XpVcqlUJ7aKpbX+bNm0cA6PDhw6L4smXLCAClpKQIsXXr1hEAev3110WvQXFxMQGglStX9lleWloaASA3Nzfq7OwU4rm5uQSA9PX16cKFC0K8s7OTbGxsyNPTU4g1NjaSTCaj0aNHU0tLixBvaWmhUaNGkbGxMTU1NRERUVNTE0mlUnJ0dKT29nYh7c2bN0kmkxEAKigoEOJLliwhIyMjunTpkui8q6urycTEhBQKhRDTpr21aWdN15AKANE5aLqGuh/T1dWlkpISIa5UKik4OJgA0Llz54S4Ntdpf+p+5swZAkCbNm3qMQ1jPeEpRoyxZ5qXlxdKSkqgUCjQ0tKCtLQ0REVFwcnJCb6+vhqnHYwYMQL5+fkafwICAjSWs2PHDiiVSoSHhwuxsLAwGBgYIDU1VeNz8vLyYGVlBSsrKzg4OODDDz+Ek5MT8vLyNH47+jiFQoHOzk7RFKa2tjbk5OQgMDBQ9HyZTCZK09DQAD09PXh4eOD8+fO9lqOtnTt3wsTEBMHBwbh3757w09zcjBkzZqC6uloYJelJfX09AMDc3Fyrst9++20MHjxYeOzq6gpTU1MMGzZMbfTIx8cHdXV1GqdPrFy5UvQ4JCQEY8eOFS2Y1tHRwaBBgwA8GnFqbm7GvXv3MHXqVAAQteuuXbsAAPHx8WrrJ1TTOwZCqVTi4MGDcHNzU1ursWrVKujq6iInJ0fteTExMaIyX3rpJRgbG/f5ujzu/fffF42QqL6F9vDwwKRJk4S4oaEh3N3dRXnn5+ejvb0dS5YsgampqRA3NTXFkiVL0NbWhuPHjwN4dI10dHQgOjoaUqlUSGtnZ4ewsDDRORERdu3aBV9fXzz33HOi959MJoOnpyfy8vL6XUeVgbbz38Xf3x8TJkwQHuvo6GD58uUA8FTLtbCwAAD88ccfT60M9t+Lpxgxxp55Li4uwpz1mpoanDp1CikpKThz5gxmzpypNh1EJpNh+vTpGvPauXOnWoyIkJqaCldXVyiVStH6gcmTJyMjIwPx8fFqUxA8PDzw2WefAQAkEgnkcjmef/75ftVJ1QlIT0/He++9B+DRHPf29nZRJwUAKisrsWbNGhw7dgzNzc2iY3/3PQ+uXbuG1tbWXqfG3L17Fw4ODj0eV50TabnF4qhRo9RiQ4YMwfDhwzXGAaChoUE0pcPMzEzjuhRHR0ccOHAA7e3tQodr3759SEhIQGlpqdp6hqamJuHfFRUV0NHR6XEdzEDV19ejra0Nzs7OasfMzc1ha2ursQOsqZ0sLCx6XDuhSfc8VO2pmlPf/djjeVdVVQGAxvNWxVTnrfo9btw4tbROTk6ix/X19WhoaBA63pro6mr/veZA2/nv4ujoqBZT1f1plqu6/p6V+6KwfxfuIDDG/lXkcjnCw8OxYMECvPzyyygsLERxcTF8fHwGnOepU6dQWVkJALC3t9eY5tChQwgODhbFLC0te+yI9EVfXx/z5s1DYmIirl+/jjFjxiA9PR1DhgwRzfFva2uDr68v2tvb8cEHH8DFxQUmJibQ1dVFfHw8fvrppz7L6ukDQvdFksCjDxVWVlbIzMzsMb/e7jMBQPhwp+39IPT09LSKA9p3QlSys7MxZ84cuLu74+uvv8bw4cNhZGSEhw8fIjAwEEqlUpT+SUYK/m49tYc2bTGQtn7aVOc/ffp0rFix4j92HtpcL89yuarrr6fOFmO94Q4CY+xfSUdHBx4eHigsLERtbe0T5ZWamgqJRIL09HSN31AuXrwY27dvV+sgPCmFQoHExESkp6cjIiICJ0+eRGRkJCQSiZDmxIkTuH37NlJTU7Fw4ULR87sv0O2Jubk5SkpK1OKavr20t7dHeXk5PD091RZb9peqA6HNlJe/S3NzM+rq6tRGEa5duwZra2th9CAjIwNGRkYoKCgQTX0pKytTy9PBwQFHjhzB5cuXe114rW0HwsrKCiYmJrhy5YrasaamJty5c+eZvJ+CavThypUrmDZtmujY1atXRWlUv8vKynpMq2JlZQUzMzP8+eefA+54a6JtO6umxjU2NoqmyWm6Xvrzml+7dk0t1r2dVOX29zrtT7mqkdC+OvSMacJrEBhjz7T8/HyN36Ddv39fmI/cfaqCNlpaWpCVlYWAgADMnj0boaGhaj9BQUE4cuQI7ty5M+ByNHnxxRfh6uqKnTt3IiMjA0qlEgqFQpRG9Y1u92+H8/Ly+r3+wMHBAa2trSguLhZiSqUSmzdvVksbHh4OpVKJVatWaczr7t27fZbn5uYGU1NTYdvMf9oXX3whepyTk4PffvtN1MHT09ODjo6OaKSAiIQpY4+bN28eAGD16tXo6upSO656bVQdqv6OnOjq6mLGjBkoLS3F0aNH1eqgVCoREhLSr7z+Sf7+/pDJZNiyZQtaW1uFeGtrK7Zs2QJjY2Ph7tn+/v4YNGgQtm7dKtpO9NatW2qjVLq6uggLC0NxcTGysrI0lj2Q+fTatrNq+pxqHYVKQkKCWt79ec3z8/Nx8eJF4TERYePGjQAgek9qc532p9yioiLo6+tj8uTJPaZhrCc8gsAYe6bFxsaioaEBQUFBcHFxgVQqxc2bN5GZmYny8nKEh4fDxcVlwPnv3r0b9+/fx6xZs3pMM2vWLOzYsQPff/+92gLYJ6VQKLB06VJs2LABDg4O8PT0FB338fGBjY0Nli5diurqatjZ2eHSpUvIyMiAi4sLfv311z7LiIyMREJCAkJCQhATEwNDQ0NkZWVp7Hiptjb99ttvcfHiRbzxxhuwtLTErVu3cO7cOVy/fr3PedN6enp48803ceDAAXR2dopGRJ42S0tLZGdn4/bt2/Dz8xO2OR06dKjofg+hoaHYv38/pk6divDwcDx48AAHDhxQ2xMfANzd3bFixQps2LABEyZMwJw5c2BjY4OqqipkZWWhuLgYZmZmcHJygomJCZKSkiCVSmFmZgZra2th4bMmcXFxyM/PR3BwMKKiojBmzBicPn0ae/fuha+vr1qH8VlgZmaGjRs3Ijo6Gh4eHsJ9AXbs2IHr168jOTlZWGw+ZMgQfPrpp1i2bBm8vb0RHh6Ojo4ObNu2Dfb29igtLRXl/fnnn6OwsBCzZ8/G7Nmz4enpCUNDQ9TU1ODHH3/ExIkTRffQ6C9t2nnu3LlYvXo1IiMjUVZWBnNzcxw9elTj1skWFhYYM2YM9uzZg9GjR2Po0KGQyWSYMWOGkGb8+PGYOnUqoqOjYWtri9zcXBw/fhwLFiyAl5eXkE6b67Sv9xoR4ejRowgMDBzwSCD7H/cf2TuJMcb66dixYxQVFUWurq5kYWFBenp6ZG5uTn5+frR9+3Z6+PChKL1cLidnZ+ce81NtYaja5nTSpEmkr6+vtt3o4/766y8yMTEhBwcHIYb/327ySdXV1ZG+vj4BoM8++0xjmsuXL9Orr75KZmZmZGxsTFOmTKHTp09r3I6xpy0aDx8+TOPHjydDQ0OytbWl5cuXU1lZWY9bNKanp5OPjw+ZmJiQRCIhuVxOISEhtGfPnn7VS7U1aFZWlije2zanmrZslMvlNGXKFLW4asvPqqoqIabaJrKyspKCgoLIxMSEjI2NKSgoiCoqKtTy+O6778jR0ZEkEgnZ2NhQREQENTQ0qG1lqZKZmUne3t5kbGxMUqmUxo4dSzExMaLtQg8fPkxubm4kkUgIgMZz7+7GjRs0f/58srKyIgMDAxo5ciStWrVKtC1oT3Xuq526U21z+vjWoio91bun91R2djZ5eXmRVColqVRKXl5elJOTo7Hcbdu2kYODAxkaGtLo0aNp8+bNwna43c+lvb2d1q9fTy+88AIZGRmRsbExjRs3jhYtWkRFRUVCOm23le1vOxMRFRUVkbe3N0kkErKwsKCIiAhqamrS2Ebnz58nb29vkkqlBEDYqvTx7UkzMzPJxcWFDA0Nyc7Ojj7++GPq6upSK1eb67S399rJkycJAB06dKhfbcNYdzpEA1zhxRhjjPUiMDAQ7e3tOHPmzD9Snp+fH6qrq1FdXf2PlMdYb6qrqzFy5EisW7dO7W7lT1tISAhu3ryJCxcuPDOL69m/C69BYIwx9lQkJCTg3LlzA9q7njE2MKWlpcjNzUVCQgJ3DtiA8RoExhhjT4Wzs/NT3xqSMSbm5uamtk0vY9riEQTGGGOMMcaYgNcgMMYYY4wxxgQ8gsAYY4wxxhgTcAeBMcYYY4wxJuAOAmOMMcYYY0zAHQTGGGOMMcaYgDsIjDHGGGOMMQF3EBhjjDHGGGMC7iAwxhhjjDHGBNxBYIwxxhhjjAm4g8AYY4wxxhgT/B8aGFm0y+X4LAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwgAAAKUCAYAAACg1h+bAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3gU1frA8e9sTbLpoYWE0Is0KQGsiAqKNAEBsdKkey1c7IqoP73qRQUFAbkKKHJFEKSLKAJelSaIBRHpISRAet1smfn9scmGTSMJSTYJ7+d59tGdOXPOO5uQnXdOGUXTNA0hhBBCCCGEAHTeDkAIIYQQQghRfUiCIIQQQgghhHCTBEEIIYQQQgjhJgmCEEIIIYQQwk0SBCGEEEIIIYSbJAhCCCGEEEIIN0kQhBBCCCGEEG6SIAghhBBCCCHcJEEQQgghhBBCuEmCIIQQQgghRDFmzpyJv7//JfedPHkSRVFYtWpVmeov73GVyeDtAIQQQgghhKjpwsPD+emnn2jVqpW3Q7lskiAIIYQQQghxmcxmM9dcc423w6gQMsRICCGEEEKIy1TUUCGbzcYjjzxCaGgowcHBTJw4keXLl6MoCidPnvQ43mq18vDDDxMSEkJ4eDjTp0/H4XBU8Vm4SIIghBBCCCHEJTgcjkIvVVVLPObpp59m4cKFPPXUU6xYsQJVVXn66aeLLPvcc8+h0+n4/PPPmTRpEm+99Rb/+c9/KuNULkmGGAkhhBBCCFGCzMxMjEZjkfssFkuR25OSkpg/fz7PP/88Tz31FAC33347vXv3JiYmplD5Hj168O677wLQp08fvvvuO1atWsWkSZMq6CxKTxIEIYQQwgvsdjuLFy8GYMyYMcVefAghKogytOT92upid/n6+rJz585C2z/44AOWL19e5DG//fYbVquVQYMGeWy/8847+fbbbwuVv+222zzet23blm3btpUccyWRBEEIIYQQQogS6HQ6oqOjC23fsGFDscfExcUBULduXY/t9erVK7J8cHCwx3uTyYTVai1jpBVD5iAIIYQQQogrgHKJV8UKDw8H4MKFCx7bz58/X+FtVTRJEIQQQgghhKhg7du3x8fHh7Vr13ps//LLL70TUBnIECMhhBBCCCEqWFhYGJMnT+bVV1/Fx8eHTp06sXLlSo4cOQK4hi1VV9U3MiGEEEIIISpM1Q4xAnj99deZMGEC//rXvxg+fDh2u929zGlQUFCltFkRFE3TNG8HIYQQQlxpZBUjIaqYMqzk/dqqkvdXkAceeID//e9/nDhxokraKw8ZYiSEEEIIIa4AldNLUJIdO3bwww8/0LVrV1RVZcOGDXz66ae8/fbbVR5LWUiCIIQQQgghRCXw9/dnw4YNvPHGG2RnZ9O0aVPefvttHnvsMW+HViJJEIQQQgghxBWg6nsQunbtyo8//ljl7V4umaQshBBCCCGEcJMEQQghhBBCCOEmCYIQQgghhBDCTRIEIYQQQgghhJtMUhZCCCGEEFeAqp+kXFNJD4IQQgghhBDCTXoQhBBCCCHEFUB6EEpLehCEEEIIIYQQbtKDIIQQQgghrgDSg1Ba0oMghBBCCCGEcJMEQQghhBBCCOEmQ4yEEEIIIcQVQIYYlZb0IAghhBBCCCHcpAdBCCGEEEJcAaQHobQkQRBCCFHjmGY5sBfYljgFQv3ka00IIS6XDDESQghRozRdUDg5AAh7v8pDEULUKMolXiKPJAhCCCFqlJMZxe9LynJWXSBCCFFLSYIghBCi1jiarHk7BCFENaWhlPgS+SRBEEIIUWv4m7wdgRBC1HySIAghhKgxHtzoKHG/v8xRFkKIyyYJghBCiBrjkz9L3u8nPQhCCHHZJEEQQghRI8RlXHoCcnZRyxsJIYQoE0kQhBBC1AiKdukJyAt/qfw4hBA1lSxzWlqSIAghhKgR9KX4xnp1HzhVWclICCEuhyQIQgghaoTdcaUrd+0yeRaCEKIwWea09CRBEF6xb98+oqOjWb9+fYXXPXPmTKKjoz22LVy4kOjoaM6ePevetn79eqKjo9m3b1+FxyCEqHghxtKV23setFIMRxJCCFE0WRBOVIiCF+QlWbduXSVGIoSore7fVPqyprec2KfLV5xXZWTBsp2wdjckpIPdDgdjSj6mWV34bQ74+VRNjEKIIslfT1EhXn75ZY/3Bw4cYM2aNQwZMoTOnTt77AsJCfG4k+8t/fr147bbbsNoLOVtSSGE12w/6eBkZunLO4Cg2Q5SH5OvuSpls0Pnx+FQOf/GH78Alntd/z+1L8ydUHGxCSHDiEpN/nKKCtGvXz+P906nkzVr1tCxY8dC+6oLvV6PXq/3dhhCiEuw2p3cvKrsx6U5QJnlerDawpvhnnZg1CuoGvgadSjKlX2xoGmax2fgTLfizLJjqGtBszlJe38P2V8fRjP74NvCH8PJGAw//o6fH2j1g1B0QGwynE+GrEqY9zHvK9dLAeZPhDE3g0kedCFEVZAEQXjdunXrWLZsGTExMYSFhTF8+HBGjRrlUWbXrl2sXbuWQ4cOkZCQgNFopF27dowdO5auXbuWq93169fz0ksvsWDBAvcQqYULF7Jo0SLWrVtHw4YNPcoPHDiQ8PBwPvjgA/e26OhoBgwYQP/+/Xn//fc5cuQIQUFBjBgxgtGjR5OWlsbs2bP5/vvvycrKolu3bjz33HPUrVu3XDELcaWITVe5daXKX0kVU9/E71wvyJub4HlBqwOCfeDJbjqe6lHzp+dlfPo7SQ9vQUvJKcfR+fM39NgI5gx+JLsXgtQA5fj5Coq0lOFMWuh6kRvEK/fCc8OqLgZRS1zZNwXKQhIE4VVffPEFSUlJDBo0iICAADZv3sx7771H/fr16du3r7vc+vXrSU1NpV+/ftSvX5/z58+zdu1apkyZwoIFCwoNY6pKf/31F99//z1Dhgyhf//+bN26lblz52I2m9mwYQMNGzZkwoQJxMTEsGLFCl588UXef/99r8UrRE1ww39VTqZVXXsqkGSFp79XCfWF8R1rbpJgOxBP4gPrLr7OL6OLehUwk0hTzGRhJKfAXi/RgOeXQ6cm0L/089+EEKUnCYLwqvj4eFatWoW/vz8Ad955JwMGDGDFihUeCcLzzz+Pr6+vx7F33XUXI0aMYPHixV5NEI4ePcrixYtp3749kH8Ob7/9NiNGjOCJJ57wKL98+XJOnjxJkyZNvBCtENVftl2r0uSgoM8Oa4zv6L32L1fmysOXkRwURUcWIQQRX5GVXr7/fCMJgigTWcq09GruLRJRKwwcONCdHAD4+PjQoUMHTp8+7VHu4uQgKyuLlJQU9Ho97du3548//qiyeIvSoUMHd3IAuIc/aZrGyJEjPcrmJTIxMZdYyaMKJSUlkZOTPwwhIyOD9PR093ubzUZiYqLHMXFxcSW+j4+P91hmUtqQNsrShlEPOi9+j4f6VO1nFRISUqFt6EIrfgUgPfYKr/Oy1Q+udr+70sbltyGqB+lBEF4VERFRaFtQUBCpqake286cOcO8efPYtWuXxx8fwOsTDYs6h8DAQIBC8xgCAgIACp2fN4WGhnq8vzhhAzCZTISFhXlsCw8PL/F9gwYNpA1po9xtGHQKQ1sorPq76p9lYNLB9G75ixdUxWeVnJyM2WyusDb8R3Ug9dUf0VKsVAQj2fiRXCF1VRiDDp4YXO1+d6WNy2+jckkPQmlJgiC8qjSrCGVlZTF+/Hiys7O55557aNGiBRaLBUVRWLJkCXv37q2weEpKNpzOolfpKOkcitsnD3ESomQr79Tz5h4nc/drxGRUbltNA6COBTrUUZgWraNdnZp9EaGvayHi8ASSn/qOzE1HISnbNcmi1H928guayMTCebIJIItgfEnDl+RCww+q9BPr0hS+eBKa1K/KVoW4okiCIKq9PXv2cOHCBWbMmMGgQYM89s2fP79C28q785+WluZx9z8nJ4eEhAQiIyMrtD0hRPGe7K7nye6u/2/wroNztvLV88+uMOvmK+vrTl/fnzpLBlKnAuu0lLTzXyvh2f9WYGu5gn0geXnF1yuEKJHMQRDVXt5d+IJ33Xft2sXvv/9eoW01btwYgN27d3tsX758OaqqVmhbQojSO/Nw2Z9Z8udo0KYbrrjkwCueGQ7a6vzX6F6XV1+wGdQvJDkQFUq7xEvkk7+aotrr1KkTYWFhzJ49m7i4OOrVq8eRI0fYtGkTLVq04OjRoxXWVvfu3WncuDELFy4kNTWVhg0bcvDgQX777TeCg4MrrB0hRNkYdAq/PAidPi5d+Se6Qps68hXnNYsfcb0KyrbCgRMw+l34+5xr2+7XoHubqo1PCFEi6UEQ1V5AQABz586lffv2rFixgtmzZ3P8+HHmzJlDmzYV+6Wi1+t5++236dq1KytWrGDu3LnY7XY++OCDQsusCiGqVmSJY1w8vSm9BtWTrw9cdxUcmZ/f2yDJgagyyiVeIo+iyWxJIYQQNcDJZAdNP7x0uUHNYO3Q6p8g2O12Fi9eDMCYMWMwGo1ejkiI2s2hPFTifoP2nyqKpPqr/n9BhRBCCCCxlKt2fjmk7PMVhBC1nzworfRkiJEQQogawVSKb6xf7/P+s1GEEKKmkwRBCCFEjWAqRZ93h3DpGBdCiMslCYIQQogaoXXYpS/+k7IcVRCJEKJmkknKpSUJghBCiBrjnV6XKCDLbgghxGWTBEEIIUSN8Vh0yb0I57OrKBAhRI2joZT4EvkkQRBCCFFrhPp4OwIhhKj5ZDaXEEKIWqOev3ytCSGKI70EpSU9CEIIIWqUjUOK3m6R734hhKgQkiAIIYSoUfo1N7BqkOe2/k0g45/SeyCEKJ7MQSg9+WsqhBCixrmrlQFturejEEKI2kl6EIQQQgghhBBukiAIIYQQQggh3CRBEEIIIYQQQrjJHAQhhBBCCFHryUTk0pMeBCGEEOJKdSEFPt0JSenejkQIUY1ID4IQQghxJUlIgbpji95nXwkGfZWGI0TVkR6E0pIeBCGEEOJKUlxyANCwhH1CiCuGJAhCCCFqnfO/JBK7+zyqU/N2KNXL3I0l778gQ42EEDLESAghRC1yeOUJfnjmgMc2Yx09D+6600sRVTPvXiJBEKIWk0nKpSc9CEIIIWqNgskBgD3ByU+vH/RCNNVQZo63IxBC1ACSIAghhKgVTnxzpth9h/5zrAojqcbMMnBAXMmUS7xEHkkQhBBC1Ar75/6JzDi4BPnWF0KUgvypEEIIUSt86QxF9XYQ1V2WzdsRCOE1GkqJL5FP+hqFEELUaKpD5eVZp+h+LBZZwf8S0rK9HYEQogaQBEEIIUSNdGDFSZ5ck0l4ehZpvkYG2hzeDqn6s9m9HYEQogaQBEEIIUSNc3RrLMP3+HIsOhKA4PQsGiVl0jghhZCsolfq2f3Gr/R4qmNVhln9GA1gL0OSkG2FwPvBUWDwVqgFLiwFnYxUFqI2kn/ZXjZw4EAmTJjg7TCqhYULFxIdHc3Zs2e9HYoQopp75r14joWHud+nWnz4M7JOsckBwO+LjlZFaNVb/ZBLl+n7kuu/3aaD372FkwOApEzQDwNlKOz5u2JjFEJ4nfQgVAKr1crq1avZtm0bx48fJzMzk6CgINq0aUOfPn244447MBiqx0e/cOFCWrduTa9evbwdSqX566+/2L59OwMHDqRhw4beDkcIcZkeHXOAn1s1cr9vfyqeQ5H1GPTzkRKPkxWOgDMXLl1my0HQDS39B9bjKdBWX1ZYQlQFmYhcetXjKrUWiYmJ4dFHH+X06dN0796d0aNHExwcTFJSEnv27OGll17i+PHjPProo94OFYBFixYxYMCAapEgjBs3jtGjR2MymSq03iNHjrBo0SK6du0qCYIQNdiBs3aGv3GOcM3Crb8dx3f/EYKzrOxvEo5B1bDkyPj6Er2xGuylvOovazbVZyZsnVnGg4QQ1ZUkCBXIarXy2GOPERsby5tvvsktt9zisX/06NH88ccfHDp0yEsRVm8Gg6Ha9KwIIUp2PlPl/QMqHcPgtwQ4lQZWJ5xOhXNWOJZa9mvMhj5g0EOQEVqGwPls+DEeVFXF4FRxKtDA15d0p0b342fR5TbQOCGNA43rl6qNXz/+i7YjmmPwuQL/1jy9rPLq/uZX13Cjl+6GG6+Ca1uDj7ny2hOiXKQHobSuwL+QlefLL7/k1KlTjBo1qlBykKddu3a0a9eu0PaTJ0/yzjvvcODAARRFoUePHjz55JPUqVPHo1xGRgYfffQR27Zt49y5c1gsFrp3786UKVOIjIx0l8vJyWHJkiVs2bKFc+fOYTQaqV+/Ptdddx2PPvooZ8+eZdCgQQBs2LCBDRs2uI/dt29fsee4b98+Jk2axIsvvkhmZiaff/458fHxNGjQgBEjRjBy5EiP8r///jurVq3i119/5dy5c+j1elq0aMEDDzzAzTff7FF24cKFLFq0iHXr1rnv9OdtW7VqFRs3bmTjxo0kJyfTpEkTpk6dyg033FBsrBcfDzBp0iT39gEDBnDTTTfxxBNP8NxzzzFkyJBCx44YMQKbzcaaNWtQFIUJEyYQFxfH/Pnzefvtt/n5558B6NatG4899pjH5w+gaRpffPEFX375JSdOnECn09G2bVvGjx9PdHR0iXELUV0dSdK4brmTRGvF1332ojp/S7loh06HQ6ejWXwSbWITOBsawJpuV3Hbr8cIsLrW9TfbnaT4mQkuYQ6CAux9+Q/2vvwHIe2DGPTfmzD4XiFfg08urZp2XlyR//+P9IM5D1VNu0KICnWF/GWsGtu2bQMo8mKzJBcuXGDixIn06tWLRx55hL///pvVq1eTmZnJvHnz3OUyMjIYO3Ys8fHxDBo0iGbNmpGQkMCqVasYPXo0n3zyCeHh4QC88cYbrFu3jv79+3PffffhdDqJiYlh7969AISEhPDyyy8zY8YMOnfuXOaYV6xYQWJiIkOHDsXPz48tW7Ywa9Ys0tLSPCZdb9++nZMnT9K7d2/Cw8NJTU1lw4YNPPHEE/zf//0fffv2LVV7M2fOxGAwcP/992O32/nvf//L9OnTWb16dYnDhm655RYSEhJYs2YNY8aMoWnTpgBERkbStm1bwsLCWLduXaHz/+233zh+/DhTpkxBUfLvOGRnZzNx4kTat2/Pww8/zOnTp1m1ahW//fYbn376qUdCN2PGDLZs2cKtt97KwIEDsdvtbN68malTp/Lmm29y0003lerchahO7tlQOcnBpeidKiGZVjZ1bQXAL03hQNMGPL3mf/yndxfOB1q493+/YbEmoldVFEq+V5j8eyr73jnENc9eAasaHT4D/15b9e2+uwnuvwm6taz6toUogsxBKD1JECrQsWPHsFgshe4kX0pMTAz/+te/6NOnj3ubTqdj5cqVnDx5kiZNmgCwYMECYmNjWbx4Ma1atXKXHThwICNHjmThwoXMnDkTcF2YX3fddbz00ktFtunr60u/fv2YMWMGERER9OvXr0wxnz59mpUrV1K/vqtbf8SIEYwbN44PP/yQO++807193LhxPPzwwx7Hjhw5knvvvZcPP/yw1AlCcHAw77zzjvtiPTo6mlGjRrF69epC9V+sZcuWdOzYkTVr1tCjR49Cd+4HDRrE4sWLOX78OM2aNXNvX7t2LXq9noEDB3qUT0lJ4Z577uGf//yne1uXLl144okn+OCDD3j22WcB+O6779i8eTPPPvssQ4cO9Tj3MWPG8NZbb9GzZ0+P5EOI6i7ZqrH/vHfajkxMZX/TcI9t8SEBLO11Nb83qscrK74jPCWjTHWe+vrslZEgLP/ee20v3S4JghA1kCxzWoEyMjKwWCxlPq5u3boeyQHgvpCNiYkBXMNVNm/eTOfOnalXrx4pKSnul6+vL+3bt2fXrl3u4/39/Tl+/DhHj1bOsn59+/Z1JwEARqORe++9F6fTyfff538Z+fr6uv/farWSkpKC1WqlW7dunDhxgoyM0n2hjxw50uNiul27dvj5+XH69OnLOo/BgwejKApr1+bfXcvOzmbr1q1cd9111K1bt9Axo0aN8nh/880307hxY3bs2OHetmnTJiwWC7169fL4WWVkZHDjjTdy9uzZy469oiQlJZGTkz8sIyMjg/T0dPd7m81GYmKixzFxcXElvo+Pj0fT8kegSxu1o40AE4T64BVJ/r5ousIJ9am6wUQmpZU5OQAIaORXLX4eISEhldtG1+Z4S3bb/KSutv/7kDYqpg1RPUgPQgXy9/cnMzOzzMdFREQU2hYUFARAamoqAMnJyaSmprJr1y569+5dZD26ix5YM23aNF588UVGjhxJREQE0dHR3HjjjfTs2dOjXHnlDdW5WN4d+NjYWPe2pKQk5s+fz44dO0hKSip0TEZGBv7+/pdsr6hemaCgIPfnU14RERF0796dTZs28Y9//AODwcDWrVvJzMzkzjvvLFQ+ICCg0LwQcH0e27dvJzs7G19fX06ePElmZia33XZbsW0nJSXRuHHjy4q/IoSGhnq8L/jzMJlMhIWFeWzLG8pW3PsGDRpIG7W0jbd66RjzVRHr4leydF8z9VIyOB+cH2tglhVF00j3MaMquCctl1b0P9tTL9zzs/DGzyM5ORmzOX9Cb4W3MagbtGoAR+KpUpFh+E64w/3W27+70kbNaKMyyRCj0pMEoQI1b96c/fv3c+bMmTINMyrpgj0vU8/7b/fu3QvdwS5Kr169WLduHT/88AP79+9nz549rF27ls6dO/P+++9jNBpLHV95aZrGww8/zIkTJxg5ciRt27bF398fnU7H+vXr+eqrr1DV0l1oFPcZXXwno7yGDBnC008/zY4dO7j11ltZu3YtYWFhl5wAXRJN0wgJCeH//u//ii3TvLn37uoJUV6j2+u4tqHCxC1Ovo+FSk8VNA0/q42ef5wk3c+HHIMeh15HeHIGD+48yJHwMJbddDU7r2pMr0OnSq4K17yE+teFcfOb3bE08C2xfK2hKHB4HtzyPGz/s/Lbqx8E0wbBPweBXl/57QkhKpwkCBXolltuYf/+/axdu5apU6dWaN0hISEEBASQmZlJjx49SnVMUFAQ/fr1o1+/fmiaxnvvvcfHH3/Mjh07iu2FKK0TJ04U2nb8+HEgv0fk77//5siRI4wfP56JEyd6lP3yyy8vq/2yuNQ4/169ehEaGsratWtp3rw5Bw8eZNSoUUUuuZqenk5CQkKhXoQTJ04QGhrqHlLVqFEjTp8+TYcOHfDz86u4kxGiGmgdqrD9nrJ/ffx4xsG+OMh2wqj20MC/tHUY2XSsNfcvzeDW/X9xqHE4FoeDhikZNEzJwG7Qsa5LK47VD+GW307QOCG12PGz444OLWZPLaco8N2rrqVIK4s8LE2IWkPmIFSgwYMH07hxYz755BO2b99eZJk///yTlStXlrlunU5H3759+eOPP/jmm2+KLJM3hMfpdHqMAQTXRXLr1q0BPIbl+Pn5lWuYzldffcW5c+fc7+12O8uXL0ev17vvvOfd9S94l//o0aPFfj6VIe+iPS0trcj9BoOBAQMGsGvXLveSqEUNL8qzdKnncoHfffcdp06d8liVqH///qiqyty5c4uso+CYTCGuBNdFGnikm4GnrjGUITlw6dfcQNLLwbz+76tI9dGjtzvY0rEZGtDntxNM27iLfvv/pmkJyYEAKuv5D9bPKqdeIYRXSA9CBfLx8WH27Nk8+uijTJ8+nWuuuYYePXoQFBREcnIyP//8Mz/99BMPPvhgueqfOnUqBw8e5JlnnuHbb7+lQ4cOGI1G4uLi+OGHH7jqqquYOXMmWVlZ9O3bl549e9K6dWtCQkI4e/Ysq1atIjAwkJ49e7rrbN++PXv27GHJkiU0aNAARVG4/fbbLxlLVFQUo0eP5q677sLPz4+vvvqKQ4cO8dBDD7nHKDZt2pRmzZrx8ccfY7Vaady4MadPn2b16tW0aNGCP/+sgq5uXBOadTodH330EWlpafj6+hIREUH79u3dZYYMGcInn3zCli1b6NKlC1FRUUXWFRwczLZt27hw4QJdu3Z1L3MaFhbm0UvSu3dvBg4cyOeff87hw4e58cYbCQ4O5vz58/z666+cOXPGY2K0EKJ0Wra2cPw5A0/feYR66VnuEcUOg47VXdowecteKn8AZQ3WtRn8cOTS5TKXg+Xe0tU5qheYTZcVlhBVQeYglJ4kCBWsUaNGLF++nC+++IJt27bx0UcfkZWVRVBQkPsCvrRLexbk7+/PRx99xLJly9i6dSs7d+5Er9dTr149OnXqxODBgwFXonLPPfewZ88e9uzZQ1ZWFnXq1KFnz56MGTPGY2Wep59+mjfeeIPFixe7J1iXJkG4++67yczMZMWKFe4Hpf3zn//knnvucZfR6/XMmTOH2bNns2HDBrKzs2nevDkzZ87kyJEjVZYgNGjQgBkzZrB06VJef/11HA4HAwYM8EgQGjVqRHR0NHv37i2x98DX19f9oLS5c+eiaRrXXnstjz/+eKFhRy+++CLR0dGsWbOGJUuWYLfbCQsLo02bNhU+BE2IK4lPsJmuAxqQs/B397YmF1KZsnVfiV9qlz9jqRY4fuHSZbL+C75m15ChLo/DgWLmdnRrCj+8AUa5lBCitlG0ipjlKa4YFz9JueAzAmq6Rx55hN9++43Nmzfj41N4Lce8JymvX7/eC9EJIQp65Y6dNPg7odRDikbs7EtAw+ozJ8hut7N48WIAxowZUyWLRxBwD2QU/7RpoOi5BKoKr66EX07B9Dvh2taVE58QlShN+WeJ+wO1t6ookupP0n4hcD1vYteuXQwbNqzI5EAIUf28sLkn1jQb0+fGY15/hLYXip5nlKc6JQdeU94RFjodvHB3hYYiRNWTIUalJQmCuKL9/vvvnDhxgs8++wyj0cj999/v7ZCEEGXgE2hi7rNR8GwUC1qsLnb+QdU/uaGa8jVD+iV6EIQQVzxJEMQVbdWqVWzcuJGIiAheeeUVGjZs6O2QhBDl5F/fSM45u7fDqN4useyzELWZTFIuPUkQRJlER0ezb98+b4dRYWbOnMnMmTNLVfaDDz6o3GCEEJcl6uZwjnx2Wi4BStK9Gaw/4O0ohBDVnCwXLYQQola44aUuxe7zrSvLcALw83FvRyCE12goJb5EPkkQhBBC1Ao6vY7AFpZCy5lqwJC1t3ojpOpHJ1/7QohLk78UQgghao0RX93OXV/f6l6sJKi1P6MODsJSz9e7gVUXA7t5OwIhvEi5xEvkkTkIQgghapWQZkGM+3uot8Oont59COZ/7e0ohBDVnPQgCCGEEFcKgwGeGVL8/l/frrpYhBDVliQIQgghxJXktQcgZwU8fHv+tqZ1Ifsz6NDEa2EJUdm0S7xEPhliJIQQQlxpTEZ4b6LrJYQQBUiCIIQQQgghaj1ZyrT0ZIiREEIIIYQQwk16EIQQQgghxBVAehBKS3oQhBBCCCGEEG7SgyCEEEJ4kSFd49wnf6EaTKiZNgLbhhDSsyGKInc7hRDeIQmCEEII4SUtZ2cT+ick8w1OFFTghI8fqRYzN6/oRdCtUd4OUYhaQyYpl54kCEIIIa4I2plE1PW/YE93QlQYziU/Yb69JYbHbgMv3K1PW3OM+n860eFag92GCTsGfK0qPtZsfh74FTdnjEfRyUWNEKJqKZqmybMhhBBC1FqapmFt8zxZR9IJJAE9KioKiTQiB3/q+J3HL+Et8DVXeiyOC9kcHbCetL3nUdGhRyVZ74+iagSoNo+yKlD/8ato/nbPSo9LiCtBgvJcifvraK9WUSTVn/QgCCGEqH1sdtQR7+LcchjVaiONcOqQRDZhpBKKhg5f0rGhciErnIjH/4thwWj34erJJDKnryVn/VFUO9h9ffHpWp/gTQ+g9/cpV0ia3cmvkUvRbHbsiglfzY6KgsWZg7OINUN0wN+fnZQEQQhR5SRBEEIIUevYQ6egz0xFwQ/wJZhUUqlPOqHkLXWYQSgWUsggkMwvDhPwjp2MT36DPUfJ/HA/NvxR8UdFQc3SkfV9ChkBs6i7pC9+o6LLHNO5Ob+i2Zw4FAMWzQ6ADg2DZs+dfaChR0NBxY4RKwb8krIq7kMRQohSkgRBCCFEraKu2I0hMwUVE058UHCiocOKPwXXQbdioS4xJCREkOQ3K3e/hoI/Wu5XpA5QUHGiw4aZlNHrypUgpG04hQIYNLXQPgUw4XS/12PHqdfIMvmx9/0jNOkdTt1WAWVuUwghykOegyCEEKJWcTyz0n2ZbyIJEymYSIaLLsDzKGg4MaJiJD95UNDQe5RXcrcC5GDihPIKZ80vkz7rh1LH5dO1Dhoa+iLjKCJp0CscahnJj0tPsfyBXez+z7FStyWEKExDKfEl8skkZSGEELVKTsjDmFLOAZ79BTZMxNHWY6uCAycGFCCQZExYsWMmjRBU9B71qoCKniCSyMKXDAJQUNHhRAWSDX7kGIwEmBUa3NeSyNk3oTO67sOdfOMgZ575CX/NhgEndowXRaFhwu5xx+5sWDC/N4tEu3h1JU3joc03YQmr/MnUTlVj3g85fLkikSMmE2lOHVl6HegVTHpQdAp+qkp9zcFXT4QQWUcGJIjq74LyfIn762r/V0WRVH/yL1oIIUStoobXxZGSihGre5sDI2k0yL2Yd331aWikGS2c9wuiY8YhAp2pAPiQhQ9ZxNOIgkOSLGSQiYVMAnLr0OFER5rJRJbRF7Nqx5rpJGH+L1jf/4mGOx7g1zu24sxyYPBROR4YikOnIyQti5CsnNw5BwoODBhwoANUBQ5HhXsmBwCKwvnDaTS9vm6FfE7WVBvfz/6LkzvOkZOlggJ1Wvtz2wsdGLER/PYnYtDpSNEpZBpy0xenRrYT8NVhznLyp1FPh5cSOfXvegT6yB1YIWoLSRCEEELUCuqek6hPLcfw5xEU7GjkzSiAc7TEgeed9wyjiUNhDfF3ZBHiTEPLnW0AGkZsmLGSg6+7vAkbTnRk4u9RT6LZn1SzHwBWvRmdQSUnw490HNhu+gyrEorBx8nRunXcz1vI8TFiyMpPYFR0ZCsmLJoNu8GA3Vj017M9yVrk9otlJ+WgN+lQnSo6vR6Tf35dqkMl4Wga+1fF8PeqGAwOJwqgB1SdjjO/pfHMtBM08jHhMBoJxcldSamcNRnI0OnxVVVizCaOYsaiqXRIzeaor5mglzNA02gaABsfsnBVPX2x8QnhLTKMqPQkQRBCCFHjOT/8AR56Dw0DTixoGEnHRCZBqOhzL/49ZZgNaIoOk2rLvXC4eA4CKAXmCuhQycQCHoODIM3k61FOVXQ4DU7sdgNZ+JEc6oOfU+fxMDZ/q+czD/LaPREUip/dhinHjs1s9NhrtNpQN58ixaIn5UQ6KWF+WJPt2O1w7qdzJPyRgppuQ1E1rP6+OM1GFEVBZ3fQc0ITftuRSOLfmSiqE1QN39zkgNwz0qsqPjaVMLuNWH8/9wArBYiwOQAHAFE2OwFOJweCLZwxGECngKqBonAiDTrOziL7FX8MerkYE6KmkgRBCCFEjZczZTkaYRhQASdOVNLwHIqjx4YTk/t93hAevbuv4WKu2QUKKgZs6HFiw4iZLHzIxo9snOhJIYiiJvLZzHr0DpUMxRdLmh3Vz7P+HKMByHG/VwFNAaveSJbRTNCFDJLrBeAwGdA5VYKTM0kN8uWb3Rn4b9mFwWbHbtDjMOhQVFf6YwLsJgNpdYNRDXrQNPR2B06Dnm+WxGJwOjHY7Jiyc9D0uiLvpSYH+mOx2dEUpcR7rW2yczgQ4o8+0Aenxej6+HKckOXAoWn8Z6+NSddU/lwJIcpGktbSklWMRJXat28f0dHRREdH88YbbxRZJikpiWuuuYbo6GgmTJhQxRHmy4v1k08+KbZMdHQ0jz32mMe2CRMmuM8xOjqaHj160LdvX5555hmOHj1ayVELUbNpOfYyH+NMzSLL5pebHKjosZFJcBElde5egUyjkQibayJzmsH1rAOPONAI4QL+pLiufTFjw0Q6waQRxDnqkYOZINJplH2+iKZ0OEzgVPUY7BrGDBWdmr9SUaK/H+SmFsm+PpwMDeVUaCgG1UmWv5GMUAuqotDwbCJNTpwnqU4ATqMBVXEt2mozGdB0CnrVs2/EZjbhm56F0WoDRcFpMqJzOjFomismXzNZwf7o7E4oYo0Su8EImobR4SjxM9dpGvgYcAaYXD0IigI+BnQ+elAUpq7Mwvx4IvetysKhylooQtQ00oMgvMJsNrNlyxYef/xxTCaTx75NmzahaRp6fc0dw2oymXj+eddqCTk5Ofz555+sX7+eH374gY8//pgmTZp4N0AhKpOm4Th4Fsfv8eha18f00y+oK3+C5Ewwm+HYeUhNzy2sz33ljf8HLfdCX8EOqOBjRPlgElrLSFBA6dEyv62dh7D1n4M/TsCYe7RvkXe/dDjxIYcYn7r8HRRO74QzdE/+naOWRhy1NKJl5umLhtwoGHHiTxrpBOPAQM5Fcxg0dGRiwUga9R1pJGUHkWVy7TdrOdRxZIAK6fi5hjc5FcLjM8gOMODUKQRmWEnBF9UAyRaLu16bwUhwcjYtTyaS6WfiSMsG2OvnJy+GHHux90BVnQ5Nr8NmNqKpGk6nhmbUozcYPI/R6XD4GDFZ7agG19AnDVD1OuqlZ5Ac6E/D5BRO163jPk4l/45iuk7Hb/6+Rd6M9dOD3ekkR69Dc6p8/r9sNh5ycEsLE50a6JjSw0gdS/6BDlXDoFNQVY2/k1T+vKCSYoO2YQpdG+rR68p3x9ehapxJU0mzQcd6enIcGg5Vw2LSFSpnKGcbouaRVLX0JEEQXtGrVy+2bNnCjh076NOnj8e+devWcf3117N3714vRXf59Ho9/fr1c78fMmQIzZo1Y9asWXz++ec8+eSTXoyuEmTlwL6j0LQ+NKrjue+3U6793VqATgfH4yE2CXq0BJPrbiUrf4CDp6B/F7A5oUNjCCvHQ6FOnodPvoOoejC4OwTlX3iRkAa/n4aOjSH0orqPxMLXB8Gkh1YRoNfBD3+62q8fDAdPQp1AqB/ken9VJPz4F1xIBbMReneEesH59R2Lh7MXnV9iOmw5AMfPQeM6kG51jdcedi0E+MLmn+GPM3DjVXBta9jyCyRnwB1dINQfvv8Ttv0KcckwqheOP+KxrTmE/Wwm9r/S0TntaOhcS3KadRh7RWI4GY8OBzmqBVOAA79zMSiJqWAwgN0BDhV89RAeBkY9HDsHdte4dMj9EtUpqAH+6AygZOeAv8l1lZiSCSgQHgpXN4aoOnDkPPx4BOw2VHteD4AJ8ENPJly0hKcGOPBFwYwee24y4EDD350euBKG7PzrT6sd7cH30DDjejaBA9cziF2TDg3oUcn7WetRcBBALNm0zH2egatePzLIwcSxwHBUnZ4fg6/m1sS9RFrPY8NEMnUJ5YLHr5QeFRM2bHjeyADIUYwk6APwU3MItWeg2Q34YaUxce7zrUcKMbm9DYpDwZLscEfpRIe1iMnINqMBDbBk2Wh8OoEjLRugKQqqTofT4ouigTk7x+MYDcgI8cdp0GNJycCU2xOT7WPGGujr+rfnQUHRNDRFwWlw3fXXFIVUP18u+FtQjQZydDpOm40c9TGTatDTMjsHJ3DY1+zqMUizuRr2N6HLtKGzOlA0jcaZNo76u5IlTa8jNVthze8O1hxSeHGnA1OOAx+jjiwfAw4UsDkxOTQ0PdhzbwwZcxw4jHo0vZLbQ5EbtkOlUVoWDbJyOFQviGyjHhwqqk6X+7AKBfSu3yCn6jpP9E7Xf3VQ6FkYefNCNI28kWZ+BtfvVXbhx1UArmpCfMBihBwHZNshw5H3rAzIm3ph0/J/mwOM4NRcf140DdLtrnoCTFDHD85nQpbddap1/SDUB46kgE6DiABIsELzIGgdBo0DoUs9Bb1OY8nvcDwFQn0h2ARXhcHETjo0TeGvZA00jdgMhZFtcCdH+89p/J2s0SRIwahoJOdAm1D46ayGisJNkQr1LQrZdo298dA0CBoFeiZRp1I1TqVB93DwMUiCVRtJgiC8ok2bNhw/fpz169d7JAi///47x48fZ8qUKUUmCLt27WLt2rUcOnSIhIQEjEYj7dq1Y+zYsXTt2tVd7vDhw4wdO5ZOnToxb948lNwvAafTyaRJkzh06BBLly6lRYsWlX+yubp16wZATExMlbVZJbb9BsP/DUkZrouQfw6CNx90JQWDX4etB13lroqEq5vAih9c35DhIfD+BLh/DmTmrszy2heu//qY4N1xML5PkU0WaeJ8+GBr/nu9DpY/DiOuhwVb4LGPIMcOviZXu6Nuhnvfgc/+V7bzzVsW5+J23nwQHhsA4+fD4m355zf9TnjqE3AUcaXxj/+AQee6WHfXreQP+1AAowFs+UM9bIv3kEF47hN+XctjarkXrjpAzXGQseUCrj/tBizEk0IomYRQj0TyJpkCkKHC3/HFniKqht59lx/IunhSrQYxCa6XuwfAdaSCEQ0TOnSYXJd/heo2kk0yUQRyFh0qGqbcoT/KRS8jYC9wbI67DtfZg4KO/GQBXOsBZaISSCgJWPFFQ5e7dGkKWUTQKD0Bs6oSnJPFeSIxYEd1fYLYch+YZsJ1vk70+JNOEKlk4UsCdVDRk24wkWz2w6HPfdqy0/W0Zl+HCjn5vyR6NMzYXQlCbvR6HASRjR6VJKcf2XhORtY78wc8BaRZXclB7oWzplfICrKgqKo7CbBk2vDPtJPSIBSfjGz3dgBfaw561UlmaGB+A6qGMcfmSg4uSlAUIDDbyq/NorDrdMQZDewO8HPv/8PPh0LSbehtDvTZrt+tHCBW7/q9VnDNq0CngJ8RTK7eCpt/3qeby6DDlukAo859hW035yakGq4ra6BRtpVO51PwcTj5KSKMTL/cpE0FHHn/KDUwKDh9DRf9WyrFBaySn4RkFZMY5FGBRKvrVRSH5vneCaQUMXJOBZJtrpebBmcyXa88f7tW32XfedfLXbAIa4/D63sLPnRPY8JWeKeXxseHNH4+V3TceWX1Cvyjs8LHhzSSrK4f37SuCv/u5fodfORbJ3MPaGhAHV9Yc6eeGyIlSahtJEEQXjNo0CDeeecdzp8/T7169QBX70FoaCg33HBDkcesX7+e1NRU+vXrR/369Tl//jxr165lypQpLFiwgM6dOwOuBOSRRx5h1qxZLFmyhDFjxgCwaNEiDhw4wDPPPFPq5MBqtZKSknLZ53vmzBkAAgMDL1GyBlFVGDfPlRzkvf/3l3DXNbDzUH5yAPDnGdcrT1wy3D8bMj3vhAJgtbkuoAd3h7pBl47j9AXP5ABctw/HzXP1XDzyoevOOUC2DaZ8ACZD2ZMDKPy97FThiaWu3oCPvs3fHpdcfHKQx1Hgi/ziMeEaHsmBhkIGDS+6I15wzDzkFFhhJ5M6+JFIFmHudKLieQ4FdCUseXerFTR8AGehJwWbyEKXm7Ao5Lij1tzHGCicIOSXyT9LFT0qOuzYCQCc2AkBdLn9CpmAEzOJ6FAJIQ5nts9FD0FTcGBy90acpxEARqyEcQ4nZgy5d50tZAEXOEcD/B02Ahw2cnR6zvkF4tDricq4gAGNOGMIEfYkd4RZmDDhwIgT0LBgdX9CdWyZpNt8yM4baqlpBGXmX3lm+5lcd8cLsPr7olM1GsSnEZKag8PompRssBWeO2C0OTBnZOMwG1F1CqasHHSqhlOvQ+d0ouT1HOl0oNfhm2PDbvHjqE/hXpNCNM2dHOSxKwp6h4pq0KGG+bl6qTSt+Av1vB4C+0W/IwbFlUAbABXCsnK47cQ5dMAfdQM5E5LbY6Rqha/IHVru7Xq5aM2jajBtu5aXa5XIqcGc/Zr7r4Wqwax9GkNbaVgdGu8dyK8kIRvGf+3kz7E143JSljktvZrxExW10h133MG7777Lhg0bGDt2LFarla+//prBgwdjMBT9q/n888/j6+u5pOBdd93FiBEjWLx4sTtBABg5ciR79uxhwYIFREdHk5OTw0cffcQtt9zCXXfdVeo4Fy5cyMKFC8t8fnlJhdVq5fDhw7z11luA67xrjQtprmE9Be3+G/b8fenji0oO8uTYXcN7el996Xo27y96e4bVtc9e4KIp2wZfHbh0vaWlakXXV1JyUEYOfC5KDooI4aIx/Plc73U4Kik5KJykFL32hR4KJAhmMouoIW+BUSuF1xYykN8DUrgNBdd5OrAUsV+PEx90ZGEi22NCcv5954uXOQU7PqQTkpsUXHyOnqv7mFUndawZxPsF4dAZsDiyMakOnCi5Z+A6e1NukuEwuJYytRqNBFqtNExNo2laIklGXxQdYAed6orfoddxulGoeyjQxZxGA742jdBU178ho91JvXNppFuMGG2eiZWmuIYkmbNzcOh1JDasS5zFQlBaJlEJifmfoari0OtI9/XBoYC+iEnMRSlqDSgNcIb6upIDKPkuvqoVTrwdmutHrrmGDLVIy3T/VP8Ou+g5FMWFqBUV1ZWtNMlBnqKK7onTsBYxd/1wEqTlaASa5fOuTSRBEF4THBxMz5493QnCd999R0ZGBoMGDSr2mIuTg6ysLGw2G3q9nvbt2/P7778XKv/iiy9y77338txzz+FwOKhfvz4vvPBCmeIcMmQIvXv3LnLf1KlTi9yenZ1d6Jg6deowc+bMYntHvCUpKQmLxYLZ7BoznJGRgaZpBAS4xunbbDbS09MJCwtzHxMXF0d4eDjUDYTGdeGU57jtxKbBhGY1R1n1U8mN+5pcF+tF0EwGlI6NC7eZKz4+nvr167uGj/W5uuiLFIsZpW9n11Cdi5MEHxP0uRo+2VFyfKWlU6BPR1i9y3O7yXOI0OXQY6PoS7HcEFBxrW9zcRKh4sCEiqGSehDyBvYoBbYVjFH12JtFKH6kU3i8louChpabDGgYcodUqR69BkUnIsVdoGg48UOHE3vuE4sv7jUo7jhngaE/AFYKD7PxcdhB08gymDBoTixOG3YM6HBNKPbB4ernUOB4/RAcucOFskwmso1GWl5IIMye7f58cjDwW7NIUkIsqHqdK0Eo4g68VmBybZPjCZyv609ykAndRfNJtIvG2ZtsDsJPxhHg71fkaWeazdj1Opw6hUYOJ+eNBo9x+opWoF2dDlXT0KueP2MHuIbflUZxV655vQCaq1cij/Hi8vnPtvMkvQeF6NAKrdZVnKI+0ugGCmfPJwGevbotgzUCcjubyvT9Ucz7yiQ9CKUny5wKrxo4cCCnT5/ml19+Yd26dbRr145mzZoVW/7MmTM888wz3HzzzfTs2ZPevXvTu3dvfvjhB9LS0gqVDwoKYsaMGZw9e5bz58/zyiuvuP9wlVZUVBQ9evQo8lUcs9nMvHnzmDdvHv/617+44YYbSE1NdX3JVzOhoaHu5ADA39/f4zMymUwef9yB/D/mOh18MBkCc8cpKwo82p+wgdejPHwH3NQu/6AWDWDoNfnv6wbCB5NcF9EFmQwo74zxmPxb8AukQYMG7rklNGuAMqqXZx06BeWDydCsAbw1ypUk5NbNu+Pgvp6uicJlVfD7RafAa/fBhNvg/ps8z2/uePArZi14hcIXUAVXU7novQ4nviSUGJYBG4p72I4DH9KwEYAvyZXUgwDkrTSEhoKaO09AK7DfiQZkEkIiLciinsfzCArKTzEUNHxz3+Unkq4EouAxCs7ccf4KBQd8uy4LnPhgI5AAkgG1xOQAIAcjjgL30QwUTvhsOtdFdIrJwmlLHRJM/mjkP2fAlBtPuq/JnRzkSfX1xXHREKK8hMIv04qa+/uhU1XCLqQSlJRJvbhU11A+ICnMnxyT3uNYxeFwDR9SFDL9fXHoFffcFp3qOmOHXk9MvTCyzYV/BqkWX5y5gddzOumWbaWB3UGrlHTQKYWSEgw6nHrXS1UUVJ2Cw2Bw/W3IKDr5dw+lc6quYUXW4nracsvZVf4KsGDN/Tw6nEtBuXh+gY/+4mfcgY+uUDJVZPu1WFFnP+NaHR3rFLGjAJMepndTCDTl1/VIF4XrIxSGdw5j4tX5tQeb4YPb9O6/xWX6/ijmvagepAdBeNW1115LvXr1+OCDD9i3bx9PP/10sWWzsrIYP3482dnZ3HPPPbRo0QKLxYKiKCxZsqTYVY927tzp/v8jR47QqVOnij6NQnQ6nUcCceutt/LYY4/x6quv0qZNG1q2bFnC0TXMbZ0gdhHsOgLN6rsuyAH8fWH7K7D/mGso0XWtQa+Hw2fgbLLrvY8Jhl0HH34DR+Nh5PWQlg0dm7hWDCqLJY/Ak0Pgk+2uXo0R1+evVvSP/jD8OteKSp2a5s9rWPmEK57tf7hWKooKgzOJsG6v68L+6sauVZVaR0CgD/iaoWEo7D4CKVmuMdI3toWI3C/ATx6F5+7yPL/RN8OXe1wrIwX5udquEwi3d3IlCOv3uVY+6t3RNV9i2+9wLgVuae/6DJdsg19Pgr8Pfo8NxBSXTfZbO1D3H8d5OhtNU1DRk4MeHaBv7INfMwtKairqMfDXTmPwA1UJQacHEjJcQ5+MerD4uC6WUjLBpEezOkDL6xfQgcmI3oxruJdDdSVZDUNc/693jVcnog5EN4f5W8Cak3tN50DDiIoOAznk3Y+0kIwfyWgo2AjJnYNgK5S85N29dPUc2Mjrgbi4lAM9CvrcuQ16nPjiGsyj5SYpF190u450YsSIhoKD+sSSQAPsFJ3A6XHgR2ruY9d0ubXo8COHTHKw5R6nAYk+Fo9jE83+1Lclu9/7k4UVM0pR16VFXKyqgM6u0eJwHEZVxcdqx+RQiYkMwWoy0uhUIhfqB2H1M3G6SR2aHjuPwalxtq4fGf6uqzq9puGbZSXL4oNvVg6Kln/vdG+7liSGBJKQHkj0X8cwqPmfb8T5RP5o3BBnbiJTx6lSx5lDy9h4jtQLdq12pbniDleddExOZ0tIgGslJH3u+biWD0LJtqMFmvMv1lXN9bsErgRC03KnmRTodVIAgw6jpmK3OkEHmRYj6xvVpW1qBhanSoPkLOKCcpNHRQFfg+v3WtXwd9jJyF2+1ePzvThpyOuRKTjvR3GVM+HqBSk43TePMXefetGhAXrXiChVyz8bfe4vc6bTNVlZD5hdCy8R5gORgZBqg6PJrrqMClzTADQdHLzg+vNj0oPFAF3qgU4P7UPh5iiFn85qrPzLdVyX+pBph3p+8I/OOur4KRxNhrhMlaPJCqPaQ0N/HTOu09gdB4eTNJoFucqn2RQi/DV2xWmY9Qo3RCgE+yjMuNa1rVmQQrPg/M9uQR8906M1TqZpXNdQwc9Yk+7K16RYvUsSBOFVer2e/v37s3jxYsxmM7fffnuxZffs2cOFCxeYMWNGoWFI8+fPL/KYHTt2sGLFCgYOHMiZM2eYM2cOXbp0qdLVi8CVMEyfPp3hw4cze/Zs5s2bV6XtVzp/3+LnCnRp7vm+TaTrlcfHBFP7USHaNoJ/PVD0vgYhrldBBePpDgy9RM/CgG7F7ytYn9HgSk6GX1d0+ft6er6/vZPn+8cGerw1NIOA65uWHF85KQX+WyZvjXYfqzidOL/5E13TuqgWH7SFX6Fb9DWE+qNFhGE7kwV/xeFUdejxQcu9DM+75FLcfQSaa1ub+uj+OcCVOHZuBkYDRsCx9ziOnv8Gq1oganORPSaudYryymr4kU5qgQTBhBUfrBhy7/pnEIAPVvd8AgWoSyKpBGDHSLLBlxyD51AkVdFhVwz4arbcOu3UIZF0tQE6p+ruGQAIyM5BVT0HfyT6WlB1OnytVvwuGqJW90I6B6+OQudU6fxzTKHBXNl+Ro+LYJ2qYXBPhHedc4avmcQQ10IJqQEWfujQhgZJKYRlZmJSVfxT0om6kMSJBvlPoTY4nPwREuC6qDe7LuyD7A56JrnmkXTKzOYXP59CF+CaosNyIQP8TQQFKEzpqufpm3zdzzbQNM195znTpnEgzolep3EhWaNLfYXI+gWTNx8KDm/x5Po5WB0afyZomI0QYdEI8tGTZdfwMYDuohgzbSp+RiW/J7KGua0pvHh98fsbWKDgIgKKonBNQ7imYeHZP3cV6Fz3Nyn0blz0Z9MiRKFFSM383ETpSIIgvO6uu+7CYDAQERGBv79/seXyHpxWcJjOrl27ipx/cP78eV5++WWaNm3KU089RUpKCvfeey/PPvssH3/8MT4+RSzZV4mioqLo27cvGzdu5JdffqmSngwhvEKvR397+/z3L9/tepE3hKZ4mqaBqqErxfh1Q7dmGLLnox04gb3LK7iek1DyRYsOB7rc9MNCOlZ8seGLkRwspGPE7p57oEMlmBTANQnciQFXT4KCCTtmHDidOuILzA/wcdjQaRpp+OJHDnpUcjCht0Gd89mkB5rQ6VQCrDbC0jNz+zT0GHCS5OPHeUsgiqbhU2Byfd6wGlWvIy3ATGB6/iR/VQG7Qe96wvHFxwA5PkbM2TbXTfMCeZPVbOJkeD1M5y4QmJODw2SlTew5fOwOzgcF4GO30zQ+gTXtWtIzIZVsvY7D/r6kmoxcMBmoa3PQ2moj1OFge6C/+466UafQOMdG9xYmPnnYF10RKzFdfGFuMSnc0Dj3kqRRiT/CS/IxKHRu4Pl7UNRd7oIPTRO1n8xBKD1JEITXNWjQgIkTJ16yXKdOnQgLC2P27NnExcVRr149jhw5wqZNm2jRogVHjx51l1VVleeffx6r1cq//vUvfHx8aNCgAS+88AJPPPEEb731Fs8991xlnlaRxowZw+bNm1m4cGGxvR5CXMkURSnzBFMlxAJk43o4W96xxU3ozu8JUNCowzkKL5xqx46Px9E6VHLQY0AlC1/sGF3TSDSVBtlpJJotOHR6fB026lnTAZUMg4UENQC7anZNENV0mO0q5kQrCiphpLt7JhzoOBxWF1UxoCoQkG4nS2fCpDoxaa4x+hkWM4rDid7uJD7EB52qYsm0YzfqOdkoGLtRj7nACkY2swGD1UZiWDB6ux3/TCthyakkhuTfifex2wnIcSUbmqKg0zSank+k6XnXCkcnGtSl+UU9GRHZNr6qH8I5s5G6udsdOp0rOcgdtrNregBdwuUSQ4iaSv71ihojICCAuXPn8u6777JixQqcTidt2rRhzpw5rF271iNB+PDDD9m/fz9PP/20x3Cim2++meHDh7Ny5UquueYabr311io9hyZNmtC7d2++/vprfv75Z4+HuwkhyqlJPYx9O+D46ndU/HANJipqSdjC9w+VIrbq3E/o8tyuoiMNX3LwvWgb+Dls+DkuejgZ2ag6jTBHGrG6MBzoMBQY8qShw4nePenZiErrxARi9cHYFT2aosOu02HXGdAcOZg1BzhVRi3pTrZdw5Zsw5ZiJfmXZPQmHe30CnFHMzm7OxFTjh1NAbvRiM7hxG4y0fJqX04cUsgGmp47h4JGjq8PvjY74WnprmVinU5sioJqNGDJTTQ0IDbMc2ieWdOIysohMHcZX7ui8LuP2Z0cmC16SQ6EqOEUrTouqyKEEEKUhd2BtuBrbC+vR0twPYXAk2vxTV0Ri/cV1dfgmoTsWUcKwWThV6i0ghNH7lKyZmxk6Y2EODNJxp8Ycyg6hw6zs/BKPaGku5+PkCdV8SFFb0FV8uPUayqhjgxsGOh66j7MUcUPxcyTGZeFQ3PNOA+KyJ9EHf9XOvYsO9vfOEzK4WSyAvxRDXr0dgeW9ExQNY5E1MekaSiqk18i6hCICUOBS4WDAb5k+xoxapCQ4yDLoMeh0xEVaeKXKX4EyZr4ohqKVV4ucX+ENqOKIqn+ZACeEEKIms9oQPlHP8wX5qP2bOte7jWPnkyMZGIvomdBLbBNw7VkbN60YQ3Ixte9clFBOTojJ/1CSfbx5YyP6257nDGY86YAGnUNIsOio2B6YHA/WdlTkGalgTPVY5viXpIV1JzSPVfDEu5HUEOLR3IA0KB1AI06h3L/f6/lhqc7UDdUIRArgYoNR6gvWV0iGPtiC7RgH/6uG8TWtk04HupZh12BU0E+xAf6Yneq9GpmJOedMJxvhXDicYskB0LUAtIHKIQQolax/XwWPaAnHdCjw4YOB5kEkUAEgSRjIT336QomkgkjkBR8yHbX4ZrIrJJEmOshZ7lLqJqwYrtoiJGGRpZipL41HUVTMWpOsi3+NHy0LZ3GtUcXFUzQu4c4teAQOcfSURUdZqcDv0LPashn1hyYNDs2xTVZ2le140APRj2+LYMr5DNSFIXOI6PoPDKqyP3NOwSybk0CIV8d5oSPP3G+Rkx2jUydwl9mEyEpOYSRzY03BzBvmKXIOoSobmSScunJECMhhBC1SmrkDEyxCRhJx4AVAAdGYmlLXse5ghMFDRUDZjKxYUTDiB9pBJP/DAMbJrKxoKLHjBUVyMaCFT8URSNk5nUEz+hVqrj2N19O+tkscDrxt7uefG3EgbGI1fYv6PzJ0pswqg70aBidKh32DyWgc90iahZClMYZ5ZUS90dqL1RRJNWf9CAIIYSoVSxL7yGl90cEkgO5CYKVAC4eVau51w/S8CELHUZy8CeDECxkYMy9w2/ChgkbOfjiRO+6WDdDQ+szZY7L3DwQ9Xhq7jMaXOso5dWpKzCJuY6aQQ56joeEcs0T7WnwWEd05qImXgshSk96EEpL5iAIIYSoVQy3XkVA9xCs+OHAjAbo3Rf82R5l/UjHhBWtc2PCU54g5PWbuHBVK9Tcr0cNsGPMnY+gkYMPvmtGlSuusHtb5j6B4eKLFAUbBhzoUFFwuHs4wKw68TcrNHyqsyQHQogqJQmCEEKIWse8+1ksO6birBOGjSBs+AAqTvQEc4EAkgklHgtppBNE4Gt9MQT5EvzUtTQ+9ChZax8jKaopiab6pBnCsNavj2P0TYTEPYf/HeV7Env9B1pi9ct7cnT+s6JBwYEBG55PZFYAQ6CxUD1CCFHZZA6CEEKIWs8+5VOy5v+PVOqiYcKcO/QIVJRuTam/Z3yVxOFIt3NwyNdYvz2NDypmbDjQk4MRf6zugU8AOTo9ar/WdF7ft0piE6K2i1FeLXF/I63qH6BaXUmCIIQQ4oqg2R2or2/EmaOSaQ9EzbLjP6Ez5g71vRLP2bd/5viTuzApGjbVhBEngWo2Cq4nNpwOCKLnqpvxv62JV+IToraRBKH0JEEQQgghvMBut/N9+wXoT5uxGXSYbSqqqqDqFVL8fGjXK4TWq/t7O0whao3Tl0gQoiRBcJNVjIQQQggvOfpPM8YUlV4+PdBMRgIj/Mg5kkydO5tgbhHi7fCEEFcoSRCEEEIIL7IH64gc0xajMW9CchNvhiNErSUPSis9WcVICCGEEEII4SY9CEIIIYQQotaTHoTSkx4EIYQQQgghhJskCEIIIYQQQgg3GWIkhBBCXAarQyV0tko2oAfiJ0Mdi3y9ClH9yBCj0pIeBCGEEKKc1h514JubHAA4gbrz4ftTDm+GJYQQl0USBCGEEKKcBn9Z9PaeK6s0DCFEKWiXeIl8kiAIIYQQQggh3GSQpBBCCCGEqPVkmdPSkx4EIYQQQgghhJskCEIIIYQQQgg3GWIkhBBCCCFqPRliVHrSgyCEEEKUwge/OOjzmYP/nXYtYdp4XslLmX52SJY6FULUTNKDIIQQQpTg+5MOeq7Kf//N5wCXvvi/ZxOMbFtpYQkhykh6EEpPehCEEEKIElycHAghxJWg1iYI0dHRzJw509thlIvVauXf//43/fv3p3v37gwcONDbIVWZ9evXEx0dzb59+yqszpSUFGbMmEHfvn2Jjo5mwoQJAAwcOND9/0IIIYSo3eRBaaVXpiFG+/btY9KkSQA899xzDBkypFCZ6OhobrjhBmbPnl0hAV6Jli5dyooVK3jggQdo0aIFFovF2yHVaO+88w5bt25l7NixREREEBoa6u2QhBBCCCGqrXLPQfjggw+444478PHxqch4BLB7925atGjBo48+6u1QaoXdu3dzzTXXMH78eG+HIoSoYdYfrR0TjT9ss7r4aRNGuH9Pf8wB5iqNSYiqJ3MQSqtcQ4zatm3LhQsX+O9//1vR8dRITqcTq9VaYfUlJiYSGBhYYfVd6RITEwkKCqqSthwOBzk5OVXSlhCi8g360tsRXB6nzcmHLUpIDgDssKzzRj5ssZrND+2o3IBe/wKUocW/xs6B5HQ4EguJqZUbixCiWOXqQejduzeaprF06VKGDBlCcHBwieWjo6MZMGBAoTkB69ev56WXXmLBggVER0cDsHDhQhYtWsTnn3/OmjVr+Prrr8nIyKBjx4489dRTNGnShG3btvHhhx9y8uRJQkNDGTNmDEOHDi2y7d27dzN//nz+/vtv/P396dOnD1OmTMHPz8+jXEZGBh999BHbtm3j3LlzWCwWunfvzpQpU4iMjCwU87x58/jtt99Yv3498fHxPP/88yXOFXA4HCxbtoyNGzcSGxuLr68vnTt3ZtKkSbRo0cKjboDY2Fj3ZzJ+/HgmTpxYqM709HRuv/12rr/+ev79738X2j937lyWLFnCp59+SuvWrct0njk5OSxZsoQtW7Zw7tw5jEYj9evX57rrrvPo2fjf//7Hxx9/zLFjx7BarQQHB9O2bVsefvhhGjdu7C6XkJDAokWL+N///kdiYiLBwcHceOONTJ48+ZJDfkobS0F5v0sAGzZsYMOGDQC8+OKLxf6syvO7umLFCtauXcs333xDQkIC77//PtHR0aSkpLBw4UJ27txJYmIiYWFh9OzZk4kTJ17y34wQwvv+vevyew9e+Z+DF26o2gUDT2+L46+VJzm9Na7Mx57dnuhKKC6mg9Yjm9B+VAvi9yTgH2Eh4oZ6KLrcu7E5dvjiJ/jga/j1FGTlQE45P7vFO1yv0ooMBZ0OfIzQuSkkZ4GmwdS+cGcPOBQDszeArwmmD4JGdeHPM7D9d2jXCHq2K1+cQtRy5fqrpSgKDz/8MFOnTuWjjz5i2rRpFR0XM2fOxNfXlzFjxpCSksKyZcv4xz/+waRJk3j33XcZNmwYgYGBrF27ltdee41mzZrRqVMnjzoOHz7Mt99+y+DBg+nfvz/79u3js88+49ixY8ybNw+dztWBkpGRwdixY4mPj2fQoEE0a9aMhIQEVq1axejRo/nkk08IDw/3qHvOnDk4HA6GDBmCxWLxuBguygsvvMDWrVvp0aMHd911F4mJiaxcuZIxY8awaNEi2rRpQ+fOnXn55Zd5++23CQ4OZuzYsQC0bNmyyDoDAgLo2bMnO3bsIDU11eMuuaqqbN68mZYtW3okB6U9zzfeeIN169bRv39/7rvvPpxOJzExMezdu9fdxs8//8y0adNo3rw5Y8aMwd/fn4SEBPbs2UNMTIz7M4mPj2fMmDHY7XbuvPNOIiMjiYmJ4YsvvmDfvn188skn+Pv7F/vZlSaWotxyyy00atSIGTNm0LlzZ/ecmY4dO5Z4XFm98MILmM1m7rvvPhRFoU6dOu7POiYmhkGDBtGmTRv++usvVq1axd69e1m6dKnMLRGiGttyQuXJ/11+PTN2wY9nHWweUTVJwrZHd3NiY2zFVqrCX8tP8tfyk+5NDa+vx+0fXocuJQOuewb+LnsyUiHOJOX//5GLYth6EDo2diUseeZuggl9YMHX+dvuvwk+keG8VwpZ5rT0yv0Xq0ePHvTo0YNVq1Zxzz33FLqAvlxhYWG8/fbbKIrrhxkcHMysWbN48803WbFiBQ0aNADgtttuo3///nz++eeFEoSjR48ya9YsevXqBcDw4cOZNWsWn332GVu3buX2228HYMGCBcTGxrJ48WJatWrlPn7gwIGMHDmShQsXFrqjbLVaWb58eanmYOzatYutW7fSp08fXnvtNfc59enThwceeIBZs2bxn//8h8jISCIjI5k/fz6hoaH069fvknUPGDCAb775hq+//prhw4e7t+/bt49z585xzz33uLeV5Ty3b9/Odddd5+7RKMqOHTtQVZV58+Z59AI89NBDHuXefPNNHA4Hn376KfXr13dv7927N2PGjOHTTz8tsockT2liKUrLli1p2bIlM2bMICIiolSfZ3n4+/vz/vvvYzDk/3OaN28ep0+f5qmnnvL4ubRq1Yo333yTjz/+mMmTJ1dKPEKIy3fPerXC6vrqdIVVVaLsRGvFJwfFOPvDeU5/G0eTn773XnJwKRcnBwCqBgu3em5btgMevgN6tEIIke+yljn9xz/+gd1uZ/78+RUVj9vdd9/tvpAG3Bf/PXv2dCcHACEhITRu3JiYmJhCdTRu3NidHOQZPXo04LroBNA0jc2bN9O5c2fq1atHSkqK++Xr60v79u3ZtWtXobqHDRtW6gnaeW2NHTvW45xatWrFjTfeyC+//EJycnKp6irommuuISwsjI0bN3ps37hxI3q9njvuuKNc5+nv78/x48c5evRosW3n3fXftm0bDkfR3ckZGRn873//o2fPnpjNZo92GzZsSGRkJLt37y7xHEsTizfde++9HskBuH7mISEhhVb6Gjp0KCEhIXz33XdVGWKJkpKSPOZNZGRkkJ6e7n5vs9lITEz0OCYuLq7E9/Hx8Wha/qJx0oa0UdPaSLFRoZxqftwFzyMkJKRCziP1REbFBn0JZ36NQztytkrbvGxa4cUsU/b8Wat+d2t6G5VJQynxJfJdVp9nmzZtuP322/nqq6944IEHih0KUx4Xj4cH3JN2GzZsWKhsQEAA8fHxhbY3bdq00LY6deoQEBBAbKzrLktycjKpqans2rWL3r17FxlL3lCki0VFRV36JHKdPXsWnU5XZDzNmjVj+/btxMbGEhISUuo68xgMBvr27cunn37KqVOnaNy4MdnZ2Xz33Xfu5AHKfp7Tpk3jxRdfZOTIkURERBAdHc2NN95Iz5493eVGjBjBjh07eP3113nvvfe4+uqrue6667j99tvd53Ly5ElUVWXt2rWsXbu2yHYjIiJKPMfSxOJNRf0unD17lquuuqpQ4mAwGIiKiuLw4cNVFd4lFZwDUnC4l8lkcv8e5SnYY1jw/cVJvLQhbdTENrrWh33nqDB6Xf7FR8HzSE5OxmzOX0GovOeh1lXRGRRUR9Ws6N66b3OUOqnw3woYi1VVfIxgtee/N+gJHnI9XHTzrqb/7tb0NkT1cNmDIidPnsy3337Le++9x7vvvlumY51OZ7H7irvwK267VsRdgdLIO6579+6MGjWq1MdVp+Vd+/fvz6effsrGjRuZMmUK27ZtIysriwEDBrjLlPU8e/Xqxbp16/jhhx/Yv38/e/bsYe3atXTu3Jn3338fo9FIcHAwH3/8MQcOHGD37t0cOHCAt99+m4ULFzJnzhyPsf533HGHRzwXu/iLsbyxVLaSfler0++CEKJibBiqp8H84v/dl8WP91y6TEXQGXT0nBXNzid+RrVX3BApd/0+CqpVw+hvoMujbanbIQTa3Qw/H4f3vyry7rzXGHTw0kjXBOULaa5trRrCO6PhscWuYVF1A+GdMRBZx6uhiqpTjX5Dq73LThAiIiIYNmwY//3vf4t9+m1QUBCpqYWXK8u7i19ZTpw4UWhbQkIC6enp7rvWISEhBAQEkJmZSY8ePSoljoiICFRV5cSJE4V6WfJivNRd9JK0atWKVq1asXnzZiZPnszGjRvdE5jzlOc8g4KC6NevH/369UPTNN577z0+/vhjduzY4e6F0Ov1REdHu1f2+fvvv7n//vv58MMPmTNnDpGRkSiKgsPhuKzPtzSxVISK+l2NiIjg1KlTOBwOj14Eh8PB6dOnL+vnLYSofPUtCvZpeoxvX16SoE2v2hWMmg9oRLP+kST+mUpqXAbbJ+4pd11+zXyo0yqYeleH0mZ4M8zBJjLPZWMOMmHw0bsK6XQwdzy8dh+cT4Uf/nRdeL//FRyOgWMXKujMcvmbQK8DvR4m9IbB10CmHQwKNK0PmdmQZYOrm7jKPDsMjsa5VjGKyL2TfUdXOJvkitNU+TeYhKiJKuQv17hx41i3bl2xPQhRUVH89ttvWK1W993WtLQ01q1bVxHNF+vUqVNs377dYx7C0qVLAbjpppsAV49E3759WblyJd98802RF5tJSUmX9fTdm266iZUrV7J48WJeffVV9zyEo0ePsnPnTjp16lSu4UUX69+/P++88w5fffUV+/btY/DgwR535stynk6nk6ysLAICAtz7FEVxr4aUdwGdkpJSaLnOJk2a4OPjQ1qa645NcHAw119/Pdu2beO3336jQ4cOHuU1TSMlJaXY8y9tLBWlon5Xb7rpJhYvXsyXX37JsGHD3Nu//PJLkpOTi12WVwhRfRh0CnqgYvoRqo6iKNRpG0ydtsE0PxrJh61Xl+okjA0NPLBjoMdcuYIs9X2L3hHo53q1yB0u0i+6+IZUFeZthFMXYFwfiKoDWw5Cnw4QUAmru7UoMIRFUfKTBSFEkSokQQgODuaBBx5gwYIFRe4fMWIEL7zwApMmTaJfv36kp6fz5ZdfEh4eXmjySkVq0aIFL7zwAoMHDyYqKop9+/bx7bff0qVLF2677TZ3ualTp3Lw4EGeeeYZvv32Wzp06IDRaCQuLo4ffviBq666qtAqRmVxzTXX0KdPH77++mvS09O54YYb3Mucmkwmpk+fftnnescdd/Duu+/y+uuvo6pqkcN5SnueWVlZ9O3bl549e9K6dWtCQkI4e/Ysq1atIjAw0N0z8X//93+cP3+eHj16EB4eTk5ODlu3biUzM5P+/fu723366ad56KGHGD9+PP3796d169aoqkpsbCw7d+6kX79+xa5iVNpYKkpF/a6OGjWKb7/9ljfffJO//vqL1q1b89dff7F27VoaN27Mgw8+WKFxCyEqh2O6AWVWzX6a8ri/hvL3mtPsfKJAL78FzL4GbvvP9dRrX4UXzDod/KPAs2iGXlN17YsrlkxELr0K6/u8//77WbVqFQkJCYX23XHHHVy4cIHPP/+cd955h4iICB566CF0Oh2///57RYVQSJs2bXj88cd5//33Wb16NRaLhREjRjB16lSPuQz+/v589NFHLFu2jK1bt7Jz5070ej316tWjU6dODB48+LJjeeWVV2jdujUbNmxg9uzZ+Pr60qVLFyZPnux+UNrlCA0N5brrruP7778nKiqqyLX+S3uePj4+3HPPPezZs4c9e/aQlZVFnTp16NmzJ2PGjKFu3boA9OvXj/Xr17Nx40aSk5OxWCw0a9aMN954g1tvvdXdboMGDVi2bBlLly5lx44dbN68GZPJRP369bnxxhvp06dPsedV2lgqSkX9rvr7+/Phhx+6H5S2bt06wsLCuOuuu5g4caI8A0EIUaVaDomi5ZDSL64hhLiyKVp5Z/cKIYQQV4DL6UEoaQ6C3W5n8eLFAIwZM6ZKFlwQ4kp2SJld4v622mNVEkdN4P01IoUQQgghhBDVhiQIQgghRAm06QYZuSxELaBd4iXyVe36a0IIIUQNpBYxVCguxUHD/xR/TOwkuQcnhKiZJEEQQgghyiE82AAUPz+hob8kCEJUJ7KKUenJXy8hhBBCCCGEmyQIQgghhBBCCDcZYiSEEEIIIWo9GWJUetKDIIQQQgghhHCTHgQhhBBCCFHryVKmpSc9CEIIIUQ5pUwteshC1qPy9SqEqLmkB0EIIYQopyBfPdp0OJvm4LXdMK4DdG4gX61CVEcyB6H05K+YEEIIcZkaBhqY28fbUQghRMWQPlAhhBBCCCGEm/QgCCGEEEKIWk+GGJWe9CAIIYQQQggh3KQHQQghhBBC1HqyzGnpSYIghBBCVJAm8x2cynT9/w0N4Pv75WtWCFHzyBAjIYQQogIos/KTA4D/xYNxlsN7AQkhPGgoJb5EPkkQhBBCiMt0NLHoREDSAyFETSR9n0IIIcRl+r9d3o5ACHFp0ktQWtKDIIQQQlymr//2dgRCCFFxJEEQQgghLlNcCWOJDl2QgUZCiJpFEgQhhBCiErVb6u0IhBAgk5TLQuYgCCGEEOXw9TEHt6/xdhRCCFHxJEEQQgghyijHoUpyIEQNIw9KKz0ZYiSEEEKUkc9s1dshCCFEpZEeBCGEEEIIUevJPIPSkx4EUciECRMYOHCgt8PwqoULFxIdHc3Zs2e9HYoQoprJyHF6OwQhhKhU0oNQgfbt28ekSZOK3a/X69m9e3cVRiSEEKKinUyrhSOZlaFFb49ZAJH1qjYWIYTXSYJQCW6//Xauv/76Qtt1uprRYTNv3jw0rRZ+AZbBuHHjGD16NCaTyduhCCGqmc61bdnS4pIDgEa5N70yloHFr2riEaKSXNlXNmUjCUIlaNOmDf369fN2GG6ZmZlYLJZSlzcajZUYTc1gMBgwGOSfhxCisPI89mzzUQd3tKiGf1NaTixdOf/78///nmth8WNglu8KIWqravjX6sowZ84cPvnkE1566SX69+/v3v73338zevRo2rdvz/z58929Drt37+bjjz/mjz/+wGazERUVxbBhwxg2bJhHvQMHDiQ8PJxp06Yxd+5cfvvtN4KCgli3bh0AMTExfPTRR+zevZukpCSCg4Np27Yt48eP56qrrgJccxDi4uJYv369u95jx47xwQcf8Ouvv5KSkkJgYCBNmjThgQce4IYbbnCXs9lsLFu2jK+++oozZ85gMpno3LkzEydOpE2bNpf8XC5cuMCyZcvYu3cvcXFx5OTkEBERQf/+/XnggQfQ6/XusuvXr+ell15i/vz5HD58mFWrVnH+/HnCw8MZO3YsAwYM8Kjb6XSyePFivvzyS5KSkoiKimLs2LGcOHGCRYsWsW7dOho2bAi45iAUt23VqlVs3LiRjRs3kpycTJMmTZg6darH5wCwcuVKtm/fzvHjx0lOTiYoKIju3bszefJkd51CiJpD0zSuWVq++Qf9vwR1esXGUyaaBs99Ch9+A4np4LyMe6n//cn1uligL/RoBe+MhXaNLi9WISqJKpOUS00ShEpgtVpJSUkptN1gMODv7w/A1KlTOXDgAG+88QYdOnQgKioKq9XKM888g4+PD6+88oo7OVi9ejX/+te/6NChA2PHjsXX15fdu3fz+uuvExsby6OPPurRzrlz55g8eTK9e/fmlltuISsrC4BDhw4xefJkHA4Hd955J82bNyctLY39+/dz8OBBd4JQUEpKCpMnTwbgrrvuokGDBqSkpPDnn3/y+++/uy+MHQ4H//jHP/j111/p168fI0aMICMjgzVr1jBu3DgWLVpE27ZtS/zs/v77b7777jt69epFZGQkDoeDn376iblz5xIbG8tzzz1X6Jh58+aRk5PD0KFDMZlMrFq1ipkzZxIZGUmnTp3c5d58802++OILoqOjuf/++0lJSeGNN94o88X6zJkzMRgM3H///djtdv773/8yffp0Vq9e7VHXsmXLaN++PXfffTdBQUEcO3aML7/8kr179/LZZ58RHBxcpnaFEN515xonexLKd6wGnM3QaOjvpQuUns/B/w5XXv1p2bD1IFz9OPwxB1pHVF5bQohKJwlCJVi4cCELFy4stP2GG25g9uzZgCtZePXVV7nvvvt49tlnWbx4MW+++SYnT57k7bffpl4916SwhIQEZs2axW233carr77qrmv48OHMmjWLTz/9lLvuuovIyEj3vtjYWJ5//nkGDx7s3qZpGjNnzsRut7N06VJatmzp3jdmzBhUtfg1vQ8ePEhSUhL/+te/6NOnT7HlVqxYwc8//8x7773Htdde694+bNgw7r77bmbPns0HH3xQ/AcHdOnShbVr16Io+V+i9957Ly+88AJr165l4sSJ1KlTx+MYm83Gxx9/7B4adeutt3LnnXfy+eefuxOEY8eO8cUXX3DttdcyZ84cd/LVu3dv7r333hJjKig4OJh33nnHHWN0dDSjRo1i9erVPPzww+5yn332Gb6+vh7H9uzZkylTprB27VpGjRpVpnaFEN5zLlNj/fHLq+PNPU5m3+KFr93zKZWbHFzMqcITS2Hds1XTnhBlIMucll7NmDVbwwwZMoR58+YVek2ZMsWjXEREBM899xyHDx9m0qRJrFu3jpEjR9KzZ093mW+++Qabzcadd95JSkqKx+vGG29EVVX27NnjUW9QUFChZUr/+usvjh8/zsCBAz2SgzwlTaDO6/X48ccfycjIKLbc5s2badKkCVdddZVHnA6Hgx49enDw4EGsVmvxHxzg4+PjvvC22+2kpqaSkpLCtddei6qqHDp0qNAxw4cP95g3Ua9ePaKiooiJiXFv+/777wEYOXKkx7m2aNGCa665psSYCho5cqRHAtOuXTv8/Pw4ffq0R7m85EBVVTIyMkhJSaFVq1b4+/vz+++/l6nNypSUlEROTo77fUZGBunp6e73NpuNxMREj2Pi4uJKfB8fH+8x0V3akDZqehvJJf/pKpWY9KLbCAkJqdzzSM68/ODL4kIaUPN/5tKGd9oQ1YP0IFSCqKgoevToUaqyffr0YefOnWzevJnmzZvzyCOPeOw/efIkQKHk4mJJSUke7yMiIjzG6gPui+XWrVuXKq6Lde3alf79+7N+/Xo2b95M27Zt6dGjB3369KFZs2bucidOnCAnJ4fevXsXW1dKSgoNGjQodr/D4WDJkiVs2rSJmJiYQqsppaWlFTomIqJwV3ZQUBDx8fHu93nPM2jcuHGhso0bN+bHH38sNqaCLu6tubi91NRUj2179+5l0aJF/PHHHx5/QAGPP6DeFhoa6vE+LyHMYzKZCAsL89gWHh5e4vuCP2NpQ9qo6W20MUOgEdLslNsjXfRFtpGcnIzZbHa/r/DzaB0BwRZIqaJEYeodQM3/mUsb3mmjMskqRqUnCYKXpaen88svvwCu4URJSUke/wDzLpBfeumlQkNr8hS8QPbx8anwOF966SUeeOABfvzxRw4cOMCyZcv46KOPmDZtGnfffbe7XIsWLXj88ceLrSckJKTEdt555x1WrFhBnz59GDt2LCEhIRgMBg4fPsx7771X5PKrxfV+VNZSraVp748//uDhhx8mMjKShx9+mIYNG2I2m1EUhWeffbbEIV1CiOrpl1F6mv2n/A9Ju6mRF4c3fP8q9JkJ8SmV14bZAJP7wv03VV4bQogqIQmCl7388sucP3+eJ554gnfffZcZM2Ywf/58dw9Ao0au1SCCg4NL3StRlKioKACOHDlS7jpatGhBixYtePDBB0lPT2fUqFHMnTuXESNGoCgKjRo1Ijk5mW7dupX7mQ+bNm2iS5cu/Otf//LYfvFwofLImzx86tSpQj0Ap06duqy6i/LVV1/hdDp59913PRK47OzsatV7IIQovabBCtp0A8qssi90+t4tlRBQWbSPgriPPLct+homLCh/nQvGw6BuUDcEDPpLlxdC1BgyB8GLVq1axXfffcfYsWO5++67efTRR9m/fz8ffvihu0yfPn0wmUwsXLiwyPH7GRkZ2Gy2S7bVqlUrmjVrxrp16zh27Fih/SXdbU9NTS10xzsgIICIiAisVqt7+Ez//v1JTEzk008/LbKeguMQi6LT6QrFkp2dzfLlyy95bEluvPFGwDVx+OJzOXr0KLt27bqsuouSl+AVPJePPvpIeg+EuAI93KUa3o8bfxtoq0tf/sdXXeXzXhPvgPA6khyIGkNDKfEl8lXDv1g13+HDh9m0aVOR+3r16oWfnx9Hjx7lnXfeoUuXLjz00EMAjBgxgt27d/Phhx/SvXt3OnXqRP369Xn66af5v//7P4YPH06/fv0IDw8nOTmZo0ePsn37dlauXHnJpToVReHFF19kypQpjBo1yr3MaXp6Ovv37+faa69l5MiRRR67ceNGli9fzs0330xkZCQGg4H9+/fz008/0adPH/eQpnvuuYfdu3czZ84c9u7dS7du3bBYLMTHx7N37153olOSW2+9ldWrV/PMM8/QvXt3EhMTWb9+PUFBQZf62EvUvHlzhgwZwpo1a5gyZQq9evUiJSWFlStX0rp1a/7880+PiceXq1evXixfvpxHH32UIUOGYDQa2b17N0ePHpXlTYWo4Sa3h/nVZ52By7fndej+dPH7y5JECCFqBUkQKsGWLVvYsmVLkfvWrFmDTqfj2WefdT/v4OIJxTNmzODee+/l+eefZ/ny5QQGBjJo0CCioqJYtmwZq1evJj09neDgYBo3bszkyZMLTQAqTrt27Vi6dCkffvgh33zzDV988QXBwcG0a9fO43kBBXXt2pW//vqL77//noSEBPR6PQ0bNuSxxx5jxIgR7nIGg4HZs2ezatUqNm3a5E4G6tatS7t27Qo9uKwo06ZNw2KxsHXrVnbs2EH9+vUZMmQIbdu2LXGidmk8/fTT1K1bl7Vr1zJnzhwaN27M008/zR9//MGff/7pMUnwcnXq1Ik333yT//znPyxYsACz2Uz37t354IMPGD9+fIW1I4Soeq/2rGUJQrdWkPMZXPcs/Jy7lutNbWH7/3k3LiEqmPQSlJ6iVdZMTiFqiMcff5y9e/eyY8eOQqs/CSFEQQ6nE+M7Zfvq1KYXvh9nt9tZvHgx4HoezcXLNQshKt7/lP+UuP8G7aEqiqT6kzkI4opR1ByOv//+mx9//JFu3bpJciCEKBWD/K0QokbSLvES+WSIkbhibNiwgU2bNnH99dcTEhLCyZMnWbNmDQaDgYkTJ3o7PCFEDbKoN4z/xttRCCFE5ZAEQVwx2rRpw/bt21mxYgWpqalYLBaio6OZMGECbdq08XZ4Qoga5KFOBqZ84+AynpsmhBDVliQI4orRvn175s6d6+0whBC1hG26gdOpDh7cDDvOeDsaIcSlyCTl0pM5CEIIIUQ5RQUZ2D6y5HttQ5tWUTBCCFFBpAdBCCGEuEwKxU9y/OIu+aoVojqQHoTSkx4EIYQQ4jJ1K93jaIQQokaQBEEIIYS4TANbejsCIcSlyDKnpScJghBCCHGZnr9BhhEJIWoPSRCEEEKICrDpzsLbMv4hY56FEDWP3PIQQgghKsAdLQ1o070dhRCiODJJufSkB0EIIYQQQgjhJj0IQgghhBCi1pOJyKUnPQhCCCGEEEIIN+lBEEIIIYQQtZ7MQSg96UEQQgghhBBCuEkPghBCCFFGL37vYM5+SLXnb5t3C0zpIl+rQlRX0oNQevKXTAghhCilwwkOrlpS9L6p26BTPQfXRcpXqxCiZpMhRkIIIUQpFZcc5Ln+syoJQwghKpXc5hBCCCGEELWe6u0AahDpQRBCCCFKITbd4e0QhBCiSkgPghBCCFEKkQu9HcElZFrB/17Pbb++DR2aeCUcIaobTVf7JinHxsayc+dOzp8/z1133UVkZCROp5PU1FSCgoLQ6/Xlqld6EIQQQohL0LRq/gxWh7NwcgDQcVrVxyKEqHSapjFt2jSaNm3Kfffdx7Rp0zhy5AgAGRkZNGnShPfee6/c9UuCIIQQQlxCmtVZ6rJTv/bCUKTwMcXvU4ZWXRxCVGOaUvKrJvn3v//NnDlzmD59Olu3bvW4iREUFMTQoUP54osvyl2/JAhCCCHEJQTPK31Zc1V/syanQ0JGyWWe+7RqYhFCVIlFixbx4IMP8tprr9GpU6dC+zt27OjuUSgPSRCEEEKIEsSmla1HQKvqb9awUZcu89oXYLNfupwQokaIiYnhuuuuK3a/xWIhLS2t3PVLgiCEEEKU4PFvylb+r8TKiaNYpZ0eEflQpYYhRHWn6ZQSXzVJvXr1iImJKXb/zz//TFRUVLnrlwRBlGjgwIFMmDDB22FUmr/++ovJkydz8803Ex0dzcKF1X2ZEiFEVdt4omzlT6VWThxFOnCs9GUvpEPKJYYiCSFqhKFDh7JgwQKOHz/u3qYoriTn66+/ZsmSJQwfPrzc9csyp1egM2fOsHTpUvbv3098fDwmk4mwsDDatWvHwIEDiY6O9naIVcLhcPDkk0/icDiYNGkSAQEBtGzZssRjjhw5wpIlSzh06BDnz5/H19eXunXr0qFDB+666y7atGnDhAkT2L9/f6liePHFFxk4cGBFnI4QopJklXEBo0MplRJG0bo8UbbyIQ+CtrpyYhGimqvy4X+V6KWXXuK7776jU6dO3HjjjSiKwhtvvMELL7zATz/9ROfOnXn22WfLXb8kCFeYQ4cOMWHCBAwGA/3796dZs2bk5OQQExPDrl278PPzu2IShNjYWGJjY3nssce4++67L1n++++/Z/r06QQHB9O/f38aNWpEeno6p0+f5ocffiAqKoo2bdowduxYBg8e7D4uJSWFt99+m86dOzNkyBCPOjt27FjRpyWEqEAv7qzGD0dLzSzfcTHnoVG9io1FCFGlgoKC2LVrF2+99RarVq3Cx8eHHTt20Lx5c1588UWeeOIJfH19y12/JAhXmEWLFmG1Wlm+fDmtWrUqtD8hIcELUXlHYqJroHBQUFCpys+dOxez2czHH39M/fr1PfapqkpqqmtcwTXXXOOx7+zZs7z99ttERETQr1+/CohcCFFVXt7j7QhKEPxA+Y6LmgRT+sC8yRUbjxDVnKavWfMMLsXX15fnn3+e559/vsLrlgThCnP69GmCgoKKTA4A6tSpU6p6tm/fzscff8yRI0dQFIWWLVvy4IMP0qtXL49yAwcOJDw8nGnTpjF79mz++OMPjEYjN954I48++iihoaEe5W02G8uWLeOrr77izJkzmEwmOnfuzMSJE2nTpk2pYjt79izz589n9+7dpKenU69ePW677TbGjRuHj48PgMcwoJdeeomXXnoJgHXr1tGwYcMi642JiaF58+aFkgMAnU5HSEhIqeITQlR/07c7eGtf+Y9XZjmY0BGsDojPUhjSQmHi1Yp7jHCp2R0wewN88RMkZUC2Dc5UwCzo97e6XgB6HXRuCvWDYdTNMLz4lVGEEFcGSRCuMJGRkZw6dYpt27Zxyy23lKuOlStX8sYbb9CkSRMeesi1KsaGDRuYPn06zz77LEOHej6U5/z580yePJlbbrmFW2+9lcOHD7Nu3Tr+/PNPPv74Y/dFu8Ph4B//+Ae//vor/fr1Y8SIEWRkZLBmzRrGjRvHokWLaNu2bYmxxcXFMWrUKDIyMhg2bBhRUVH8/PPPLF68mIMHD/L+++9jMBgYO3YsV199NYsXL2bIkCF07twZoMSL/MjISI4fP87Bgwe5+uqry/XZCSGqv49+vbzkIM8Hv+b9n8bXJzXOZCj83w36slUycQEs3nb5wZTEqcK+3MnOG3+Gj6bCmFsrt00hvECtYSsVlWTs2LGXLKMoCh9++GG56pcE4Qozbtw4du/ezZNPPklUVBRXX3017dq1o2vXrjRt2vSSx6elpfHuu+8SGRnJkiVL8Pf3B2DYsGHcd999zJ49mz59+hAQEOA+5syZM0ybNo17773Xva1Zs2a88847fPbZZ4wePRqAFStW8PPPP/Pee+9x7bXXussOGzaMu+++m9mzZ/PBBx+UGN+8efNITk5m9uzZ3HDDDQAMHz6cOXPm8Mknn7BhwwYGDx7MNddcg8FgYPHixXTs2LFUQ38mTJjAM888w7hx42jRogUdO3akXbt2dOvWrdheByFEzfPUzsqpd94Bjf+7oQwHpGXBJzsqJ5iSvP+VJAhCVHPbtm0r1CPpdDqJi4vD6XRSt25dLBZLueuvRfO5RWl07NiRZcuWMWDAADIyMli/fj2vv/46w4cPZ/z48Zw5c6bE43fv3k12djYjR450JwcA/v7+jBw5kqysLHbv3u1xjMViKbTU1vDhw7FYLHz33XfubZs3b6ZJkyZcddVVpKSkuF8Oh4MePXpw8OBBrFZrsbGpqsrOnTtp3bq1OznIM3r0aHQ6Hdu3b7/UR1Ss3r17s2jRIm699VbOnTvH6tWreeWVVxg0aBDTpk0jOTm53HV7U1JSEjk5Oe73GRkZpKenu9/bbDb3fI08cXFxJb6Pj4/3eOy7tCFt1KQ2KotTy2/j4vMICQkp+jw0zfWqak4VqD4/D2njympDlM7Jkyc5ceKEx+v06dNkZWXx7rvvEhAQwLffflvu+qUH4QrUokULZs6cCbj+Yf7888+sXbuWAwcO8M9//pNly5ZhNBqLPDY2NhZw9QAUlLctr0yeiIiIQvWZTCYiIiI8yp44cYKcnBx69+5dbOwpKSk0aNCgyH3JyclkZWUVGVtQUBB16tQpFFtZderUiU6dOqFpGqdPn2bfvn2sWrWKnTt38sILLzB37tzLqt8bCs4DuTjxA9zL4F4sPDy8xPcFf0bShrRRk9p4vaeDh76mwk3oqLjbuFhycjJms9n93uM8RlwP//2+4oMpyYTbgOrz85A2rqw2KlNtWua0OEajkYcffphDhw7x8MMPs3HjxnLVIwnCFS48PJwBAwbQv39/HnroIQ4ePMgff/xBp06dvBJPixYtePzxx4vdX10mAiuKQuPGjWncuDEDBgxgxIgR7Nq1i3PnzhU5iVkIUXOM62jgUKKDt3++vHqGtwSHBueyYEhLHY93Lcf454+mQstw1yTltGzIscP5Cn4SmwK0awRhgTCqlwwvEqIWuPrqq/nkk0/KfbwkCAJwXfC2b9+egwcPcv78+WLLRUZGAnD8+HG6d+/use/ECdfjRiMiIjy2x8bGYrfbPXoRbDYbsbGxNGnSxL2tUaNGJCcn061bN3S6sqf5ISEhWCwWj6cK5klLSyMhIaHY1Zsuh9lsplWrVsTGxnLhwgVJEISoBd662cBbN7tWIyoPbXoFfb36mOClka6XRwMa6O4qf73jboJFj0BZV1USogbTatEk5UvZunUrfn5+5T5eEoQrzK5du4iOjsZg8PzRW61Wdu3aBRQ9fChPjx498PX1ZcWKFQwcONA9ASYzM5MVK1bg5+dX6DkAmZmZrFy50mOS8sqVK8nMzPRYFrV///7MmTOHTz/9lAceKLy+d2JiYqGuyovpdDpuvPFGvvrqK3788Ueuuy5/qb4lS5agqmqhZVjL4scff+Taa68tNCkoOTmZX3/9Fb1eT6NGjcpdvxCi+vlmGPRe5e0oiqAosPt16PF02Y+N+w80CL10OSFEtfXyyy8XuT0lJYWdO3eyf/9+nn66HH8fckmCcIV5++23SU1NpWfPnrRo0QIfHx/OnTvHV199xenTp+nfvz8tWrQo9viAgAAeeeQR3njjDUaPHs2AAQMA1zKnMTExPPvss4XGIEZGRrJo0SKOHTvGVVddxZ9//sm6deto0qQJI0fm3xW755572L17N3PmzGHv3r1069YNi8VCfHw8e/fuxWQysXDhwhLPb+rUqezevZvp06czbNgwGjVqxP79+9m6dStdunRxx1seTz31FKGhodxwww00bdoUg8FAbGwsmzZtIjExkfHjx5f6oWtCiJrh1iYGoJo+Tbl7OXpETTpJDsQVS6tFHQh5c0kLCgkJoXnz5ixYsIDx48eXu35JEK4w06ZNY8eOHfzyyy9s27aNjIwM/P39adGiBaNGjWLgwIGXrGP48OHUqVOHTz75hEWLFgHQqlUrZs2aVeQd+nr16vH6668ze/ZstmzZgtFopG/fvjz22GMejwE3GAzMnj2bVatWsWnTJncyULduXdq1a1eqi/vw8HCWLFnCggUL2Lx5M+np6dSvX58xY8Ywbty4Qj0nZfHiiy/yww8/sHfvXjZt2kRWVhZBQUG0adOGadOmceutMm5XCAEtAy5dpsLs+D+4qQxPUU3/b+XFIoSoMqqqVmr9iqZ5Yw01caXIe5LypZ5fIIQQ1VX/VQ42nSx9+X92hlm3XvpmhN1uZ/HixQCMGTOm2NXjLkkZeukyAAFmSJMEQVy5vgxdXuL+wUn3lrj/SiI9CEIIIUQJ3rkZNi0uffkTFbzIUIWR5EBc4WryJOXTp0+X67ioqKhyHScJghBCCFGCVmFlm4cQZL50mQqVvBRCRpVcZvqgqolFCFEpmjRpUmiRlNJwOp3lak8SBCGEEOISvhsGN5dyNaPbi18IrnIEB0Adf0jIKL7Mv0dXWThCVFdqze1A4KOPPipXglBekiCISrV+/XpvhyCEEJftpsZ6oHR34oa28sLjWs8tAf2wovepX1RpKEKIijd69Ogqbe8KeOi0EEIIcXnKcufOqPfCV6tOB9mfFd5+/H15GJoQuTSdUuJL5JMeBCGEEKIUMh7R4f9u5S4teFl8TKCt9nYUQogq9MMPP7B//35SU1MLLX2qKAovvPBCueqVBEEIIYQoBYtJB1TjBEEIUaLa9KC0pKQk+vfvz549e9A0DUVRyHtyQd7/X06CIEOMhBBCCCGEqEGeeOIJfv31V5YvX87x48fRNI0tW7Zw5MgRJk2aRKdOnTh79my565cEQQghhCilI2NL3v+hPFBdCFEFNm3axMSJE7n77rsJCHA9vl2n09GiRQvmzZtHkyZNeOyxx8pdvyQIQgghRCm1DDWg/lPPqzdASIFBujOvgbGdZeSuENWVpiglvmqSlJQU2rVrB4C/vz8AGRn5Sx3fdtttbNmypdz1y18yIYQQogwUReHZaww8e423IxFCXKkaNmxIfHw8AGazmXr16nHw4EHuvPNOAGJjYy/ruQmSIAghhBBCiFqvJj8oraCePXuydetWnnvuOQDuvvtu3nzzTfR6PaqqMnv2bG6//fZy1y8JghBCCCGEEDXItGnT2Lp1Kzk5OZjNZmbOnMkff/zhXrWoZ8+evPfee+WuXxIEIYQQQghR69Wmh6F16NCBDh06uN+HhITwzTffkJKSgl6vd09cLi+ZpCyEEEIIIUQNcujQoSK3BwcHX3ZyAJIgCCGEEEIIUaO0b9+ejh078tprr3H06NEKr18SBCGEEKIm6PgoKEPzX62meDsiIWoUTSn5VZPMnz+funXrMmPGDFq3bk3Xrl3597//zalTpyqkfkkQhBBCiOru5c/htxjPbX/Hw7T/eCceIYRXTZw4kW+//ZbY2FjmzJmDxWLh6aefplmzZlx77bXMmTPnsp6krGiaplVgvEIIIYQoBbvdzuLFiwEYM2YMRqPRs0BaJrSZCnFpJVekra6kCIWoXT6NWlni/vtOD6+iSCpHbGwsK1eu5PPPP2fPnj0oioLdbi9XXdKDIIQQQlQ3LSZD0AOXTg6EECJXeHg47dq146qrrsLPzw9VVctdlyxzKoQQQlQnZy/AsXPejkKIWqc2PSgtj6ZpbN++nRUrVrBmzRoSEhIICQlh5MiR3H333eWuVxIEIYQQojq56tGylT8SC60iKicWIUS19P333/P555+zatUqzp8/T2BgIIMHD+buu++md+/eGAyXd4kvCYIQQghRnaRZy1b++mfhwtLKiUWIWkRTak8Xwk033YS/vz8DBw7k7rvvpm/fvphMpgqrXxIEIYQQoiZLSPd2BEKIKrZy5Ur69++Pj49PpdQvCYIQQgghhBA1yF133VWp9UuCIIQQQgghar2a9jA0b5JlToUQQlwxfjzt4I4VDhYecHg7lIqj93YAQojaRnoQhBBC1Hp/JTposzj//VcxMOlbV5KgTa9GX4WpmWU/xlnxYQhRG6m1aJJyZatGfxWF8I4zZ86wdOlS9u/fT3x8PCaTibCwMNq1a8fAgQOJjo72dohCiMuQZvVMDgpSZjn4sDeM7VQNvhINcgEjhPC+avDXUAjvOXToEBMmTMBgMNC/f3+aNWtGTk4OMTEx7Nq1Cz8/P0kQhKjhguZeusy4b2DdEQdfjvDy16KP2bvtC1GLyRyE0pMEQVzRFi1ahNVqZfny5bRq1arQ/oSEBC9EJYS4XJqm0f4DJ4fKsALo2tOu3gQABWgfCpM6wEOddZgMVTRl7/lPqqYdIUSNl5aWxvvvv893333H+fPnWbhwId27dycpKYklS5YwaNAgWrRoUa66JUEQV7TTp08TFBRUZHIAUKdOHY/3u3fv5uOPP+aPP/7AZrMRFRXFsGHDGDZsmLvMM888w7fffsv777/v0fvw008/8cgjj3DHHXfw8ssvV84JCVHLbTym8vJPKnGZcEdThRynxtZToKkQl1Vx7WjAb0kwdQdM3aECKn46+HKIQp+mlTgr+PV15TtOGQoP3ARzx0OgX8XGJISods6cOcNNN91ETEwMLVu25PDhw2RkZAAQGhrKwoULOXXqFHPmzClX/bKKkbiiRUZGkpqayrZt2y5ZdvXq1Tz88MNkZ2czduxYHn/8cSIjI3n99dc9/gE+99xzhIeHM2PGDFJSUgBXT8SLL75Io0aNePrppyvrdISo1X6/oDF4rcqeeIhJhw9+1Vj6B5zNqNjkoDhZKvRdrXE6Tav8xsrjkx0w/n1vRyFEtaUpSomvmuSJJ54gPT2dX375hR07dqBpnn+XBg8ezDfffFPu+iVBEFe0cePGYTAYePLJJxk6dCgvvfQSq1at4sSJEx7lEhISmDVrFrfddhsfffQRDz74IMOHD2fWrFmMHDmSTz/9lDNnzgDg7+/Pq6++SlJSEi+99BKqqjJjxgzS09N57bXX8POTu3tClMfnf6k4VO/GoGqw+u9KShC+/fXy6/hiF1htl1+PEKJa+/rrr3nkkUdo27YtShHJTbNmzYiJiSl3/ZIgiCtax44dWbZsGQMGDCAjI4P169fz+uuvM3z4cMaPH+++6P/mm2+w2WzceeedpKSkeLxuvPFGVFVlz5497nrbt2/P5MmT+f777xk/fjx79uzh4Ycfpk2bNt461WIlJSWRk5Pjfp+RkUF6ev7AbZvNRmJioscxcXFxJb6Pj4/3uJshbUgbFdGGzpZBdeCjWd3/XxGfVUhIiOuzCvS9/OD8fcCgrzU/c2njymujMtWmHoTs7Gzq1q1b7P6Lfw7loWgF+ySEuILFxcXx888/s3btWg4cOEDz5s35f/buOzyKcu3j+He2phcgQOhVQIqAKCBVpAmCKPDaRVRQUFQs59iOBz0eCxawIjaQ4lGxgQoogjQVFRDsUkMPEEJ6Ntvm/WPJwpIQAoQkJL/Pde1lduaZee5ZQ3buedqsWbN47rnn+PDDD4s89tZbb+Xmm28OvjdNk9GjR/Pzzz/TqVMnXnrppUKzfBEpnv05Jm1n+NhdhnlC1TBIGm0lynHq/5Y9Hg/TpgXmXx05ciR2uz0wluBUPHYl/Ov/Tjk2kYrozaafFLn/5o2XlVIkp65Dhw40a9aM2bNnc+DAARISEvj666/p1asXAF27dsVqtbJs2bKTOr8GKYscITExkUsuuYSBAwdy8803s379en7//ffgE5NHH320wMDlfLVr1w55v3v3bjZu3AjAjh07yMnJITIy8vRegEgFlhBh8NO1Vl5bFxikfHlTgywPLNxqYrWYzNsIe3NPX/1Dm8BrfUsmOShx1WLg9Vvhsk5lHYlIuVWRpjm96667GDFiBG3atGH48OEA+P1+Nm3axKOPPsr333/PRx99dNLnV4IgUgjDMGjVqhXr169n37591K1bF4C4uDg6dux43OO9Xi8PPfQQPp+Pe++9l+eee46nnnqK//znP6c7dJEKrVaUwWNdQ2cRGt4s8N/X+4aW9fv92J73c6LN5PMvg94NLNitZdAL979Xw0Pvnvhx+6eXeCgiUn5de+21bNu2jYcffpiHHnoIgP79+2OaJhaLhSeeeIIhQ4ac9PmVIEiltmrVKjp06IDNFvpPweVysWrVKiAw0Oecc87h1VdfZerUqZx77rmEhYWFlM/KysLhcOBwOACYMmUKv/32G//+978ZNGgQe/fuZebMmXTs2JFLLrmkdC5OpJKzWCz477UE1zY4nt2jITGmjL8WHxx2cgmCiByXaalATQgEZk287rrr+Oijj9i0aRN+v5/GjRtz+eWX06hRo1M6txIEqdSef/550tPT6d69O02aNCEsLIy9e/eycOFCtm/fzsCBA4OLjNx///08/vjjDB8+nAEDBpCYmMjBgwfZtGkTS5cuZc6cOdSqVYtVq1YxY8YM+vfvz6BBgwC47bbbWLNmDRMnTqRNmzbUq1evLC9bpFIx77UdN0lw3WXBWVqLoRXFX8bTNIlIuZeTk0O3bt0YNWoUt956K+PHjy/xOpQgSKV29913s2zZMtatW8eSJUvIysoiKiqKJk2aMGLEiOANPsDgwYOpV68es2bN4uOPPyYzM5O4uDjq16/PmDFjqFq1Kqmpqfz73/+mdu3aPPDAA8FjbTYbTzzxBNdccw0PPfQQb7/9dmBAooiUCt89VsKf83H0BKC7b4bEuHL0Veg/iXlDqmrqZJHKJCIigq1bt57WiU80i5GIiEgZKHQWI48XHCc4C5HDCnlzTkOEIhXL1BZzi9x/y5+XllIkp+7qq6/G5XLx8ccfn5bzl4P2VBEREQHgZAZGu30lH4eIlGv/+te/2LBhA9dddx0rV65k165dpKamFnidrHLUrioiIlLJWfTcTuR0qUiDlFu2bAnAH3/8wbvvHntiA5/v5B4gKEEQERERETmDPPLII6d1DIISBBERkTPZmL7HLyMicBpvqEvbhAkTTuv51ZYpIiJSnrRrcGLlX731tIQhIpWXWhBERETKk7XPg3F5WUchIuXYY489dtwyhmHwr3/966TOrwRBRESkvPniARj4ZFlHIVKhVKRBykV1MTIMA9M0TylBUBcjERGR8mbAeWB+DAffgXfGlXU0IlLO+P3+Ai+v18vmzZsZP348HTp0YN++fSd9fiUIIiIi5VVcNFx/ISx4sPD9K47fzUBEAkzDKPJ1prNYLDRs2JBnn32Wpk2bMm7cyT9cUIIgIiJS3vXvALPvCN227lno2qps4hGRcq179+7Mnz//pI/XGAQREZEzwdU9Ay8ROSmmUXmei69evRrLKSy8qARBREREROQMMmPGjEK3p6WlsXz5cj7++GNuvvnmkz6/EgQRERERqfAq0ixGN9xwwzH3VatWjfvvv59HHnnkpM+vBEFERERE5AyydevWAtsMwyA+Pp7o6OhTPr8SBBERERGRM4hhGCQkJBAeHl7o/tzcXPbv30+9evVO6vyVZ7SGiIhIKdiZ4eWbTW5cbl9ZhyIiR6hI05w2bNiQTz755Jj7582bR8OGDU/6/GpBEBERKQGbD3ho8qYJFgMwAD/ReblkPBxV1qGJSAVjmmaR+z0ej2YxEhERKWtNXveDzcLZ+zNokJZNrs3KLzVi6fpqFivHKkkQKXNnViNBARkZGaSlpQXfHzhwgO3btxcol5aWxnvvvUdiYuJJ16UEQURE5BTtTHODzUL7PQc5d09acHv99Bw+Mk7+S1pEJN+kSZN47LHA6umGYXDXXXdx1113FVrWNE0ef/zxk65LCYKIiMgpWL7dS4//BboWnb0/I2Sf3W/SNDUbUAuCSFk708YZHK1v375ERUVhmib/+Mc/uOqqq2jfvn1IGcMwiIyM5Nxzz6VDhw4nXZcSBBERkZOU4fLT4z0/GBYsfhOrv5B+wcfpKywiUhydO3emc+fOAGRnZzN06FBatWp1WupSgiAiInKSmkzxgGEBwyAq18PPNeI4NzkN26GkwGsYbIxX64GIlKx///vfp/X8ShBEREROwk+7POzPM8BmgN8kw2nnl8Q4NleLpufWfXgtBvucTjIjHGUdqohQsVZSzvftt9+ydu1a0tPT8fv9IfsMw+Bf//rXSZ1XCYKIiMhJOH+WeXhWlPwbD79Jts3KF81qAVA1K69sghORCi01NZWBAwfy448/YpomhmEEpz7N//lUEgQtlCYiInKCnvzWDV7f4cQgn8UA3+ExB5lOq8YgiJQTFWmhtPvuu49ffvmFd999ly1btmCaJl9++SUbNmzg1ltvpW3btuzevfukz68EQURE5AQ9uNwPTjsceVPhMyHXC25/4L9+kzrpuaD8QERK2Pz587nlllu44ooriI6OBsBisdCkSRNeeeUVGjRocMwpUItDCYKIiMiJyl+hNH/WItMElw/yuwD7gVwf0Xke6qZmlUWEInKUitSCkJaWRsuWLQGIigpMhJCVdfhvTd++ffnyyy9P+vxKEKSACRMmnNLcuRVBhw4dmDBhQlmHISLlVf7NhEEgOfAV3kywvkYsbVMy+b9/7Tnpqvx+P5sW7CRtWwY5B90nfR4RqThq1apFcnIyAE6nk+rVq7N+/frg/l27dmGcQtKjQcrlyM6dO3nnnXdYu3YtycnJOBwOqlatSsuWLRk0aFDwpvXzzz8v1vlGjRrFLbfccpqjFhGpXOxPuQ61IBjBRMHq8eErrLBhsL5mLK12pZ9UXdMbfUr0wRxyIhzkRQW+sh1eL44sN9WqW4k6KxbL7nQSejegwaPnY1TAWVpESsqZ1kpQlO7du7No0SIeeughAK644gomTpyI1WrF7/czefJk+vXrd9LnV4JQTvzxxx+MHj0am83GwIEDadSoEXl5eezYsYNVq1YRERFBhw4duPzyyzn//PNDjn3kkUdo0KABN954Y8j2pk2bluYlVCjffvstVqu1rMMQkXLGb5p4sQTGFfj84DHBb+JzWgI/H9mSYDPAaiE5Opz2u9NY+V0aHdpFERZ+/K/ejD05zOj9DfFuN55wKzbTh5kHWbERuE07RngY9l0HSEkBLBY2vrODn9/cRE27hwu231Cy1+zKwzv3Z3zTv8fv8eN47kqsjaphRNgw9HdSpEzcfffdLFq0iLy8PJxOJxMmTOD3338PzlrUvXt3XnrppZM+vxKEcuKNN97A5XLx7rvvctZZZxXYn5KSAkCbNm1o06ZNyL5HHnmEKlWqMGDAgFKJtTRkZ2cTGRlZZvU7nc4yq1tEyqedyR6Gfe4FtwF2IzDOwG6AGUgEsBxKEPxmYDYja+Bppc8wMPzw2isphPn3YQIOPCRGmRjR1alS/yCpyXl4s3JY/W4Sfy7ej4GNOunZwZWZDcDh9mHx+fE6Al/drohIau3KCM60mhNh56DVYLkxlSiysOEjNyySyNbxxHVJoMr/NScv1Y17awqRVcC/KQ3frzuwLf8Nj+Ekb6+Bg1zCyMTAhhcrHmz4iAJM/Pix4yGz7StY8RLFXpxk4sdCNrF4CceCiwhSAQN7lANL6/qYtargP6sORp0qWFrWhqR9gSsa1AH+2h2YDSo6HHLyoHFNCHNAbARs3x/4XCOcEB91uFtXtgt2poDbAw1rgt0WSNYijvq77faA2wtR4YX/D83NC5wzzBHoJpaRA7Fl970jciJat25N69atg+/j4+P5+uuvSUtLw2q1BgcunywlCOXE9u3biY2NLTQ5AKhWrVqJ15mXl8drr73GggULyMzMpHHjxowdO7bIGN944w1+/PFH0tPTSUhIoHfv3owePZrw8MN/gPO7QS1atIhJkybx7bffkpeXR+vWrbnzzjtp3rx5sOzu3bsZPHgwo0aNomHDhsyYMYOtW7fSp0+f4BiAH374gRkzZvD777/jdrupV68ew4YNY9iwYSHxrV+/nrfeeou///6bzMxMYmNjadq0KaNGjQr+I0pPT+fNN99k+fLl7N+/n/DwcBITE+nbty/XX3998FwdOnTgkksuKTAO4dNPP2XOnDkkJSVhs9lo1aoVo0aNom3btiHl8o+//PLLefnll/njjz9wOp307NmTe+65h4iIiBP5XyUiZWjxojTuXOzj96ox4LEEbiYtBtiPGsZnHFo07Sg10l3EeL04jpju1GvaSE9xQ0pj0raYPLtoAzX3HsDh9hJutZIXZgaTgyPZ3d5ggpCwP5sja4vI8ZBWJQw/XlxE4sYOLgPfT5mYPyXjmryWXOwcIJZwcjmHH3CSjYmNbKpjxcBNOD4sBIYomjjwYZI/7sHEC3gJx4tJJPsPlfQTTRqQhkF+QmNCVh58vwEDsBJodMm/ohPu6FE9FqbeCs/Ng5V/hu4zjMD/j2Gd4a3bIDIMHvsAnp0LWa5AIjJ9XCDJgEDicNsb8M7SQCC9WsOfO2HbfmhZF6bdDuepBb4iqkhdjI4lLi6uRM6jBKGcqFOnDtu2bWPJkiX06tWrVOp86KGHWLp0Kd26daNz587s3LmT++67j1q1ahUo++eff3LrrbcSHR3N5ZdfTvXq1dmwYQPvvfce69ev5/XXX8dmC/11GjduHDExMYwaNYoDBw7wwQcfMHr0aN5++22aNGkSUnbZsmW8//77DB06lKFDhwZbDz7++GOefPJJWrduzY033kh4eDg//PADTz31FLt27eLOO+8EICkpidtuu42qVaty5ZVXUqVKFVJTU1m3bh0bNmwIJgj3338/a9euZejQoTRt2pS8vDy2bt3KmjVrQhKEwrz44ovMmDGDli1bMnbsWHJycvjkk0+45ZZbeO655+jatWtI+Q0bNjB+/HgGDRpEv379WLNmDXPnzsVisQT7DIpI+ZaT7eVfn7v4ve6hhzQ+M5AEFLOvv8Pto9mBrJDkAAILGfksBja/CYaBabfj9Pgx/JBaM5bIzGx8VgPrUYOffbZDXXpME7u74KiHMLcHADeHV292YyeHcOyYROAlDxcGeYSRjQlkUxM/drKIIoosDs9fYmCG3CYYOHATzR+4iCGCw+MqLMWYy/WUbs32pcPwZ8DrL7gvf5D4+99C7SrQvSX8+73D++f9BHdPg2njAu+fnQtvfn14/8KfD//8+w4Y+gxsmQI2dZ+S8m379u088cQTfPPNN+zfv59PP/2U7t27k5KSwmOPPcbIkSNp167dSZ1bCUI5cdNNN/HDDz/wj3/8g3r16nHOOefQsmVLzj33XBo2bFji9a1atYqlS5cWeErevn177r333gLlH3vsMapVq8aMGTNCuv6cf/753HfffSxYsIBBgwaFHJOYmMjEiRODo+h79erF9ddfzwsvvFCgX9zmzZt57733Qq41JSWFZ599lr59+/Lf//43uH348OE8++yzzJ49m6FDh1KnTh1WrVqFy+Xiv//9L61atSr0mrOysvjpp58YNmwY//jHP4r/YRFIQGbOnMk555zDa6+9ht1uB2DIkCEMHz6cp59+ms6dO4eMW9i4cSPTpk0LxjN06FCys7OZN28e48ePVyuCyBlg9aostscc9W/Vbgld/6AwpgnpLtwuH3nHuDU2zNDyURk57EuMDyQMRmCcg8nhG2u3w4bbGfjatvhNPHYLDk/oDXN8bg4u7JhH1enBih8L4CMcN1HsBcCPAxM7XuyA5bg38X7s2MnDxv7jlDwNCksOjjZ/LWQXsnr1/LWHf17wc8H9R9qRAr9th7Yl/90rZasitSD88ccfdOvWDb/fT8eOHdm0aRNerxcI9DpZuXIl2dnZvPXWWyd1fk1zWk60adOGWbNmcckll5CVlcVnn33GU089xfDhwxk1ahQ7d+4s0fqWLl0KwHXXXReyvWfPntSvXz9k26ZNm9i4cSP9+/fH4/GQlpYWfLVt25bw8HBWrVpVoI7rr78+ZIqtFi1a0LFjR3788UdycnJCynbt2rVAIvT111/jdru59NJLQ+pMS0sL/qP48ccfgcNzAC9btoy8vEK+HAiMK3A4HPz2228nvLrgsmXLME2T66+/PpgcACQkJDBo0CD27NnD33//HXJM69atCyQr5513Hj6f75RWNyxpqampIZ9ZVlYWmZmZwfdut5sDBw6EHLNnz54i3ycnJweXfFcdquNMriMmLo9ot/dwAYtR+KNw0zy8YrJpQpYb8vxgGOx22sk4qoU1zzCwHtmqYBh47FaMQ92KYlMzsfpNPHYrmbHhpMdHkhEfEUxMam1Lw+Hx4z8Ui98Ap8VNhM9dIDkAsOIPdv/xYuEACYFq8QMmBn7MYIljs5F76LjyyV8/gewaUQV3NKwe/DGnZtF9s027lbxqh89xpv7unql1SPH84x//IC4ujg0bNjBr1qyQ/y8AAwcOZMWKFSd9frUglCNNmjQJPs3fs2dPsEvKzz//zD333MOsWbNCbk5Pxa5du7BYLAWSAYCGDRuybdu24PutW7cCMHXqVKZOnVro+VJTUws9T2HbVq1axZ49e2jcuHFwe7169QqUTUpKAihyXER+vX379mX+/PlMmzaNd999l9atW9OpUyf69etHYmIiAHa7nbvvvpvnnnuOwYMH06hRIzp06EDPnj0LzAx1tPwb+iNjzpe/bdeuXZx99tnB7bVr1y5QNjY2FgiMhSgvqlSpEvI+P9nKlz/d7pHyP9Njva9Zs6bqUB0Voo6259bg4k92ssUTidtuDQw89pvBAchB+Q9DTBMO5IbMZuQ0TZLDw8j2eAn3+XBbDOpmZoceb5pkxIZTLfkgOyPDCMsN9Pu3+vzkhYWu2Gz4TaKzAjdllkPVOEwv0WYeLmxEkkseTrwEWjQt+AnHjQ0vPiCTCLxEk0ksUaRjJReIwIaHXCIJJwvjUApgwY0fG2DBioswDt/s5RGBk8DDHh82wI+VYjzlP1mXdICFa4/dkhAVhuWxq4hsUhPeWwUbDj2ICXPAf68JFot47Fr45k84cOhG1mmHPE9wv/HPy3DWSTh82jP0d/dMreN0qkgtCMuXL+eRRx4hISGhQBIGgfuqXbt2nfT5lSCUU4mJiVxyySUMHDiQm2++mfXr1/P7778XGAxbGvKz0muvvZbOnTsXWiYmJuaU6ggLCztmvY8++ugxB2nn34Q7HA5effVVfvvtN1atWsXatWuZOnUqb7zxBo8//jgXXnghAMOGDaNnz56sXLmSNWvWsHjxYj744AP69OnDk08+eUrXcLSipkk9OtMXkfLruf/UpueCNCat87PUGk2Rj9lNQpKDCJ+fBE9grIAfSLXbiPV4CMwKFGDBTY1oCz5M0mOchKdn47Fbcbi9WP0mkZkusqPDAkmCaRKZkUtuuJ2oLPeh4/04cePChh0vbixEkIsPAx8WnOQRSwYWvOymJg6yacQubFjJpArgBVxEkoubcFw4seIljDQiOYAHJybWYDIA4CacVOpjPVSLiYUYtmEcGtBsENo9yjzifbDrQpQz8Fl5vIHEymqBFnWgZyuoEg1Lfgl0F2pdH67sAn3awt40+McM+Gp9YPajLs2h7zmBpG1YZ0g8dMP683Pw4XdwMBsu6wj1Dt/w06IO/P0yzPkuENCwzrBmC6xPgq4toHOz4v5qiJQZv99fZFfl/fv3n9KMjEoQyjnDMGjVqhXr169n3759JXbe2rVr4/f72bZtW4Gn4vktBvnyn+5bLBY6duxY7Dq2bt0aMgVX/jar1VqsJwZ169YFAiPyi1tvq1atgt16kpOTueaaa5gyZUowQYBA37whQ4YwZMgQfD4fjzzyCF9++SXXXnttcNnyo+UnIps3b6ZOnToh+7Zs2RJSRkQqFsMwGDwgnsEDYHeml9qvFvGU3GdCnBPcfrAaeCywO89NgttDhGkSk+fhsYcTaNk8Bo/Hw7Rp0wAYOXJkSAvxM92/wbY9FafbS3iOG6vHR57TRkSOG6vfZGf9OCwmVEvOJCE1k8Aw4cAsQ2Fdq9Nq2f8Vumja0W3GhU0AmrdmJ541O7E3iGbfmHmw5QDhHMCCHQt+PNjJI4YI60Eso7thTc0m7KlLsTRICDmPcYyfi+2R/yu4rWY8zLjz+MdGOOH6C4+9v2o03HrEIlJ92wZeImeI9u3b88UXXxTay8Lr9fLee+/RqVOnkz6/xiCUE6tWrQoOLjmSy+UK9u9v1KhRidXXo0cPAGbOnBmyfenSpSHdiwCaNWtG48aN+eijjwodC+H1egvtMjNjxoyQJ+V//fUXP/74I+edd16xBuj26dMHh8PB1KlTcblcBfZnZWXhdgeeVqWlpRXYX6NGDeLj44OxuVyuAuexWq3BBeUyMjKOGUv37t0xDIOZM2eG/H9KSUnhs88+IzExkWbN9NRJpKKrFW07PNbgaKYZGMDstEGUHcJseMLspESHsS/Kxvzp9fl4VmNaNj9+i+t9yy/kgukXsLd6DPuqx+C3WojKCgx3zooKw/T5CMt0YXO58WGQbnNgdKnNueadtF5xxSmtqOw8tw5Rozvh7NuSGpsfoIb5LDHmNOzm+1jNOYSZ7xJrTiHW+yrRr15FxHs3F0gORMoj02IU+TqTPPDAAyxcuJAxY8bw22+/AbB3716+/vpr+vbty59//sn9999/0udXC0I58fzzz5Oenk737t1p0qQJYWFh7N27l4ULF7J9+3YGDhxYYGrQU9G5c2e6devG559/Tnp6OhdccAE7d+7k448/pnHjxmzevDlY1jAMHnvsMcaMGcNVV10V7L/vcrnYuXMnS5Ys4fbbby8wi9GePXu4/fbbg1NuffDBBzidzuDUpMdTo0YN7r//fh5//HGGDx/OgAEDSExM5ODBg2zatImlS5cyZ84catWqxVtvvcWqVavo2rUrtWvXxjRNVqxYQVJSUnD60m3btjF69GguvPBCGjduTHR0NElJSXz44YfUrl27yKnAGjRowHXXXceMGTMYNWoUffr0CU5zmpOTw3/+8x+tvCxSSbw7wODqz71gt4bOZlTg50ODgsNsRFpO/Ou2ac9ERi2pwrRLvuGAJYKI3Dycpo8uE1rS4sqS+z4QkTPPxRdfzPTp07nzzjt5/fXXgUBXcNM0iYmJYcaMGXTv3v2kz68EoZy4++67WbZsGevWrWPJkiVkZWURFRVFkyZNGDFiRIGb75Lw5JNPMmXKFBYuXMiPP/5I48aNeeaZZ1i4cGFIggCBVoTZs2czbdo0li9fzkcffURkZCSJiYkMGjSI8847r8D5X3rpJZ5//nlef/11XC5XcKG0/Cf2xTF48GDq1avHrFmz+Pjjj8nMzCQuLo769eszZsyY4OCnHj16kJKSwtdff01qaipOp5O6devy8MMPc+mllwKBhGPw4MGsWbOGpUuX4vF4SEhI4LLLLmPEiBGFjoM40h133EHdunWZM2cOL7/8Mna7nZYtW/L444+f9DzDInLmuaqNg6sXuo8/1emhMQNhHg/z7os/qboiqji57bv+J3WsiISqSIOUITAT5eWXX85XX33Fpk2b8Pv9NG7cmH79+p3ySsqGqdGSUsLyV1JevXp1WYciInJaGE+5AzMZFeOGIyLLRfaEglNvFjUGQURK3tM9i572859Lu5VSJCfnwQcf5Morr6RNmzanvS6NQRARETlBDWIB36HByvkr+Xr9gZc/9LlbjkON9SLlgWkYRb7Ku6eeeio43gDgwIEDWK1WlixZUuJ1KUEQERE5QVvHOIJdiPAfeuXP5ekzQwcyH71mgohICTldHYGUIIiIiJyEGQMth5KDQnYe2YrgP42Lh4lIsZ3pLQilSQmClLgJEyZo/IGIVHjXtbKBz3fsaU8PcfhKKSARkRKijpEiIiIn6bkuFu5ZYRbsRpQ/p7ppYtFcICJSQpKSkli7di1AcJ2njRs3EhcXV2j59u3bn1Q9msVIRETkFNR+Jofd3iPWRDh6diOvD/N+Z4HjNIuRSOl64qLvitz/4OILSimSk2OxWDCO6gplmmaBbUdu9/lOrglTLQgiIiKnYNd9EazZ5abDbONwy8GR1LdZREpA/gOF0qAEQURE5BS1qmEHXx4Y1gIJQZgWWRcpF870gcgjRowotbo0SFlEROQUOW0GDWIs4PFh8fiOmP7UT9IYZQgicmZRgiAiIlICtt7m4K2BNvw2AzCJdxrkjLdSI1IJgkh5oGlOi09djERERErIjefYuPGcso5CROTUqAVBRERERESC1IIgIiIiIhWeqV5ExaYWBBERERERCVILgoiIiIhUeBqIXHxKEERERM4QPreXlIk/YcGk6r3nYQnT6ssiUvKUIIiIiJwBdt80H//bP+HHihUPqf/6COuUK4m/9byyDk3kjKAWhOLTGAQREZFyzrUhlZy317OdGmyhFlupzQGqY46ZWdahiUgFpARBRESknNvc7C32UA03dmx4sOFjH/Hk4cS99WBZhyciFYwSBBERkXLswKdbSCMGH1bseKlBGrVJoS77OUBNtjR5s6xDFDkj+A2jyJccpgRBRESkHNv28E94sAMmiaQSjhsDsOEnlhw8fhveTFdZhykiFYgSBBERkXLMkrQXAAdeHHhD9hmHXumDppd6XCJnGhOjyJccpgRBRESknDL9fqpm78bAjw8LZiFlLPjJWbYb0+cv9fhEpGLSNKciIiIl5K3bf2bfL5lYTBMT8BnQ89aGdLm63kmdb2fLF/EQTjRZuAgjBztxZGNi4MOKFxs2XPjw4duciu2saiV7QSIViKY5LT61IIiIiJSApy5dRer6DGymiQWwAg4TVkzZyt5NmSd8Pt++LKL/2sF+qlGVTKqTRlUyseLHhg8HbsCLFysewtnf7LGSviQRqaSUIIiIiBRDSpaXJhOziHskg1b3JXPRP5L55PtsABZ/moyZ5jlGFyB4c+TaAtt3fbcX4+U4jNdjOfBneoH9G2s8iwXwHprYNJKckP0GUIW9tOBHrOQRRy5mdt6pX6hIBWUaRpEvOcwwTbOwv2ciIiJySPUnsthv2rD5/ERm5GFz+wgHDCvE5+Rx8bZdRHk8WPwmdq8v5FgTcFstDLi1Pu2vDHQ1mtPvSzI2Z4dWYoWRvw3BYrewLP5NGqf9SRUy8GCSSSwOwgo81XOSRjR7yCUSLxFY60URse250/Y5iJzJHh5YMFE/0uNftC+lSMo/jUEQEZFK7f8+djNnE2AYYJrUjoDX+hlc0tROaq5J1SeyD93l5+E1Id1qhSg7Np8fw+tjR0wU25o35oKD6bRMOUh8rgvTMLD6fFh9fvwWCz6HnTWzk2h/ZT28eb7DyYFpBuoF8MH0ph/QIWULYTlRxLGfCLIAiCWVbKqSS/UjIjdxkImXSOyY7KMmCdt3leZHJyIVlLoYSaWXkZFBly5d6NChA1988UVZhyMipajhq4eSAxPwmuCHXTkw6CMT4wkXVZ/OBY8f8nwE+w/5TfD68Vot+G1WME3S7Ta+jY8hzPTjcdjx2m3khTnxGmD1enHmeUjZ7yEv08Oen1IC5zkyOTikiicDmzuLeMteIsnCRQQ+rHhw4CIMP95DYZjYycIkCi8xeImlBnvJJA5vxPWl9vmJnEnUxaj41IIgld6CBQtwu93Url2befPmMXDgwLIOSUROs92ZXmq/6oejZwY1AR/gzd9ngK+QnrimCX6TcKBVlou/wx00ycjC5j9cNiw7l8js3EPv8vADU3osZsjEVoUmBwDRvmzqenfhNe1soCMewjDwYceL9YggI8nGiSUQX5BBHClYc3PwGVcCDggLg8cvgxu7Y42PPPEPSkQqJSUIUunNnTuXDh060KNHD5577jl27txJnTp1yjosETmC12+ydi/UjIR6MYU/6ftln5/vd5tUDTOJsBvszjL5dAPszg40AiRnw4E8E9N36Oa8qBF4DkugRcHlO3YZvx+n38RpmrTIyQsde2CahOfkhhS3AF6blU/v+40ow8AALKYPv2ENHrPDUZuDcdVpmpaC9VB8JlbcWHFhw4GXKHKw4MGO54izBwrbyCUwh1IEYIDLC/fOgXvn4MPkcAZkgM3ErBGNv0k9rO3qYVQLw4h0QotaGHkeqFcNXB7Mtg3hjz0QHYbRtAakZcMfO6BlXYhV0iFnDlONBMWmBEEqtb/++osNGzYwYcIEunbtyuTJk5k3bx5jx44NKefz+Zg2bRqffvopqamp1KtXjxtvvJGtW7fyxhtvMG/ePGrVqhUsn5KSwhtvvMHKlSs5cOAAcXFxdOvWjTFjxlClSpXSvkyRM9q6fSaDP/GxIxMsBoxuY/BqbwvGoSfwbp9Jz/d8fL/niIPMQ00DBZ7SG2ANjDXAcihJ8BeSKRhG4BwWC0Q5IdcDhSxEVi83D0wTu2GQHBOBue9AYHVj08RS6JRGFjxRDqIzkrlo50qquVM5aI/lu4TzSA6vGTjWbgSTgyN5sZJFOBbc1CIj/0KxkYmV7EPvLJhEcbhlIbSFIeBQQuJ1Y+xKwborF5ZtJLByQx4WDic2JgZ+a2xgQQeA9nWw/LkBIzcPIsPg1VFw/YWFXKiInMk0BkEqtblz5xIREcFFF10UvIn/4osv8PtDbwQmTpzIa6+9Rp06dbjjjjvo2bMnTz/9NCtXrixwzuTkZK677joWL15M//79+ec//8mAAQP46quvuOmmm8jKyiqtyxOpEG5dFEgOIHAv/9p6ky+2HL6Dfm29PzQ5gMANflF9ig0jkCBYDbAVUs5vBloQLEYgMbCGljFMk1bZLmK8fjAMquXkMnBXCrkOB6ZpYhoGXqs15BgT8FstGKafATsWU82dCkC8J53eycuw+z1Y/eC1WPBaCsbkPfSVnUIV3Iee71nJxUZ2ILEgsKqyQXGnOnUQaGnIvxUwMAnDPOLZoUnE4eQAYO1OzPz8IdsFt06Fg/qbJmcGv2EU+ZLD1IIglVZeXh4LFy6kV69ehIeHAzBw4EC++eYbvv/+e7p06QLA5s2b+eijj+jcuTMvvPACFkvgy7R3795cffXVBc47ceJEvF4vs2fPpkaNGsHtvXv3ZuTIkcyePZtbbrmlFK5Q5MxnmiY/HH3zD6zaY3JJ48DPXyedYiWGAYYZ2uXIJJAceP2HxiAYYLcGWxtMq4HDdfhGfE2dKmQctNNu1wEic1wAeB02DLeJxefHNAw8DjumxULNzGSiPaFTnDr9HhKzkzlgrYlpGOyJiaFOWnrwmb8LG97gV3ZgFeVAylAwGTAofD2GwlkLbDGxYeA99HPB/SHH5LphfRL0bFXsGkWk/FMLglRa33zzDZmZmVxyySXBbV27diU+Pp558+YFt61YsQKAK6+8MpgcADRp0oROnTqFnDMrK4uVK1fSvXt3nE4naWlpwVetWrWoU6cOP/zww2m+shOTmppKXt7hm4ysrCwyMw+v+up2uzlw4EDIMXv27CnyfXJyMkcusaI6VMfJ1mEYBm2rU0C76kawjq61C+4vEdajBigbBlgtgRcGm6MDDxYynDaSqkSyqEkiyZHOYHHTYsEd5sQVGU5eRFhgxiMgyxGFn0JaCPxhwZ/Tw8PZ7YwlkzAOEkEW4cF9EWQTfigxKPwG/kSehBbsNmVw5LiLwsZgHN5mOmxwdmDM1pn0e6U6ym8dUj5ooTSptMaMGcOmTZt46623gn2ZAV5//XW+/vprFixYQFxcHE888QQff/wxn376aYHBy8899xz/+9//gmMQfvvtN2644YYi661duzZz5849HZckUiF9t8vkkk98HAw8mOf/mhm8O9CC9VA3nByPSYeZPv5MPeKgY8wSdExef8FBy34TcrzHPMRpmFTFJDkmDP+hWJrvS+OG738v8umb4fHS76/FtE7/K7hta3g91oafj8dhwTDBkefHkecjItdz1O2+SQ0OkEgyNrzk4CSBpOBNvQn4iaZ4HQTcgIfggGYgMAYhJ/jOxILfiAbz0BU1ropl6xYMvx9sVnj+Bhinmd/kzPDPS9cXuf/pueeUUiTln7oYSaW0a9cuVq9ejWmaXH755YWWmT9/fqFdiIrj4osvDmmZOJLT6Sx0u4gU7oLaBjtGW1mxy6RWlEGbhNBb5gi7wR832vhqq5+lO/zEOSHeYfDdHvgpOTC+OC0PDroP5QA+/6FuRUecxFLIdKamCU4L5BV8yg5gtxrsjg4L2WY1ISsygjyHA7/FICzPTXR2dmDAsmniB7w2C9/W7MjOiNpUd+0n1RnP9vDaVEvJI8x1OCEJ97uJIo9c7PixYMeLHZMsYthIDADV2X5ocPHhy/HjxwSsHOoaFcx8ggs5HHoZmPFxmA1qYGmagFE1AqNKJDSuBnkeqJcQGNdwXlNYvzMwi1HHRrDrAKzbCu0aQS1NuiBSESlBkErps88+wzRNHn74YaKiogrsnzJlCvPmzePqq68Ozk60bdu2Ai0I27ZtC3lfp04dDMPA6/XSsWPH03cBIpVMpMOgf8OiWwT6NrTQt+HhZ/ej2h277IEcL9Ve8B/uaGs99IP/0FgEg0DS4LSC1Q9uX2Bf4L6a+rl51M1z822UI7jAktXvp92uA+SGH04aXGGBBwKxmVk4Ds14NPDxs1l2x2p2RySyOyIxWDa1ahhRmS6qZOdQ37uFOG8G6dQnigwOEocNP9mEHxqgbBBJGrXZhHEoRcgfqJxOLHFkEmgdcMLgdvDiVVjrJxz/gy6EAdD77MMbalcNvETOMFoMrfiUIEil4/f7+eyzz2jSpAlDhgwptMyWLVt4/fXX+f333+nWrRsvv/wy7733Hp07dw6OQ9i0aROrVq0KOS4uLo4uXbqwZMkSfv31V1q3bh2y3zRN0tLSiI+PPy3XJiLFUzXChvkAtHjTzV+ph24aLEe0KuT3vvUTWBPBGVgxmTwf+KBKhpea2Xn03LqfbXGRWEyTBgeziXQX7JKU57AfOqXJmOW9yNqeU2hMfqtBRmwY52T8RiPvRiz4CSeXTGpgP7R2QRS5+DEwgWhSySEaD5H4MElgF1nEEuVIw5Y3q0Q/LxGpXJQgSKWzatUq9u7dy6WXXnrMMr169eL1119n7ty5PPjgg1x22WV88sknjB07lp49e5KWlsacOXNo1qwZf/75Z8gYhvvvv5+bb76ZUaNGMXDgQJo1a4bf72fXrl0sX76cAQMGaBYjkXLiz5sddJ7pZtWu/HURTKKtJtMGWhh6toMdaT7qveDC4jMJ9/rxWK24bVZ+rhLNQYeNGrluEg7m4PB4ycUgPDcPDiUE+Sx+E69hQFQYzigHjhb2woMxTSyePH6PakZYmo865hYiScPERhbxwdzFcqir0D7q4KYRHFoAzYIPAz/RedNO2+clcibTVKbFpwRBKp38AcK9evU6ZpkmTZpQr149vvrqK+6++27uv/9+EhISmDt3Li+88AL169fn/vvv5/fff+fPP/8MGVdQs2ZNZs2axTvvvMOyZctYsGABDoeDGjVq0K1bN/r06XPar1FEiu/76xzH3Fc3zor/kQii/5tDbp6B0xdYjcBvtZAUFc5+u42qGbk0yXXRdV8KUdkuDlSJw2s/9PVqmsRmZGL1eGl+aaC7omEYdJvYnhX/WHt4MLUZuMm/IekqDIvB4ui3yMqqRhjZuIkgD+eh0QQWHHiw4MdNfqIRuOlJoxaJZxXeOiEiciI0i5HIKRg/fjw//fQTy5Ytw2otbLpBEakoktM8XPBSLruyTaymj5r4eWRAGDf0iGLJ42tY+U0eEa487C432VER+CwWInJcODweMsOdPPht6IrD2QezebfXZ5Bpo0H/WvR5+YLgPtNv8rP1eRxYDy195iB0VLV51Hs/LfiNiOxJWCI0EYJIYe65/Nci9z/3cesi91cmakEQKQaXy0VYWOhsJRs3buS7777jggsuUHIgUgnUjLOz5V+Fdw/q9fC5fPvdKtw+OzaPl5jMwwuh5TlsjHirfYFjHFEOzDEZAPQcGdrl0bAYtDt4C3vj/8Nu6lJwbYPQ9za8+MlWciAiJUIJgkgxfP7558yfP58uXboQHx9PUlISn3zyCTabTeMJRASAB+edz8sj1pC7zYvVZsXiD4xZ6HFPM2o3jz3h8xlxUXgaVcO+xY3vOF/XMaQRtva/Jxu6iEgIJQgixdC8eXOWLl3K+++/T3p6OpGRkXTo0IHRo0fTvHnzsg5PRMoBq83CnbPPK9Fz1v77blLsL1OwS9FhBn4s+HC0q1PofhEJME9olfHKTQmCSDG0atWKl19+uazDEJFKxmKz4ooKJyorGxfhhZYxsRD1zw6lHJmIVGRFrQYvIiIiZSyuc1XC8WDgO0YJk/j7epdqTCJnIr9hFPmSw5QgiIiIlGMN/tMJcNOAP45IEgITEFrwYseNrWrhrQsiIidDXYxERETKsfCOtQnjINXYQxz7ySYGK1782EinCtU2P1DWIYqcEUy1EhSbWhBERETKuSrf3I4XGza8xJJKFBlEkYYfB+GN4ss6PBGpYJQgiIiIlHMRPRuyr/F5wYHKLsLZSwOq/nR7GUcmIhWRuhiJiIicAWptug/37iz2jJ1HWN+mJI4t2SlVRSo6dTEqPiUIIiIiZwhHrSgSP726rMMQkQpOCYKIiIiIVHh+NSAUm8YgiIiIiIhIkFoQRERERKTC0xiE4lMLgoiIiIiIBClBEBERKWGTfvRif85LrZe95HnNsg5HRAA/RpEvOUxdjEREREqQ8aw3+PMeF4RN9vFOP7i+tb5yReTMoBYEERGRErJgo7fQ7SO+LOVAREROgRIEERGREjJgbgme7IL7wbj88Ot/y0rw5CKVj2kYRb7kMCUIIiIipWBrauGtC4Ua/xZ8vyF029UvwFMflmxQIiKFUIIgIiJSCoadSOvC5C8K3/7AuyUSi0hl5DeKfslhShBERERKwca0so5ARKR4lCCIiIiUANMsejrTTF8JVVTzhhI6kUjl4jeMIl9ymBIEERGREvCvpcfJAHz+4p3ow2+L3r83o3jnERE5SUoQRERESsBvqccrUcwF0+6edqqhiIicEq3aIiIiUgLmbj1OgeJ2Ydhx3ExDRE6CpjItPrUgiJyACRMm0KFDh7IOQ0TORLo5EZEzhFoQKonVq1dz6623HnO/1Wrlhx9+CL7v0KEDXbt2ZfLkySHl9u3bx+233862bduYMGECF198cXBfXl4e8+bNY/HixWzatInMzEzCw8OpV68eHTp0YPDgwTRo0KCkL63MLV26lL///ptbbrmlrEMRkfLMMDBNE6MkEoXftkKrhqd+HpFKRFOZFp8ShEqmX79+dOnSpcB2i+X4jUk7duzgtttu48CBAzz33HN07do1uG/nzp2MHz+erVu30r59e66++mqqVatGTk4OGzZsYN68ecyaNYvPP/+c6tWrl+g1lbWlS5fy+eefK0EQkeOqMsnHwbuL+Ood9nTxTnTBA5DxXskEJSJyFCUIlUzz5s0ZMGDACR+3adMmbrvtNlwuFy+99BLt27cP7nO5XNx1113s3LmTZ555hgsvvLDA8Xl5ebz77rsn/eQsOzubyMjIkzpWRKS8SDveREYf/XCcAodkuk85FpHKxkRNCMWlBEGO65dffuGuu+7CarUydepUmjdvHrL/008/JSkpiZEjRxaaHAA4nU5GjhxZrPpGjx7Nnj17mDJlCi+++CKrV68mIyOD1atXA5CSksIbb7zBypUrOXDgAHFxcXTr1o0xY8ZQpUqV4HnS09N58803Wb58Ofv37yc8PJzExET69u3L9ddfDxzuevXvf/+bQYMGhcQxYcIEPv/882C9x4p17dq1ACFjE/LPl5yczNSpU/npp584cOAAUVFR1K1bl8svv5xLLrmkWJ+HiJRP29J9DP3UZM3+EzjINDGednN2NQs3toIoEwzTxJj+DYx+7cQCMC6Hc+rDD0+D03Fix4qIFEEJQiXjcrlIS0srsN1msxEVFVVg+6pVq7jvvvuIiYnhlVdeKXQMwZIlSwAYMmRIicWZk5PDLbfcQps2bRg7diypqYFZPZKTkxk5ciQej4dLL72UOnXqsGPHDj766CNWr17NzJkzg9dx//33s3btWoYOHUrTpk3Jy8tj69atrFmzJpggnKobb7wR0zT5+eefeeyxx4Lb27Rpg9fr5bbbbmP//v0MGzaMevXqkZWVxaZNm/j555+VIIicwT7628ewz4o5bemRDAOsBn8chHtXGMRyBRueG4ct+cuTC2T9Ngi7EtJmQqxaWUWKosXQik8JQiUzdepUpk6dWmB7YQOSN2zYwPjx46lVqxavvPIKNWvWLPScmzdvJjIyktq1a4ds9/l8ZGZmhmwLCwsjLCzsuHGmp6czdOhQxo4dG7J94sSJeL1eZs+eTY0aNYLbe/fuzciRI5k9eza33HILWVlZ/PTTTwwbNox//OMfx63vZHXq1ImFCxfy888/F+i6tXHjRrZt28a4ceMYMWLEaYtBRErfzV+eRHJQiHQiWVKjDVcmf3dqJxr+DHw1oURiEhHRNKeVzGWXXcYrr7xS4HX0jTgEbtI9Hg9Vq1YlNjb2mOfMysoqtPVh69at9O7dO+Q1Z86cYsd63XXXFahn5cqVdO/eHafTSVpaWvBVq1Yt6tSpE5yJyel04nA4+O2339i9e3ex6yxJ+Z/JmjVrgi0g5VFqaip5eXnB91lZWSGJndvt5sCBAyHH7Nmzp8j3ycnJmObhGyjVoToqWh0ZJTgE4M8atY9f6Di8vySFvC9Pn5XqUB0nUoeUD2pBqGTq1atHx44di1X2vPPOo0mTJkyfPp0777yTyZMnExERUaBcVFQUWVlZBbbXrl2bV155BQg8TT+6haIo8fHxREdHh2xLSkrC7/czd+5c5s6dW+hx+a0Ydrudu+++m+eee47BgwfTqFEjOnToQM+ePTn//POLHcepSExM5MYbb2T69On079+fs846i/POO4/evXvTsmXLUomhOI4ctwEUSPYcDgdVq1YN2ZaYmFjk+6Nbm1SH6qhodTSK87IpjRLRa9Nvp3wO2w29Qt6Xp89KdaiOE6njdFIXo+JTgiBFuv322zEMg2nTpnHHHXfw4osvFkgSGjduzNq1a9m1a1dIN6Pw8PBgMmK1Wk+o3qK6IV188cXH7L/vdDqDPw8bNoyePXuycuVK1qxZw+LFi/nggw/o06cPTz75JECRsyr5fL4TirkwY8eOZfDgwaxcuZJ169Yxd+5cZs6cyfXXX88dd9xxyucXkbKx7AqDhm+YuI83K1GRTNrYthNfPxtzCyc/v0rVKHiqZMZViYiAuhhJMdx2223ceOONrFu3jnHjxpGTkxOyv1evwJOrTz/99LTGUadOHQzDwOv10rFjx0Jfbdu2DTmmWrVqDBkyhP/85z/Mnz+ffv36sWjRIn7//XeAYNep9PT0AvXt2rWrWHEdb+rWOnXqcOWVV/LUU0+xYMEC2rdvz4wZM8p1tyMRKVqtaCt5d9v48RqD8e2gaUwxD/T7GdoAPr8Mdo6C2yIWs+rKs/EemA7/ufLEgri6CyS9BikzTjB6kcrJbxT9ksOUIEixjB07lptuuon169dz++23k52dHdw3ZMgQGjRowMyZM/nmm29OWwxxcXF06dKFJUuW8OuvvxbYb5omBw8eBAKzNblcrpD9VquVpk2bApCRkQFArVq1sFqt/PjjjyFl169fX2gdhQkPDwcKJhlZWVl4vd6QbU6nMzgTVH4MInLmOi/RyvMX2dgwupgN8hYLHw6zMbCxjepHNsZGh8PD/3dilc++B+pXrIUnRaR8UBejSuavv/5i/vz5he7r2bNnoWMM8o0ZMwbDMHjzzTcZN24cL774IlFRUYSFhTF58mTGjx/Pfffdx7nnnkunTp2oWrUq2dnZJCUlsWjRIqxWa8jMQyfj/vvv5+abb2bUqFEMHDiQZs2a4ff72bVrF8uXL2fAgAHccsstbNu2jdGjR3PhhRfSuHFjoqOjSUpK4sMPP6R27dq0a9cOgIiICAYNGsSnn37Kgw8+yLnnnsuOHTv47LPPaNq0KRs2bDhuTK1bt+aDDz7gqaeeomvXrthsNlq1asXGjRv573//S69evahfvz4RERH8+eefzJ07l1atWhU6ZayIVGw3nn2cAgsfhP5PHP9EdeNLJB6RysSvhdKKTQlCJfPll1/y5ZeFz7f9ySefFJkgANx6660YhsEbb7zBuHHjeOmll4iKiqJOnTrMnDmTefPmsXjxYmbNmkVWVhbh4eHUrVuXSy+9lEsvvfSUb4pr1qzJrFmzeOedd1i2bBkLFizA4XBQo0YNunXrRp8+fQCoUaMGgwcPZs2aNSxduhSPx0NCQgKXXXYZI0aMCBnjcPfdd2OaJkuXLmXZsmW0aNGC559/nk8++aRYCUK/fv34+++/+eqrr1i8eDF+v59///vftG/fngsvvJA1a9awcOFCfD4fNWvWZOTIkVx77bWn9DmIyJnprQHH+drt16Ho/fnWTT7lWEREjsUwj5yvSkRERE6K8az3uGXMew8nCB6Ph2nTpgEwcuRI7Hb7oRNdfvzKzI9PKkaRyuzKEUlF7n/vnQalEseZQGMQRERESkDbKscvIyJlxzSMIl9ymBIEERGREvB/zUroRE0LX7VeRKS0KEEQEREpAa1ObQ6Gw1Y8XkInEpEjaZrT4lOCICIiUgIGNbFBSQzrq3Gcvkr3X3bqdYiIFEGzGImIiJSCqJJ6JPfkdSV0IpHKxa9xBsWmFgQREZFScF5JdUESETnNlCCIiIiUgoVXnMDTy88eKHz7/rdLJhiRSsiPUeRLDlOCICIiUkJsRXRhcNisxT/RJefBN4+C7dD5WtQKrH1QLe7UAhQRKQaNQRARESkhefdYsT7nK5mT9WwNno9K5lwiIidALQgiIiIlxGIYXHNWwe2uO9V9QaSs+YyiX3KYWhBERERK0KzBNmaaJp9v8tE6ARrE6atWRM4s+qslIiJSwgzDYFBTfcWKlCea5rT41MVIRERERESC9HhDRERERCo8vxoQik0tCCIiIiIiEqQEQUREREREgtTFSEREpJww/X6SWzxD2IZd5BmRRM4dSfSgQuZNFZETptWSi08tCCIiIuXEQevtWDekk0F1XGYkuYPf4MD9X5d1WCJSyRimaZplHYSIiEhF9/LDm/hus4/d0ZGB55heLx3cv1N3s4Hfa8PpcdH7j1/I9UQD4MOCBZMYDtDQfLRMYxepCPqM3l3k/kWv1yqlSMo/tSCIiIicZvPf3cnCHQa7YqOpm5NHnZw8avjgb18TvDjx223kRkSx4JyOuMMshOMmEhcAuUSVcfQiUtkoQRARETnNXv4qj/UJ8bROOUhiVjaJWdnE5ObS8sBByF+8yTTx2q1sqFWTeLaRwDaqsA8XYWUbvEgF4TeKfslhGqQsIiJymv0VE0XXXSlEeH3BbXFuD167HY/NiomB1e/D5vESlZfNQergw4aTPOqyHf/eTCw1osvwCkSkMlGCICIichpl5nrJsNmI8vsK7KuSnk3NHSlgmPgsFjLjIkhIySP7ULciF2F4seNL/A81/RNLO3SRCsWnWYyKTV2MRERETpMtqT5qP+0itWYMf8WFjiWITs+m9s59ZMc6yY4NxxXloPbeVMLzPCHlsgnHRPOJiEjpUYIgIiJymnR9Jp3MSCfOPA85hpV94WF4LIGv3sjUDLKjww6PQTAMsBT+tewzlCCISOlRgiAiInKaJGbn4fT5uXRjMu0ysrEZBplhThbVrMbfsZGYltAuD6kxEXisR381G+y3Vim9oEUqKJ9R9EsOU4IgIiJyGjzzv1RSHXba7jlIlDd0/MFZ2bnsT4jD8Ie2DHgtBn/XrYb/iC5FdnIxfWFkb0orjbBFRJQgSNEGDRrE6NGjS/y8n332GR06dGD16tUlfu7ybOrUqXTo0IHdu4terEVEzkyrd3m48WMX09bksfjrdDruTqXV3nQsfhPjiHVJnX6TVbWrkxoVGZxeMSonjw4bdnJOUjI2TAxMDPzUYSOfdqzNlEsWl9FViVQMfsMo8iWHaRajSsjlcvHxxx+zZMkStmzZQnZ2NrGxsTRv3pw+ffpw8cUXY7NVjF+Nd999l+joaAYNGlTWoYhIBeb2+uk1dgthhGMaBqsinIRFRRDvzsKWP3uRCT7TxLQYbI1wcs6BdPwRTjIinFi8Xtpv2EG4OzBA2QAMTBqyjijSOGf3PupkZ/F9nWfptOMeDN3MiMhpVDHuAqXYduzYwZ133sn27ds5//zzueGGG4iLiyM1NZUff/yRRx99lC1btnDnnXeWdagl4n//+x+JiYlKEETktPnXw2v5JL0Gtc1w3FYLq2rH4bJZAfilehz9t+6lTlZgVWSraZJss7HXYnBx8v7gOew+k0iXu8C5s4klijR67tqI02vFaxjsDrufmMaxRP/xYOlcoEgF4VNiXWxKECoRl8vFXXfdxa5du5g4cSK9evUK2X/DDTfw+++/88cff5RRhGeW7OxsIiMjyzoMESllOW4/4XaDax5OInm/hao5QPUwcLnYHhMWTA4AfBaDNTXiqJOVHNxWx5WHzesNOafbbiXPbsPpCWy34sWOl900ADzEel14icRm+ol25/FdloMLjLFYq0Zh+XY8Yc0SS+HKRaSyUIJQiXz66ads27aNESNGFEgO8rVs2ZKWLVsW2J6UlMSkSZP4+eefMQyDjh078o9//INq1aqFlNu9ezdTpkzhhx9+IDMzk+rVq9O3b19uuukmwsLCjhuj2+1m1qxZLFy4kJ07d+JwOGjXrh233HILzZs3D5bz+/289957zJs3j927d2MYBlWrVqVt27Y8+OCD2Gw2OnToAMCePXuCPwPMmzePWrVqAfDHH3/w9ttv8/PPP5OTk0NiYiIDBw5kxIgRId2sRo8ezZ49e5gyZQovvvgiq1evJiMjIziGYuPGjUydOpWff/6Z3NxcateuzSWXXMK1116L1Xr4ZkGkokvONnnnN5NUl58Iu0GmG3rWNbikceFD3hZs8bN4u0mzndu4dt237GnagJktOmJardSMhE1pcE6sl6vWf8fCjV6WNGhBZq3qRGzaSfd9WznvnHg+3W7B9eNmFtZtyW8161LdcNFo7x4Stu2ifso+ZpzXkx3xVYn0urlrxXxa79lOq7RkGu/bjZHnZW9kNE9eeBkANbLSqZ+6nws3/0rV3Gxy7E58Hg9/1WmIxTRZ1rgls9p2ZXdcVdxh1QlL9JPtqA4WCxurR2Hx+AtcY5bj8N8S49DgY6899O+CabHwR5PanPPnNpy4iSAPACceMqmDkz0YGNjwYQO67UgCPLgP5GBv/ihufICJBS+ZTtiUkEBGdDRdHRk44yKgRR1oUhNuuBCqakVmESmaEoRKZMmSJQBcdtllJ3Tc/v37ueWWW+jZsyd33HEHGzdu5OOPPyY7O5tXXnklWG7Pnj2MGDGCrKwshg0bRr169VizZg3Tpk1j/fr1vPrqq0WObfB6vYwbN45ffvmFAQMG8H//939kZWXxySefcNNNN/HGG29w9tlnA/D222/z2muv0a1bN4YOHYrFYmH37t0sX74ct9uNzWbjscce4/nnnycuLo4bb7wxWE98fDwAK1eu5L777qNu3bpce+21xMTE8OuvvzJ16lQ2bNjA008/HRJfTk4Ot9xyC23atGHs2LGkpqYCgSRj9OjR2Gw2hg8fTtWqVVmxYgUvvfQSGzdu5PHHHz+hz1vkTLUjw6TDLB/7cvK3BG6Gn1ttcm8Hk2d6ht4UP7zSx39X5Q/crcfLfh+bUxLJ/tESPBbgi7cm8kDjljzbczCkE3hRjxfj63Hl3JVcte5bLhtxH/5DawjsNx2EuVO4df0qBt78YHCdAbfNwe8JdXjkqw9D4qiZncmoHxfTY+xjpEYGbp5b7N3J8lf/TbWcTEyg6/aNAGypVpM/a9bBNAJ15TgITPeR33XBYgFf6MxEDdKzwQwMOrYcGqicZ7WSZbcRdajFANPkQHQkP5zdgIv++gOOyDMc+NgdVpX6rpQj1oG1YOAgElfI2rB+LMTnZXDeziwANlStwVnrk2DZoZbhlxbAmolKEqRS8h6/iByiBKES2bx5M5GRkdSpU+eEjtuxYwdPPvkkffr0CW6zWCzMmTOHpKQkGjRoAMArr7zCwYMHmTx5Ml27dgVg+PDhvPDCC8ycOZPPP/+cIUOGHLOe999/nzVr1vDSSy/RuXPn4PZhw4ZxxRVXMHnyZF5//XUAvvnmGxo2bMikSZNCzjFu3LjgzwMGDGDKlClUqVKFAQMGhJTLy8vjP//5D61atWLKlCnBxGXo0KE0bdqUSZMmsXr16pCWh/T0dIYOHcrYsWNDzvXss8/i8XiYNm0aTZs2BeCKK67ggQceYOHChQwePJjzzz+/yM9YpCJ4dZ3/iOQg1Is/mzzQ0aRKeOB2NtNt8tzq0BvpX2o1LHDc+ds30mnbBoaMuK/Q875/zgX8lVArmBwAYBjUTT/AhH7/d/jG/ZA5bTrx1gcOojyh/f1j83KDyQHAnzXq8HKX/kxYNCfkBvxffa8IJgdAaHIAYDHANMEPhmlSOzOXZimZWE1/8Dy5FoPOO5KxmCZ+w8Di8RKVlYPFNHE7HVjNgq0Q1VzZHN172qRg66SBBT8GlkMJ1lkH9oYW2LYfpi2Bey8tcKyISD5Nc1qJZGVlnVSf+YSEhJDkAAjeOO/YsQMIdPlZvnw5zZo1CyYH+W644QYsFgtLly4tsp4FCxbQoEEDWrRoQVpaWvDl9Xrp2LEj69evx+UKDPSLiopi3759rFu37oSvB+CHH37gwIEDDBo0iKysrJD6unTpEixztOuuuy7kfWpqKr/88gvdu3cPJgcAhmEEWy2++eabk4qxtKSmppKXlxd8n5WVRWZmZvC92+3mwIEDIcfs2bOnyPfJycmYR0zpqDoqRx3J2RyT2wc7DhwusD/Tg6sYj/NqZKZzMCIKzzFaH02LhZTImIL1WW2khRf8e2daLHitBc8VnecqsG1D1ZoFtu2KOWrBssIWOLYYYEDvLftomZJNltPJ9qhIUsKcbI+KoFpG4Om+z2rFNAxMmxVXRFjwVLtj446OmhSqsJvq5OI8TuVAgVTiKMlpZ9TvleqoXHWcTj7DKPIlh6kFoRKJiooiO7uIb/BjqF27doFtsbGxQOCpOsDBgwfJycmhUaNGhZatVq0au3btKrKerVu3kpeXR+/evY9ZJi0tjZo1a3Lbbbdx7733cvPNN5OQkMC5555L165dueiii7Db7ce9pq1btwLw2GOPHbPM0X/U4uPjiY4ObZbPX8+gsOtu2LAhFovluNdd1qpUCb3hiYqKCnnvcDioWrVqyLbExMQi39esGXpjpToqRx3DzvIz/ffCb1rbVodz6hyup1FVB+fX9PLj4bG72L0ePLbQf79LmrQiPieLc3Ynsb5WgwLnrXswhWvXLufJiy4P2W7z+bj5h8X885LQpL5B6l7iXAWbOX6rWbfAth5JfxbYNuSPn5jT5nALZ35rAUeuiOwzcXh81MrOJTkqkKTYzED3ojiXG4thkBURDoaB4TcJz8vDtFgwMYjMzuGXuvWIcruIy8khkBzEcpBAErSdWjRjC/GkY8VdSKtCoA0hn9tixeEPXaSNoZ3OqN8r1VG56pDyQQlCJdK4cWPWrl3Lzp07T6ibkcVy7IamI58klIQmTZowfvz4Y+7PHz/Qpk0bPv30U77//ntWr17NmjVrWLhwIW+99RZvvvlmMIE5Xtx33nknZ511VqFlEhISQt4XZ5C1SGU2sLGFF3vBxJ/8pOZCpB0y3HBhXYNXexf8OzJnsJWxX/v5OslP8/R9TPzwLVZ2OJ8p7Xris9mIc8KuzDDuvfcBZi75kH+c3YclTVpisxh4fCZdt/3N+I3fkpLu5bZvF/Je2wtw2exkO8JY3rA5HXZs4rqfvuGDtl1x22xE5eXy8sdvkRoeSboznAZpKUDgOfwPdRrRMnkHv9esi9Xn44bVS7n5h8XBZ/TGoXKT505nS3x11tQ54qFAmguc1kCSYLeCGViQKcbtwcjKxmcxiPEcbi7JCg/DC0R7fZgWA5fTQWSuC4/TDtmBlgWb4SUcF/uJCyYHgVgt7CCR6uzFwMQ8FFd+fBay8Fis2P0+NlepDpg0Tk8JjI2oUxX+/X/QuVkJ/l8XOXN41UhQbEoQKpFevXqxdu1a5s6dy2233Vai546PjycyMpItW7YU2JeRkUFKSsoxb8Tz1a1bl4MHD3LeeecVmZTki4iI4KKLLuKiiy4CYM6cOTz99NPMnTuX66+/HuCYiwnVq1cPgPDwcDp27Hjcuo4lfzakwq47KSkJv99faAuMSEU1rr2Fce2L13u1XozB55dbAStQGx59hL5AwXa9s+Gxs1lQYPs5h14wEniZQPIf+HcfD1wHpslrnsBtfoQjBh76FxgGweeepokB3J3r5u48N8lJe3GmpxO7dyeZwy/AqFmFpE5tcL7/LXn1Eli8zU7nHdtotTudvZGRLGzUkFo5aez2x4LfDGRFDhteq4XfEmI4Z186HqslZJyCabHwZfUqJIc5aJeWRfuD6UTkgtXvJyrLRcO9e6maHeim4aJgi2i2EU66zUmEx8ufVWuwJT6aC3J2UL1NApYOTbDc3h/sFhpXKdj1SkSkOJQgVCJDhgxhzpw5zJw5k5YtW9KzZ88CZf78809+++03hg8ffkLntlgsdOvWjYULF/Ldd99xwQUXBPdNnz4dv99faH1HGjhwIC+88AKzZ88u0NcfAl1+8psq09LSiIuLC9mfPw1qRkZGcFt4eHjI+3ydO3emSpUqTJ8+nT59+hRocXC5XPh8vuOO2ahSpQpt2rRh+fLlbNq0iSZNmgCBm5Rp06YBcOGFFxZ5DhEpOQUeChgGEQ4j5P3R+wGMCCdEOEmMjwZqQ8+ziTtU5ByAq849/PMR5kz5jde2w4Vb/uCzJu3IcFvAYQMLfF+7Cq33pRWsE+h8MIN3a1dnTXw0UW4PtfcfoNr+TOomHcTqsbCNWtjw4inka7qKmc7m6NrEvzOMcy9pyrnF/GxEKjvv8cbnSJAShEokLCyMyZMnc+edd3LvvffSqVMnOnbsSGxsLAcPHmTNmjV8//33wafvJ+q2227jhx9+4N5772XYsGHUrVuXtWvXsmjRItq3b88ll1xS5PFXXXUVP/zwAy+88AI//fQT5513HpGRkSQnJ/PTTz/hcDiYOnUqEJjZqHXr1rRs2ZKEhARSUlL45JNPsNvt9O3bN3jO1q1bM3fuXKZMmULDhg0xDIPu3bsTHh7Oo48+yr333svQoUMZPHgwdevWJTMzk6SkJL755hueeeaZkFmMjuXee+9l9OjRjBo1KjjN6cqVK/n+++/p37+/ZjASqcCGj2nF8Fv8PPG4lwEff8BXzVrxftvzcRt2nH6Tg2EOwnwmjiO6Y5rA5ohwbKZJhNvDedt2Eub2kBUbxp+ta9H8t93Y3T682NlUPZ7PWjfh2hV/EO72gtPFukFNuXZmP+xhxx9vJSJyMpQgVDJ169bl3Xff5aOPPmLJkiW8/fbb5OTkEBsbS4sWLZgwYQL9+/c/qXMnJiYyffp0XnvtNRYsWEBmZiY1atRg5MiR3HTTTUWugQBgs9mYPHkyH374IfPnzw8mAwkJCbRs2TIkwbj22mv59ttvef/998nKyqJKlSq0atWKkSNHhnRlGjt2LOnp6cyZM4fMzExM02TevHmEh4fTuXNn3nnnHd555x0WLFjAwYMHiYmJoU6dOlxzzTUhsxIV5eyzz+btt99m6tSpfPjhh8GF0saNG8e11157Ep+kiJxRLBYefKQt345syeevZ1LtYDpWj5VIi4X5zerQfcMeano8WAiMZ14TF82P8YHuPwfDnLzc7mwe+PEXnH4/XruV/dVj4OB+Pm7XklkXtCbW5eKO9QvJ9Ydx0YF7yvRSRaRyMMySHmUqIiIi9LxjJ3/Hx5Kb6+XSnSnYTZM8i4XZtRMwj+p2dN0fm2i/P7D4YsK+NOptPUh2lI2D0U7OT/6THVUjaDS5P/WuaVcWlyJSITQZt7/I/ZteSihyf2WidRBEREROg/f/VZ06B7Ow2K3stVmI8HjY47AXunrBkQlDdGouuTiwZUHbPbuINLMJz/MqORCRUqMuRiIiIqdBjQQHuXkeOuam4bdaWR0bzcaYiAKDlqPz3LRKOYAjz0OVPdmEpQfWMfBjwWP4yDQTqZqZVRaXIFKheLQYWrGpBUFEROQ0eWZoJAmZOZg2CwfDHaSEOUMWOm6Qnsmda38nIs9H4/X7qLI3dDHL32s2JiU8EjvuUo5cRCozJQgiIiKnycV9q3J+/xj2hjn4K+bQtMmGEVhUzWIQ5/aQkJuHaTHIiA9djNFvgbSqEfxdOxEn2YWcXUROhOc4LzlMCYKIiMhpdPsNtWiRmlHoegjVc3KDP++rHYMvDKqQQQP20MC/l4T0DDwOC5FfjyvNkEWkklOCICIicpr5DOiSko7d7w9ui/Z4aZaRg9ewEJOWS5PN+zjLtZv67CWeLKqSQecdf1MjLY3oi4o37bKISEnQIGUREZHTbP851Wj1414Sc91sjwjDZprUcrnZXzWeszfuIi4li7C8PKKO6krkwEvLPTvLKGqRiiVHg5SLTS0IIiIip9nC8fEsqx6P3++l9cFUmmZkEOnKxJqeTlxWLq4wG1nRtkK/lG2mr9TjFZHKTQmCiIjIaRZmM/j95Rq0vyKRv2rEcbBxLP+dchbdL/mJjEfTuXzrZfT4dgguHCHHmUBOeETZBC1SweQaRb/kMHUxEhERKQUWw+ChQVE8NCgKAI/n8LwphtUg6uwqZDzRh+wHFxOGGy8WMi0RNDtwVxlFLCKVlRIEERGRcqLWA53hgc5lHYZIheRGzQTFpS5GIiIiIiISpBYEEREREan41IBQbGpBEBERERGRICUIIiIiIiISpC5GIiIiIlLxaaG0YlOCICIiUsqm/mcdn/5mJy28N2HuPHr1yqZJk7iyDktEBFAXIxERkVL1+iNrmLkxio3Vq7M/OpodVasx7KmMsg5LRCRICYKIiEgp+uXbTJJjY0O2ZYWH8+yUXWUUkYhIKCUIIiIipSg9PLzQ7d98n1rKkYhUMoZR9EuClCCIiIiUon1RUQU3miYuTdIuIuWEEgQREZFStDMuBvPojYZJbp4SBBEpH5QgiIiIlIL0fbmMH7qaHGdYgbYCPxYMh6NM4hKpNIzjvCRI05yKiIicZk8P+h5PLmRHR2D1mxx9N2IBquRm4nd7WXvdCqr2rkXDUc3KJFYRESUIIiIip1FOhhtPbiAlqJuZAwXzAwASsrJZ4pwFGKR9sI3No7+ne/qVOGLCSjlikYpKzQTFpS5GIiIip9HM29cGb0ssHOMWxTRp//vBI/YG+jwsjf1fKUQoIhJKCYKIiMhptD/JFfzZDwUGKFfJyaBd8mbWt6qK76hvZUNf0yIlR2MQik1djERERE6jyLw8chxOIPBUbmDSThbVq4XbamXM6vmM+/FzHH4fOVYnf/nbk0r1kOMz/kwjpkVc6QcuIpWWEgSRYlq9ejW33npryDaHw0FCQgLt27fn+uuvp2HDhsF9HTp0KFC2Ro0adOvWjZtuuonYo1ZSFZGKKeeodQ8iPR76Je1ivyOPe1bNDW6P8OVxNj/zLX0wD7UceGzw2/XfcMFPl5VqzCIVkloJik0JgsgJ6tevH126dAEgLy+PjRs3MnfuXJYsWcJ7771HYmJisOxZZ53FtddeC0BGRgbffvst7777Lj/88AOzZs3CbreXyTWISGkK3JWk2Wy8flZDMuw2ME2e+n5BgZJhuHDiwkUEAG6njT0/p5VmsCIiShBETlTz5s0ZMGBAyLZ69erx7LPPsmTJEq655prg9urVq4eUvfLKKxk/fjwrVqxg2bJl9O7du9TiFpHS8fOvacy46Qci3BayIpz81TiRBtm5fFyrJjl2G7U8XsJNk1lte9LyQBKN0vfwz4HXsq5Wfc5L2sqwz3dQPT03cDLTjxmmr2oRKV36qyNSAqpVqwZQrBaBTp06sWLFCnbs2HG6wxKRk2Ga8MYieP9b2J8OFgNy3JDrxmyQQK61Gv7lG3GaBzHwHBrfaHLQGslvMeeQ64+hsy2ah67swaZa1Q6fN89LrYM5hJuBYcq5Njt39bmJrKpW9sbEAbCzbTXW1WjC68/PB8DhNpnXpRl3PJBKRoQdC2A1fVTLyuTqn1fwd43afNiuCxYDWmfuZcpPn3B+TQPuHgwt6sBbX8Pcn6BWPNx7KTStVbqfpUi5oj5GxaUEQeQEuVwu0tLSgj9v3ryZV199lbi4OHr16nXc4/MTg7i4uNMYpYictAdmwdOfFL5v5wH8JBDJ/gK3GuuiOpJJlUNzmRrsrBY6zshitwaTg3w5EQ72xkSHbNuaGM+WxDga7UnD7jWxO/zsqRoTUiYtIoonel/O8HXf4TPBZ8LayBoMOvcq/nrmLuI/+A5G9ISXj+jG9OH38PsLUDP+BD4MEamMlCCInKCpU6cyderUkG2NGjXizTffDLYk5PN6vcFkIiMjgxUrVvDhhx8SFRVFjx49SitkESkuvx9eKTg2IJ8BRJBaIDnYa00g01Il+P5gVBguR2iLot8ATJNcuxW7z4/NBIt59KSnAeEuT/Dnjht3M7OHm1ynI6SM12rj/XZdQ7bti45lTptOjP5hMbzxdehJU7Ng9nK459JjXp9IhaYGhGLTBMsiJ+iyyy7jlVde4ZVXXmHSpEmMGzeOtLQ07rzzTvbs2RNSdtWqVfTu3ZvevXtz+eWXM2nSJBo1asTLL79MlSpVjlFD6UpNTSUvLy/4Pisri8zMzOB7t9vNgQMHQo45+jqPfp+cnIx5xI2P6lAdZ0wde5IxvX5OlNviDHmfkJ5DjbSs0EI+k21xEeyODmdbbAQHnXaqZ+VRI8sVUqzHum0kHswGIDvKhmk1cHh9hdbrL+SGx20NPPszfYVch9sLnEH/P1RHpatDygfDNI/x+EJEQuRPc3rnnXdy3XXXhez77bffuOGGG+jTpw9PPvkkEJjmtFWrVowZMwYITHOamJhIzZo1Sz12ETkBt74GU7865u5sqhBJasg2P7Ag/hI8hAW3fd+0Fs8M6oRpseB0ezE9PtxW6+GDTJPLd+wj0ufn76rRpIY7OHfjTm75ZBX4LRyMCeNgVScem5W7R/Qt0IJg+P30+2sdC89uH9wW7cph49N3UsOTA8M6wewVhw+IcAa6GDUIXWdBpLIw/plZ5H7z6egi91cm6mIkUgJatWpFVFQUq1evDtkeFxdHx44dyygqETkpL94EtaoEBimnZweWPnZ7wO3FrBGPSTWyNtoI4yAGXoxDayO3y/yBtbEd8JsO1tZPZEaPNpiGQftd++m0cx+vntMstB7D4IDTQVxWLq32ZwDQb9WfOP0+cg0L1jAfOQ4bH3ZqiQ8Dq9eLBROr30/1rAxu/HExKZExYJoYBjTJSGHK0veo0aMJ3H85dGwKzevA3B+hdlV4cKiSAxEpFiUIIiXE5/Ph8XiOX1BEyjeHHR75v8DrKAYQVfAIAGodes164XfqTV7DvV/O57t6zanv8RPl9xPu8ZJrD/3aDXN7MAGvYVBlTyoxybm4LTYS/Fkk7vOTYbPj9/jJeyj8qNoigcAaKy8FtyUC40OLPTw88BIROQFKEERKwKpVq8jNzeWcc84p61BEpIxde2dLuLMlAGPS3UwcuoZFTWrTIDuHDTFR+CwWME3iXR42RUWy2TQx8TNv7kzwxYWcq+3uvVzx1WrgrNK/EJGKRoOUi00JgsgJ+uuvv5g/PzBHudvtZsuWLXzyySfYbLbgeAMREYCIWAceYEPVOFIiwwJrLGBSIzWHKHdg4LFpGLitNt4590JGLPs55HgLJk1y3aUfuIhUakoQRE7Ql19+yZdffgmAxWIhNjaWTp06ccMNN9CyZcsyjk5EyhsbUD07N5AgGAYOrz+YHORz+EzW1UrgOkKnF8zFTutXLyjNcEUqLrUgFJsSBJFi6tChQ4FByEU5kbIiUnE5TJOLtu5mW1wU2Q47HGPuwHO27+EA0USTiw0/LuxkEkaH69W9SERKlxIEERGR06hqNQMOuLj7+9/YUDUWrwE/V6ka8jDTBNbXqklfdpLK4akWT3xFBhE5NjUhFJcWShMRETmNrnzhHDBNnD4/rfcdpH5adoHbFAPIjAgntHnBpJfr6tILVETkECUIIiIip1FczQiceVmHBihDvCuPCI83pIxhmly0ZQttv+qDNcFBtavr0du8AZvTXhYhi0glpwRBRETkNLt3ZV/6j6sD7lxabfoDi8NKStUIkhMicTut1PJ4sfp8VOtTmwv3XUXb2ReWdcgiFY9xnJcEaQyCiIhIKTh3SD3OHVKP3lfXID7nAM9+PId6qWksbt6U6Z0uYKduUESknFCCICIiUorSYsP55I0ZOH2BqU6H/vwrcdm5fJ+YUMaRiVRwhrLw4lIXIxERkVLU++9NweQg34UbN2Gx6StZRMoH/TUSEREpRfY8T4Ft2XYHta85pwyiEREpSAmCiIhIKcprVp3NVaqEbPu4VWvuG5lYRhGJiITSGAQREZFSNPHt8xhzvYWGv+8gzuXi51q1uOXVtmUdlkjFpyEIxaYEQUREpJRNmXEuHk8bpk2bRjsyaNmgc1mHJCISpC5GIiIiIiISpBYEEREREakE1MeouNSCICIiIiIiQWpBEBEREZGKTw0IxaYWBBERERERCTJM0zTLOggREZHKZMZ6LyMWhX79mvfayygakcrBeCSnyP3mYxGlFEn5pxYEERGRUjZiEQT6Oxx+Gc96yzQmEZF8ShBERERERCRIg5RFREREpBLQKOXiUguCiIiIiIgEqQVBRERERCo+NSAUm1oQREREREQkSAmCiIiIiIgEKUEQEREREZEgjUEQEREpRY203oFI2dAYhGJTC4KIiEgp2lrWAYiIHIcSBBERERERCVIXozPE6tWrufXWW4+5f9q0abRu3RqADh06hOyzWq1UqVKFpk2bcvXVV9OpU6eQ/SkpKcyaNYvvvvuO5ORkDMOgSpUqNG/enD59+tCrV6+Sv6ByYtGiRXz33Xf89ddfbNmyBZ/Px7x586hVq1aBssuWLWPp0qX88ssv7N27l6ioKBo1asS1117LBRdcUOj5P//8c9599122bdtGZGQk3bp14/bbbyc+Pv50X5qIiIgcyVAfo+JSgnCG6devH126dCmwvW7duiHvzzrrLK699loAvF4ve/bs4dNPP+X2229n4sSJwZv+PXv2MGLECLKzs+nfvz/Dhg0DYMeOHaxZs4bPPvusQicIc+bM4ffff6dp06bUqVOHbdu2HbPsE088QWRkJD169KB+/fqkp6fz2WefcccddzBmzBhuuummkPKzZ89m0qRJtG/fnnvuuYd9+/Yxe/Zsfv31V9555x3Cw8NP9+WJyJnENMs6AhERQAnCGad58+YMGDDguOWqV69eoFyvXr246qqr+Pzzz4M3/TNnziQ1NZVnn32Wnj17FjhPSkpKicRdFnw+Hx6Ph7CwsGOWeeyxx6hWrRo2m42nn366yATh8ccf57zzzgvZdsUVV3D11VfzxhtvMHz4cGJiYgBIS0tjypQpnH322UyZMgWr1QrA2Wefzd13383//vc/brzxxhK4ShE542RlQVRUWUchInJMGoNQiSQkJABgt9uD23bs2AHA+eefX+gx1apVK9a5vV4v06dPZ/jw4VxwwQVcdNFF3HvvvWzatClYJjMzkwsuuID77ruv0HO8/PLLdOjQgb///ju4LSsrixdffJEhQ4bQuXNnevfuzYMPPsjOnTtDjv3ss8/o0KEDP/zwA2+++SaXXnopF1xwAYsWLSoy7po1a2KzFS9PPjo5AAgLC6Nbt254vd6Q5GLp0qW4XC6uuOKKYHIA0L17d2rXrs2CBQuKVaeIlHNb98L/PQsNboHhz8DKP6HLA2BcfsyX/9Ebj9laYNqHwYX/CpxHRKSMqAXhDONyuUhLSwvZZrfbiYyMDNnm9XqD5bxeL8nJybz55ptYrVYuvfTSYLk6deoA8Mknn3D11VdjnGT/vH/9618sWrSIjh07MnToUA4cOMCcOXMYOXIkb7zxBs2bNyc6Opru3buzbNky0tPTiY2NDR7v9/tZsGABTZs2pVmzZkAgObjxxhtJTk5m8ODBNGrUiJSUFD788ENuuOEGZs6cSWJiYkgcL7zwAl6vl8suu4zIyEjq169/UtdzIvbt2wdAlSpVgtt+//13ANq0aVOgfOvWrfnyyy/JyckhIiLitMcnIqeJzwf9HoONewLvt+2HuT+Cx1fkYUX9lTW9foylv0PfR+Hvl6Fu8R7SiEgxaAhCsSlBOMNMnTqVqVOnhmzr06cPTz75ZMi2VatW0bt375BtMTExTJw4MWRA7TXXXMP8+fOZNGkS7777Lu3atePss8+mXbt2tGjRolgxrVq1ikWLFtGnTx+eeOKJYJLRp08frrvuOp599lnefPNNAC655BK+/vprvvrqK4YPHx48x+rVq9m7dy9XXXVVcNtrr73Grl27mDZtGmeddVZw+6BBg7jyyiuZOnUqEyZMCInF5XLx7rvvFtmtqCRt2LCBJUuW0K5dO2rXrh3cnt81K7/V5kgJCQmYpsn+/ftLJYERkdPkh42Hk4N8x0kOimQY/F6jDq337oRcN3z0Pdw16NRiFBE5CepidIa57LLLeOWVV0JeRw+OBWjVqlVw/0svvcRDDz1EzZo1efDBB/n++++D5erUqcP//ve/4M36woULef7557nuuuu48sor+fPP4zdzL126FIAbb7wxpAXirLPOolu3bqxbt46DBw8C0KlTJ6pWrcoXX3wRco4vvvgCq9XKxRdfDIBpmixYsIB27dpRvXp10tLSgq/w8HBatWrFqlWrCsQybNiwUksODh48yH333UdYWBgPP/xwyD6XywWAw+EocJzT6QwpU9ZSU1PJy8sLvs/KyiIzMzP43u12c+DAgZBj9uzZU+T75ORkzCO6UKgO1VEh64gu4YkGTJOE7IzD7w+dv0J8VqpDdRSzDikfDNPUtAlngvxpTu+8806uu+66Ist26NCBrl27Mnny5JDtWVlZXH755djtdubOnVto3/uUlBTWrVvHF198wYoVK6hatSoffPBBSHego91xxx2sWrWK7777rsA5X331Vd5++22mT59Oq1atAJg0aRKzZ8/mo48+on79+uTm5tKvXz/atWvHCy+8AAT+6PTt27fI67RYLPz4449AYAzCo48+yuTJk+natWuRxx3L008/zZw5c445zemR0tPTGTNmDNu2bWPy5MkFxieMHz+eFStWsHLlygIJywsvvMDMmTOD1y8iZ7D+j8GX6w6/rxYNKZnHLJ7PmPh+wSkXTRPvP6/EappQPwF+nVzySYhIJWY8llfkfvMRZylFUv6pi1ElEhUVRevWrVm2bBnbt2+nUaNGBcpUq1aN3r1707t3bx5++GEWLlzIt99+W6yZk4pr4MCBzJ49my+++IKxY8eyZMkScnJyuOSSS4Jl8vPW888/nxEjRhT73KXRepCens7YsWNJSkriueeeK3Twcv7g7v379xeYgnb//v0YhlFo9yMROcN88k94fRH8uBHOawI39IIXv4DJ8+BgTqGHFPVUznp2HbisI9w+QMmBiJQZJQiVjNfrBSAnp/AvriO1atWKhQsXBgfhHkvt2rXx+/1s3bqVpk2bhuzbunVrsEy+s846i7POOosFCxYwZswYvvjii+AA5nzx8fFER0eTnZ1Nx44di319p1t+crB161aeeeYZOnfuXGi5li1b8sknn/DLL78USBB+/fVX6tevrwHKIhVBuBPuvCR02yP/F3gdg+VZD8ccLfnbCyUXm4iE0iDlYtMYhErk4MGD/PLLLzidTho2bAgEui4V1hfe7/ezYsUKgEJbGo7Uo0cPILCa85E91jZt2sTy5ctp27ZtgZWDBw4cyJ49e1i4cCGrV6+mT58+wb75EOg+1L9/f37//Xe+/vrrQutNTU0txlWXnIyMDG677Ta2bNnCxIkTC12wLl+PHj1wOp188MEH+HyHBy0uX76cXbt20b9//9IIWUTKJd2liEj5phaECmrfvn3Mnz8fCNzsJycnM3fuXDIzMxk7dmxwWtRZs2axfv16unXrRvPmzYmKiuLAgQMsWbKEP//8MzieoSidOnWiT58+fPXVV2RmZtK1a9fgNKcOh4N77723wDEXX3wxL774Ik899RR+vz+ke1G+2267jfXr1/PAAw+wePFiWrdujd1uZ8+ePXz77be0aNGiwCxGJ2rt2rWsXbsWIDgg+4MPPiDq0CJGN998c0g8f/31F/369SMjIyP4+eZr06ZNcNrY+Ph4xowZw+TJkxk7diz9+vVj//79zJo1iwYNGnD11VefUtwiIiIip4sShApqw4YNPPLII8H3kZGRnHXWWdx+++3069cvuP2mm27i66+/5ueff2bVqlWkp6cTHh5Ow4YNueuuu/i///s/LJbjNzT95z//oVmzZnz++edMnjyZ8PBw2rdvz5gxY2jSpEmB8lWqVOGCCy5gxYoV1KtXr9D1AqKionj77beZNWsWixYtYvny5VitVqpXr07btm0ZMmTIyX04R/jpp5944403QrbNmjUr+PORCUJ+AvHll1/y5ZdfFjjXv//972CCAHDttdcSGxvLu+++y7PPPktkZCS9e/dm3Lhx6l4kIgWd5Do0IiIlTbMYiYiIlCLjWe8x95n36rmdyOliPH6cWYwe1ixG+TQGQUREpBTd17KsIxARKZoSBBERkVI08WK1EohI+aYEQUREREREgpQgiIiIiIhIkNo5RURERKTi00xhxaYWBBERERERCVILgoiIiIhUfGpAKDa1IIiIiIiISJASBBERkTKnNUtFpPxQgiAiIlLKAismm0e8tIqyiJQfShBERETKgPtOmBozjakx03DfWdbRiIgcpscVIiIiIlLxaZBysakFQUREREREgtSCICIiIiKVgJoQikstCCIiIiIiEqQWBBERERGp+NSAUGxqQRARERERkSAlCCIiIiIiEqQEQUREREREgpQgiIiIiIhIkAYpi4iIiEjFp0HKxaYWBBERERERCVKCICIiIiIiQUoQREREREQkSAmCiIiIiIgEaZCyiIiIiFR8GqRcbGpBEBERERGRICUIIiIiIiISpARBREREROQYJkyYQFRUVFmHUao0BkFEREREKj5DgxCKSy0IIiIiIiISpARBRERERCo+4zivk/Trr7/Sr18/IiMjiY2NZdiwYWzfvj24/6abbqJbt27B9ykpKVgsFs4777zgtqysLOx2O3PmzDn5QEqQEgQRERERkZOwY8cOunfvzoEDB5g1axavvfYaa9eupUePHmRmZgLQvXt3fvrpJ1wuFwDLly/H6XTy888/B8t89913eL1eunfvXmbXciSNQRCpxEzTDP5xEpHS5fF4yM3NBSAjIwO73V7GEYmUnejoaIwzcIzApEmT8Hg8fPXVV1SpUgWAdu3acfbZZzN9+nTGjRtH9+7dycvL44cffqBHjx4sX76cyy67jK+++opvv/2W/v37s3z5cs466yxq1KhRxlcUoARBpBLLzMwkNja2rMMQqfTuuuuusg5BpEylp6cTExNzWusw7y35294VK1bQq1evYHIA0Lx5c8455xxWrlzJuHHjaNiwIXXq1GH58uXBBOHWW28lNzeXZcuWBROE8tJ6AEoQRCq16Oho0tPTyzqME5aVlcXAgQP54osvKt3Uc6VFn3Hp0Od8+ukzLh2n+jlHR0efhqhOv4MHD9K2bdsC22vUqEFqamrwfX5ikJGRwfr16+nevTvZ2dl8+OGH5OXl8eOPPzJq1KhSjLxoShBEKjHDME77E5vTwWKxYLVaiYmJ0Rf+aaLPuHTocz799BmXjsr6OVepUoV9+/YV2L53717OOuus4Pvu3btz9913s3TpUqpVq0bz5s3Jzs7mn//8J9988w15eXkhA5nLmgYpi4iIiIichK5du7J48WIOHjwY3Pb333/zyy+/0LVr1+C2/BaD559/PtiVqG3btoSHh/PUU09Rt25dGjRoUNrhH5NaEEREREREiuDz+fjwww8LbL/zzjuZNm0affv25aGHHsLlcvHwww9Tr149brjhhmC55s2bU716dZYtW8aLL74IgNVqpUuXLixYsIBrrrmmtC6lWJQgiMgZx+FwMGrUKBwOR1mHUmHpMy4d+pxPP33GpaOif84ul4vhw4cX2D5z5kyWLVvGvffeyzXXXIPVaqVPnz48//zzBcZVdO/enQ8//DBkMHKPHj1YsGBBuRqgDGCYpmmWdRAiIiIiIlI+aAyCiIiIiIgEKUEQEREREZEgjUEQkQrjzz//ZMSIETidTlasWFHW4VQYPp+PWbNmsXLlSrZs2YJpmjRt2pRbb72Vdu3alXV4Z6SkpCQmTpzIL7/8QmRkJAMGDGDs2LFaTbmEfP3118yfP5+//vqLjIwM6tWrxxVXXMHgwYPPyNV6zwQ5OTkMGzaMffv2MWPGDM4+++yyDklOgRIEEakQTNNk4sSJxMfHk5OTU9bhVCh5eXlMnz6dSy65hBEjRmCxWPjkk0+49dZbefnllznvvPPKOsQzSkZGBrfeeiv16tXjmWeeYd++fUyaNAmXy8U///nPsg6vQpg9ezaJiYncddddxMfH88MPP/Df//6XvXv3Mnr06LIOr0J688038fl8ZR2GlBAlCCJSIcybN4+0tDQGDx7Me++9V9bhVChOp5O5c+eGLKrXsWNHrrjiCt59910lCCfoo48+Ijs7m2eeeYbY2Fgg0Erz9NNPc+ONN5KQkFDGEZ75Jk2aRFxcXPD9eeedR3p6OrNnz+bmm2/GYlEP65KUlJTEnDlzuOuuu3jyySfLOhwpAfoXIiJnvMzMTF5++WXuvvtubDY99yhp+aujHr2tadOm7N+/v4yiOnN99913nH/++cHkAKBPnz74/X5WrVpVhpFVHEcmB/maNWtGdnY2ubm5pR9QBTdx4kSGDh1K/fr1yzoUKSFKEETkjPfqq6/SokWLcrVMfUXn9Xr59ddfadiwYVmHcsZJSkoqsGJqdHQ01apVIykpqUxiqgzWrVtH9erViYyMLOtQKpSvv/6azZs3c/PNN5d1KFKC9KhNRM5of//9N/PmzWP27NllHUqlMmPGDPbv38/VV19d1qGccTIyMgosoASBJCEjI6MMIqr41q1bx1dffcVdd91V1qFUKC6Xi0mTJjF27FiioqLKOhwpQUoQRKRcycrKIiUl5bjlateujc1m4+mnn2bYsGEFnshK0U7kcz56Zp1Vq1YxdepUbr75Zlq0aHG6QhQpEXv37uWBBx6gQ4cOXHnllWUdToXy1ltvUbVqVQYPHlzWoUgJU4IgIuXK119/zeOPP37cch9++CF///03SUlJ/Pe//yUzMxMAt9sNBMYlOBwOnE7naY33THUin/ORyddff/3FP//5T/r378+oUaNOY4QVV0xMDFlZWQW2Z2ZmFhjrIacmMzOTO+64g9jYWCZOnKjBySVoz549zJo1i2eeeSb4+5w/viMnJ4ecnBwiIiLKMkQ5BYZpmmZZByEicjKmTp3KG2+8ccz9I0aMYNy4caUYUcW2Y8cObrrpJpo1a8akSZM0IPwkjRo1itjYWJ599tngtqysLC688EIeeeQRBg0aVIbRVRwul4vbbruN5ORkpk2bRvXq1cs6pApl9erV3Hrrrcfc36pVK6ZPn156AUmJ0l93ETljDRo0iHPPPTdk2+eff86iRYt44YUXqFmzZhlFVvGkpKRw++23U7NmTZ5++mklB6fgggsuYNq0aWRmZgbHInz99ddYLBY6depUxtFVDF6vlwceeICkpCTeeOMNJQenQbNmzXjttddCtm3YsIHnn3+eBx54gJYtW5ZRZFIS9BdeRM5YtWrVolatWiHb1qxZg8VioUOHDmUUVcXjcrm44447SEtL45577mHz5s3BfXa7nebNm5dhdGeeoUOH8v7773PPPfdw4403sm/fPl544QUuv/xyrYFQQp5++mlWrFjBXXfdRXZ2Nr/++mtwX7NmzXA4HGUYXcUQHR19zL+zLVq00N+FM5wSBBERKVJqaiobNmwA4O677w7Zl5iYyGeffVYWYZ2xYmJimDJlCs888wz33HMPkZGRDBkyhLFjx5Z1aBVG/noSkydPLrBv3rx5BR4siEgojUEQEREREZEgDecXEREREZEgJQgiIiIiIhKkBEFERERERIKUIIiIiIiISJASBBERERERCVKCICIiIiIiQUoQREREREQkSAmCiIiIiIgEKUEQEalAbrjhBgzDKOswAPjtt9+w2WwsWrQouG3p0qUYhsH06dPLLjApF6ZPn45hGCxduvSkjtfvUuHWrVuHxWJh2bJlZR2KnMGUIIhIubdlyxZGjx5N8+bNiYiIID4+nhYtWjBixAi++eabkLINGjSgVatWxzxX/g10SkpKofv//PNPDMPAMAxWrFhxzPPkl8l/hYWF0bRpU+6++25SU1NP7kIrmLvvvpsuXbrQp0+fsg6lVCQlJTFhwgTWrVtX1qFIKUlLS2PChAknneScrKJ+19q2bcuQIUO45557ME2zVOOSisNW1gGIiBRl9erV9OjRA7vdzvXXX0/Lli3Jzc1l48aNfPXVV0RHR3PhhReWWH1vvfUW0dHRhIeH8/bbb9OtW7djlm3bti333HMPAKmpqcyfP59JkyaxaNEi1qxZg8PhKLG4zjTff/89ixYt4tNPPw3Z3r17d3Jzc7Hb7WUT2GmUlJTEo48+SoMGDWjbtm1ZhyOlIC0tjUcffRSAnj17llq9x/tdu+uuu+jRowfz589n4MCBpRaXVBxKEESkXHv00UfJyclh3bp1nHPOOQX2Jycnl1hdHo+HmTNnMnz4cGJjY3n99dd58cUXiY6OLrR87dq1ufbaa4Pv77jjDgYNGsTnn3/O3LlzGT58eInFdqZ59dVXqVatGgMGDAjZbrFYCAsLK6OoRCqHbt260aBBA1577TUlCHJS1MVIRMq1jRs3UrVq1UKTA4CaNWuWWF2fffYZ+/btY8SIEdxwww1kZ2fz/vvvn9A5+vXrB8CmTZuOWWbKlCkYhsG8efMK7PP7/dSpUyfkqeBXX33FFVdcQaNGjQgPDycuLo6+ffsWu49xz549adCgQYHtSUlJGIbBhAkTQrabpsmUKVM499xziYiIICoqigsvvLBAd65j8Xq9fPrpp/Tu3btAS0Fh/caP3Pbqq6/SrFkzwsLCaN26NZ9//jkAv/76K/379ycmJoaqVatyxx134PF4Cr3OLVu2cOmllxIbG0tMTAyXXXYZW7ZsCSnr9/v573//S/fu3alZsyYOh4N69eoxZswYDhw4UOh1ffTRR/Ts2ZO4uDgiIiJo1qwZd9xxB263m+nTpwdbskaOHBnselacp8pJSUlcd9111KhRA6fTSePGjXnwwQfJyckJKTdhwgQMw+Dvv//mwQcfpE6dOjidTs455xzmz59/3HrgcL//xYsX89hjj1G/fn3Cw8Pp2LEjq1atAmDZsmV07dqVyMhIEhMT+c9//lPouT799FO6dOlCZGQkUVFRdOnShblz5xZa9o033qB58+Y4nU6aNGnC5MmTj9n9JT09nX/+8580adIEp9NJQkICV111VYH/hyequJ9zUeN4DMPghhtuAAK/tw0bNgQCDzLy/5/n/1s78t/X//73P9q0aUNYWBj16tVjwoQJeL3ekHMX999pcX7XDMOgX79+LFy4kKysrBP8pETUgiAi5Vzjxo35+++/+fjjj7n88suLdYzP5zvmGIO8vLxjHvfWW2/RsGFDunXrhmEYtGvXjrfffpubb7652PFu3LgRgGrVqh2zzJVXXsn48eOZMWMGgwcPDtm3ePFidu3aFey6BIEbgtTUVK6//nrq1KnDrl27ePPNN7nooov45ptviuwGdTKuu+46/ve//zFs2DBGjhxJXl4es2fPpk+fPnz88ccFYj7amjVryMrK4vzzzz+hel955RUOHjzIzTffTFhYGC+++CKXXXYZc+bMYdSoUVx11VUMGTKEr776ipdeeonq1avz8MMPh5wjOzubnj170rFjR5588kk2btzIq6++yqpVq/j555+DCaXb7eaZZ55h6NChXHrppURGRvLTTz/x1ltvsXLlygJdxB566CGeeOIJzj77bMaPH09iYiKbN2/mo48+4rHHHqN79+48+OCDPPHEE4wePTr4/6RGjRpFXvO2bds4//zzSU9PZ+zYsTRt2pSlS5fy5JNP8u2337J48WJsttCv6hEjRmC327n33ntxu91MnjyZIUOGsGHDhkJvMAtz//334/P5uPPOO3G73Tz33HP07duXGTNmcNNNNzF69GiuueYaPvjgAx555BEaNmwY0lr26quvctttt9G8eXMeeeQRIPB7OmTIEKZOncro0aODZSdPnsz48eM555xzeOKJJ8jJyeHZZ5+levXqBeJKD0SabgAADpRJREFUT0/nggsuYPv27dx44420bNmSPXv28Oqrr9KxY0dWr15N/fr1i3WNp/o5H0+LFi2YNGkS48eP57LLLgv+fYqKigopN2/ePLZs2cJtt91GzZo1mTdvHo8++ijbtm1j2rRpJ3wtxf1d69y5M1OnTmXlypX079//hOuRSs4UESnHvvvuO9Nut5uA2bRpU3PkyJHmq6++av7xxx+Flq9fv74JHPe1f//+kON27dplWq1W89///ndw2+TJk02g0LoAs2/fvub+/fvN/fv3mxs2bDCff/550263m7GxsebevXuLvK5hw4aZTqfTTE1NDdl+7bXXmjabLeT4rKysAscnJyebVatWNS+++OKQ7SNGjDCP/tPeo0cPs379/2/v/mOqKv84gL8vIBfvD7ryQ8E0/HkVCAw0fklIpsZWEKTDBcmtLbBgg0qnYmtuZZkups1q2hQNlLQhP5okgoXKGD8cImsG+SNwmGKIQHAldJ7P94++58zDuRe4qEXf7+e1Mb2f8/A85zz3no3nPs/zOV6KOlpaWgiA7JoLCgoIAO3evVtW9u7duzR//nyaNm0aCYIw5LVlZ2cTACouLlYcq6ioIAC0b98+RWzy5MnU3d0txRsbGwkAqVQqOnLkiKyewMBA8vDwUFwnAMrIyJDFxWtavXq1FBMEgW7fvq04vz179hAAOnz4sBSrra0lAPTss89Sf3+/rLwgCFJ/WLq24SQkJBAAKikpkcXXrl1LAGjPnj1SbNOmTQSAXnjhBdl7UFdXRwBow4YNw7a3b98+AkABAQE0MDAgxYuLiwkAOTg40JkzZ6T4wMAAeXh4UEhIiBS7desWabVamjlzJvX09Ejxnp4emjFjBul0Ourq6iIioq6uLtJoNOTt7U1ms1kq29bWRlqtlgBQRUWFFE9PTycnJyc6d+6c7LxbW1tJr9eTyWSSYrb0ty39bOkeEgGQnYOle2jwMTs7O6qvr5figiBQbGwsAaDq6mopbst9OpJrr6ysJAD06aefWi3DmDW8xIgxNqaFhoaivr4eJpMJPT092LdvH1JTU+Hj44OIiAiLyw6mTZuG8vJyiz/Lli2z2M7+/fshCAKSkpKkWGJiIsaNG4fs7GyLv1NWVgZ3d3e4u7vDaDTi3XffhY+PD8rKyix+O3o/k8mEgYEB2RKmvr4+FBYWIioqSvb7Wq1WVqazsxP29vYIDg5GbW3tkO3Y6sCBA9Dr9YiNjcXNmzeln+7ubkRHR6O1tVWaJbGmo6MDAODi4mJT26+99hoee+wx6bW/vz+cnZ0xefJkxexReHg42tvbLS6f2LBhg+x1XFwc5syZI9swrVKpMH78eAB/zTh1d3fj5s2bWLx4MQDI+vXgwYMAgC1btij2T4jLO0ZDEAR89913CAgIUOzVyMzMhJ2dHQoLCxW/l5GRIWvz6aefhk6nG/Z9ud9bb70lmyERv4UODg7GggULpLijoyOCgoJkdZeXl8NsNiM9PR3Ozs5S3NnZGenp6ejr68OJEycA/HWP3L59G2lpadBoNFLZKVOmIDExUXZORISDBw8iIiICjz/+uOzzp9VqERISgrKyshFfo2i0/fywLF26FIGBgdJrlUqFdevWAcAjbdfV1RUA8Pvvvz+yNtj/Ll5ixBgb8/z8/KQ161euXMGpU6ewZ88eVFZW4qWXXlIsB9FqtViyZInFug4cOKCIERGys7Ph7+8PQRBk+wcWLlyI3NxcbNmyRbEEITg4GJs3bwYAqNVqeHl54YknnhjRNYmDgJycHLz55psA/lrjbjabZYMUALh8+TLee+89HD9+HN3d3bJjD/uZB01NTejt7R1yacyNGzdgNBqtHhfPiWxMsThjxgxFbMKECZg6darFOAB0dnbKlnQYDAaL+1K8vb1RVFQEs9ksDbi+/fZbZGVloaGhQbGfoaurS/r/xYsXoVKprO6DGa2Ojg709fXB19dXcczFxQWenp4WB8CW+snV1dXq3glLBtch9qe4pn7wsfvrbmlpAQCL5y3GxPMW/507d66irI+Pj+x1R0cHOjs7pYG3JXZ2tn+vOdp+fli8vb0VMfHaH2W74v03Vp6Lwv5deIDAGPtX8fLyQlJSElatWoVnnnkGVVVVqKurQ3h4+KjrPHXqFC5fvgwAmD17tsUyR48eRWxsrCzm5uZmdSAyHAcHByQkJGDHjh24dOkSZs2ahZycHEyYMEG2xr+vrw8REREwm814++234efnB71eDzs7O2zZsgU//vjjsG1Z+wNh8CZJ4K8/Ktzd3ZGXl2e1vqGeMwFA+uPO1udB2Nvb2xQHbB+EiAoKCrBy5UoEBQXhs88+w9SpU+Hk5IR79+4hKioKgiDIyj/ITMHDZq0/bOmL0fT1oyae/5IlS7B+/fp/7DxsuV/Gcrvi/WdtsMXYUHiAwBj7V1KpVAgODkZVVRV+++23B6orOzsbarUaOTk5Fr+hXL16Nfbu3asYIDwok8mEHTt2ICcnB8nJyTh58iRSUlKgVqulMj/88AOuXbuG7OxsvP7667LfH7xB1xoXFxfU19cr4pa+vZw9ezYuXLiAkJAQxWbLkRIHELYseXlYuru70d7erphFaGpqwsSJE6XZg9zcXDg5OaGiokK29KW5uVlRp9FoxLFjx9DY2DjkxmtbBxDu7u7Q6/U4f/684lhXVxeuX78+Jp+nIM4+nD9/Hs8995zs2M8//ywrI/7b3NxstazI3d0dBoMBf/zxx6gH3pbY2s/i0rhbt27JlslZul9G8p43NTUpYoP7SWx3pPfpSNoVZ0KHG9AzZgnvQWCMjWnl5eUWv0Hr7++X1iMPXqpgi56eHuTn52PZsmWIj4/HihUrFD8xMTE4duwYrl+/Pup2LHnqqafg7++PAwcOIDc3F4IgwGQyycqI3+gO/na4rKxsxPsPjEYjent7UVdXJ8UEQcD27dsVZZOSkiAIAjIzMy3WdePGjWHbCwgIgLOzs5Q28+/2ySefyF4XFhbil19+kQ3w7O3toVKpZDMFRCQtGbtfQkICAGDjxo24c+eO4rj43ogDqpHOnNjZ2SE6OhoNDQ0oLS1VXIMgCIiLixtRXX+npUuXQqvVYufOnejt7ZXivb292LlzJ3Q6nfT07KVLl2L8+PH44osvZOlEr169qpilsrOzQ2JiIurq6pCfn2+x7dGsp7e1n8Xlc+I+ClFWVpai7pG85+Xl5Th79qz0moiwbds2AJB9Jm25T0fSbk1NDRwcHLBw4UKrZRizhmcQGGNj2jvvvIPOzk7ExMTAz88PGo0GbW1tyMvLw4ULF5CUlAQ/P79R1//NN9+gv78fy5cvt1pm+fLl2L9/P77++mvFBtgHZTKZsGbNGmzduhVGoxEhISGy4+Hh4fDw8MCaNWvQ2tqKKVOm4Ny5c8jNzYWfnx9++umnYdtISUlBVlYW4uLikJGRAUdHR+Tn51sceImpTT///HOcPXsWL774Itzc3HD16lVUV1fj0qVLw66btre3x8svv4yioiIMDAzIZkQeNTc3NxQUFODatWuIjIyU0pxOmjRJ9ryHFStW4MiRI1i8eDGSkpJw9+5dFBUVKXLiA0BQUBDWr1+PrVu3IjAwECtXroSHhwdaWlqQn5+Puro6GAwG+Pj4QK/X48svv4RGo4HBYMDEiROljc+WfPzxxygvL0dsbCxSU1Mxa9YsnD59GocPH0ZERIRiwDgWGAwGbNu2DWlpaQgODpaeC7B//35cunQJu3fvljabT5gwAR9++CHWrl2LsLAwJCUl4fbt29i1axdmz56NhoYGWd0fffQRqqqqEB8fj/j4eISEhMDR0RFXrlzB999/j/nz58ueoTFStvTzK6+8go0bNyIlJQXNzc1wcXFBaWmpxdTJrq6umDVrFg4dOoSZM2di0qRJ0Gq1iI6OlsrMmzcPixcvRlpaGjw9PVFcXIwTJ05g1apVCA0NlcrZcp8O91kjIpSWliIqKmrUM4Hs/9w/kjuJMcZG6Pjx45Samkr+/v7k6upK9vb25OLiQpGRkbR37166d++erLyXlxf5+vparU9MYSimOV2wYAE5ODgo0o3e788//yS9Xk9Go1GK4b/pJh9Ue3s7OTg4EADavHmzxTKNjY30/PPPk8FgIJ1OR4sWLaLTp09bTMdoLUVjSUkJzZs3jxwdHcnT05PWrVtHzc3NVlM05uTkUHh4OOn1elKr1eTl5UVxcXF06NChEV2XmBo0Pz9fFh8qzamllI1eXl60aNEiRVxM+dnS0iLFxDSRly9fppiYGNLr9aTT6SgmJoYuXryoqOOrr74ib29vUqvV5OHhQcnJydTZ2alIZSnKy8ujsLAw0ul0pNFoaM6cOZSRkSFLF1pSUkIBAQGkVqsJgMVzH+zXX3+lV199ldzd3WncuHE0ffp0yszMlKUFtXbNw/XTYGKa0/tTi4qsXbe1z1RBQQGFhoaSRqMhjUZDoaGhVFhYaLHdXbt2kdFoJEdHR5o5cyZt375dSoc7+FzMZjN98MEH9OSTT5KTkxPpdDqaO3cuvfHGG1RTUyOVszWt7Ej7mYiopqaGwsLCSK1Wk6urKyUnJ1NXV5fFPqqtraWwsDDSaDQEQEpVen960ry8PPLz8yNHR0eaMmUKvf/++3Tnzh1Fu7bcp0N91k6ePEkA6OjRoyPqG8YGUxGNcocXY4wxNoSoqCiYzWZUVlb+Le1FRkaitbUVra2tf0t7jA2ltbUV06dPx6ZNmxRPK3/U4uLi0NbWhjNnzoyZzfXs34X3IDDGGHsksrKyUF1dParc9Yyx0WloaEBxcTGysrJ4cMBGjfcgMMYYeyR8fX0feWpIxphcQECAIk0vY7biGQTGGGOMMcaYhPcgMMYYY4wxxiQ8g8AYY4wxxhiT8ACBMcYYY4wxJuEBAmOMMcYYY0zCAwTGGGOMMcaYhAcIjDHGGGOMMQkPEBhjjDHGGGMSHiAwxhhjjDHGJDxAYIwxxhhjjEl4gMAYY4wxxhiT/Af18s/qmdt8rwAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 800x670 with 2 Axes>"
       ]
@@ -4510,6 +4450,11 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### SHAP 분석 결론 (XGBoost)\n\n- **Thallium**: 값=3이면 강한 음의 SHAP(Heart Disease 억제), 값=7이면 강한 양의 SHAP → IG 1위와 일치\n- **Chest pain type 4**: 양의 SHAP 집중 — 나머지 type과 이진 구분이 실질적\n- **Max HR**: 높을수록 음의 SHAP — 운동 능력이 좋을수록 Heart Disease 낮음\n- **ST depression**: 높을수록 양의 SHAP\n- **EKG results, BP**: SHAP 분산 작음 → 예측력 약한 변수 확인\n\nEDA 통계 결과와 방향성이 일치하여 모델이 데이터 구조를 잘 반영하고 있음."
   },
   {
    "cell_type": "markdown",
@@ -4543,28 +4488,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 75,
    "id": "ucisa6zqe3s",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'result': 'skip',\n",
+       "{'result': 'new',\n",
        " 'affected_nodes': [],\n",
-       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e7230>,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e7230>}"
+       " 'old_obj': None,\n",
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f02318dcbf0>}"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from mllabs.processor import FrequencyEncoder, CatPairCombiner\n",
-    "from sklearn.preprocessing import PolynomialFeatures\n",
-    "\n",
     "if e_aml.status == 'closed':\n",
     "    e_aml.reopen_exp()\n",
     "\n",
@@ -4598,35 +4540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "r5sv86k995s",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'result': 'skip',\n",
-       " 'affected_nodes': [],\n",
-       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e7380>,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e7380>}"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# 후보별 개별 실험 + 전체 조합\n",
-    "e_aml.set_node('xgb_freq',    grp='xgb', edges={'X': [(None, X_all), ('freq_st', None)]})\n",
-    "e_aml.set_node('xgb_cat',     grp='xgb', edges={'X': [(None, X_all), ('cat_pair', None)]}, params = {'enable_categorical': True})\n",
-    "e_aml.set_node('xgb_cont',    grp='xgb', edges={'X': [(None, X_all), ('cont_inter', None)]})\n",
-    "e_aml.set_node('xgb_all_fe',  grp='xgb', edges={'X': [(None, X_all), ('freq_st', None), ('cat_pair', None), ('cont_inter', None)]})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 76,
    "id": "lr7clbed349",
    "metadata": {},
    "outputs": [
@@ -4634,23 +4548,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Building 0 node(s)\n",
-      "Build 1/1 (100%) Node 0\n",
-      "Build complete: 0 node(s)\n",
-      "Experimenting 0 node(s)\n",
-      "Exp 1/1 (100%) Node 0\n",
-      "Experimentation complete: 0 node(s)\n"
+      "Building 3 node(s)\n",
+      "Build 1/1 (100%) cat_pair 3/3 (100%))\n",
+      "Build complete: 3 node(s)\n",
+      "Experimenting 4 node(s)\n",
+      "Exp 1/1 (100%) xgb_freq 4/4 (100%)> 500/1000 (50%) validation_0-auc: 0.95644\n",
+      "Experimentation complete: 4 node(s)\n"
      ]
     }
    ],
    "source": [
+    "# 후보별 개별 실험 + 전체 조합\n",
+    "e_aml.set_node('xgb_freq',    grp='xgb', edges={'X': [(None, X_all), ('freq_st', None)]})\n",
+    "e_aml.set_node('xgb_cat',     grp='xgb', edges={'X': [(None, X_all), ('cat_pair', None)]})\n",
+    "e_aml.set_node('xgb_cont',    grp='xgb', edges={'X': [(None, X_all), ('cont_inter', None)]})\n",
+    "e_aml.set_node('xgb_all_fe',  grp='xgb', edges={'X': [(None, X_all), ('freq_st', None), ('cat_pair', None), ('cont_inter', None)]})\n",
+    "\n",
     "e_aml.build()\n",
     "e_aml.exp()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 77,
    "id": "a74a135a-7ecd-4ac1-9446-8116b8926009",
    "metadata": {},
    "outputs": [
@@ -4668,20 +4588,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 78,
    "id": "110f26d4-2631-4244-97ed-8127bcd9ee4e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'result': 'skip',\n",
+       "{'result': 'new',\n",
        " 'affected_nodes': [],\n",
-       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e7440>,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e7440>}"
+       " 'old_obj': None,\n",
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f0230157440>}"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4690,13 +4610,13 @@
     "from mllabs import ColSelector\n",
     "e_aml.set_node('lgb_cat',     grp='lgb', edges={'X': [(None, X_all), ('cat_pair', None)]}, \n",
     "               params = {'categorical_feature': ColSelector(col_type='category')})\n",
-    "e_aml.set_node('lgb_all_fe',    grp='lgb', edges={'X': [(None, X_all), ('cont_inter', None)]},\n",
+    "e_aml.set_node('lgb_all_fe',    grp='lgb', edges={'X': [(None, X_all), ('freq_st', None), ('cat_pair', None), ('cont_inter', None)]},\n",
     "              params ={'categorical_feature': ColSelector(col_type='category')})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 79,
    "id": "79b4f328-347c-4b87-a354-08c7a9aa873c",
    "metadata": {},
    "outputs": [
@@ -4704,9 +4624,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experimenting 0 node(s)\n",
-      "Exp 1/1 (100%) Node 0\n",
-      "Experimentation complete: 0 node(s)\n"
+      "Experimenting 2 node(s)\n",
+      "Exp 0/1 (0%) > lgb_cat 0/2 (0%) > 1/1000 (0%) valid_0-auc: 0.9323, valid_0-binary_logloss: 0.6581Training until validation scores don't improve for 50 rounds\n",
+      "Exp 0/1 (0%) > lgb_cat 0/2 (0%) > 500/1000 (50%) valid_0-auc: 0.9564, valid_0-binary_logloss: 0.2647Early stopping, best iteration is:\n",
+      "[469]\tvalid_0's auc: 0.956399\tvalid_0's binary_logloss: 0.264662\n",
+      "Evaluated only: auc\n",
+      "Exp 0/1 (0%) > lgb_all_fe 1/2 (50%) > 1/1000 (0%) valid_0-auc: 0.9323, valid_0-binary_logloss: 0.6581Training until validation scores don't improve for 50 rounds\n",
+      "Exp 0/1 (0%) > lgb_all_fe 1/2 (50%) > 600/1000 (60%) valid_0-auc: 0.9565, valid_0-binary_logloss: 0.2645Early stopping, best iteration is:\n",
+      "[620]\tvalid_0's auc: 0.956475\tvalid_0's binary_logloss: 0.264485\n",
+      "Evaluated only: auc\n",
+      "Exp 1/1 (100%) lgb_all_fe 2/2 (100%)\n",
+      "Experimentation complete: 2 node(s)\n"
      ]
     }
    ],
@@ -4716,7 +4644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 80,
    "id": "c21a1611-a7eb-4b4b-a01a-13e6d4588b6c",
    "metadata": {},
    "outputs": [
@@ -4734,58 +4662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "id": "1f205c3e-5958-4d93-8db4-a98881ec300b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No error nodes found\n"
-     ]
-    }
-   ],
-   "source": [
-    "e_aml.show_error_nodes(traceback = True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "id": "d4be9239-3a34-435b-8ba1-20d4100d072b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "d = next(e_aml.get_node_data_train('xgb_cat', 0))['X'][0]# .get_column_list(ColSelector(col_type='category'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "id": "a412d113-622e-4cb2-a419-6047b6d74985",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Thallium__Chest pain type',\n",
-       " 'Chest pain type__Exercise angina',\n",
-       " 'Thallium__Exercise angina']"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "next(e_aml.node_objs['cat_pair'].get_objs(0))[0].obj.get_feature_names_out()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 84,
    "id": "6hb614u6kx6",
    "metadata": {},
    "outputs": [
@@ -4848,9 +4725,9 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>lgb_all_fe</th>\n",
-       "      <td>0.954839</td>\n",
-       "      <td>0.958407</td>\n",
-       "      <td>0.956436</td>\n",
+       "      <td>0.954852</td>\n",
+       "      <td>0.958741</td>\n",
+       "      <td>0.956475</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>xgb_cont</th>\n",
@@ -4875,12 +4752,12 @@
        "lgb1        0.954899   0.958201   0.956518\n",
        "xgb_cat     0.954893   0.958117   0.956490\n",
        "lgb_cat     0.954890   0.957568   0.956399\n",
-       "lgb_all_fe  0.954839   0.958407   0.956436\n",
+       "lgb_all_fe  0.954852   0.958741   0.956475\n",
        "xgb_cont    0.954825   0.958233   0.956314\n",
        "xgb_all_fe  0.954811   0.958360   0.956428"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4915,20 +4792,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 85,
    "id": "04bcb18d-f7af-4290-ba97-1a91540c6525",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'result': 'skip',\n",
+       "{'result': 'new',\n",
        " 'affected_nodes': [],\n",
-       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e74a0>,\n",
-       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f175a5e74a0>}"
+       " 'old_obj': None,\n",
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f0228146390>}"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4942,7 +4819,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 86,
    "id": "0e42981c-625c-4fd4-839a-7d83533180c2",
    "metadata": {},
    "outputs": [
@@ -4950,9 +4827,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experimenting 0 node(s)\n",
-      "Exp 1/1 (100%) Node 0\n",
-      "Experimentation complete: 0 node(s)\n"
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) cb2 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
      ]
     }
    ],
@@ -4962,7 +4839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 87,
    "id": "4697f126-f9b9-46f5-9fea-c57f9108c4c4",
    "metadata": {},
    "outputs": [
@@ -5031,9 +4908,9 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>lgb_all_fe</th>\n",
-       "      <td>0.954839</td>\n",
-       "      <td>0.958407</td>\n",
-       "      <td>0.956436</td>\n",
+       "      <td>0.954852</td>\n",
+       "      <td>0.958741</td>\n",
+       "      <td>0.956475</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>xgb_cont</th>\n",
@@ -5048,10 +4925,10 @@
        "      <td>0.956428</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>lr3</th>\n",
-       "      <td>0.950505</td>\n",
-       "      <td>0.950816</td>\n",
-       "      <td>0.951911</td>\n",
+       "      <th>cb2</th>\n",
+       "      <td>0.946906</td>\n",
+       "      <td>0.948648</td>\n",
+       "      <td>0.948643</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -5065,13 +4942,13 @@
        "lgb1        0.954899   0.958201   0.956518\n",
        "xgb_cat     0.954893   0.958117   0.956490\n",
        "lgb_cat     0.954890   0.957568   0.956399\n",
-       "lgb_all_fe  0.954839   0.958407   0.956436\n",
+       "lgb_all_fe  0.954852   0.958741   0.956475\n",
        "xgb_cont    0.954825   0.958233   0.956314\n",
        "xgb_all_fe  0.954811   0.958360   0.956428\n",
-       "lr3         0.950505   0.950816   0.951911"
+       "cb2         0.946906   0.948648   0.948643"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5095,7 +4972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 88,
    "id": "2999f5ad-c29b-4501-b9e3-2f6c2e9c5a84",
    "metadata": {},
    "outputs": [
@@ -5103,9 +4980,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Building 0 node(s)\n",
-      "Build 1/1 (100%) Node 0\n",
-      "Build complete: 0 node(s)\n"
+      "Building 1 node(s)\n",
+      "Build 1/1 (100%) ohe_pair 1/1 (100%)\n",
+      "Build complete: 1 node(s)\n"
      ]
     }
    ],
@@ -5116,7 +4993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 89,
    "id": "286712df-15a3-4a2e-9f0d-e414203ca544",
    "metadata": {},
    "outputs": [
@@ -5124,93 +5001,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experimenting 0 node(s)\n",
-      "Exp 1/1 (100%) Node 0\n",
-      "Experimentation complete: 0 node(s)\n"
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) lr2 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
      ]
     }
    ],
    "source": [
     "e_aml.set_node(\n",
-    "    'lr2', grp='lr', edges = {'X': [('std', X_cont), (None, X_bin), ('ohe', None), ('ohe_pair', None)]}, \n",
+    "    'lr2', grp='lr', edges = {'X': [('std', None), (None, X_bin), ('ohe', ohe_drop_first), ('ohe_pair', ohe_drop_first)]}, \n",
     ")\n",
     "e_aml.exp()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
-   "id": "82251deb-ed53-4f8f-9ed9-64a73faf83f9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>valid</th>\n",
-       "      <th>train_sub</th>\n",
-       "      <th>valid_sub</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>lr1</th>\n",
-       "      <td>0.945429</td>\n",
-       "      <td>0.945591</td>\n",
-       "      <td>0.946846</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr2</th>\n",
-       "      <td>0.938139</td>\n",
-       "      <td>0.938318</td>\n",
-       "      <td>0.939891</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr3</th>\n",
-       "      <td>0.950505</td>\n",
-       "      <td>0.950816</td>\n",
-       "      <td>0.951911</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        valid  train_sub  valid_sub\n",
-       "lr1  0.945429   0.945591   0.946846\n",
-       "lr2  0.938139   0.938318   0.939891\n",
-       "lr3  0.950505   0.950816   0.951911"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "e_aml.collectors['AUC'].get_metrics_agg('lr.*')[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 90,
    "id": "0c7bbe27-e5fa-4684-b1ab-53798ea61dfe",
    "metadata": {},
    "outputs": [
@@ -5218,9 +5024,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Building 0 node(s)\n",
-      "Build 1/1 (100%) Node 0\n",
-      "Build complete: 0 node(s)\n"
+      "Building 1 node(s)\n",
+      "Build 1/1 (100%) std_cont_inter 1/1 (100%)\n",
+      "Build complete: 1 node(s)\n"
      ]
     }
    ],
@@ -5231,7 +5037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 91,
    "id": "51f1f206-02b1-47b8-8147-fde812c47d73",
    "metadata": {},
    "outputs": [
@@ -5239,22 +5045,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Experimenting 0 node(s)\n",
-      "Exp 1/1 (100%) Node 0\n",
-      "Experimentation complete: 0 node(s)\n"
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) lr3 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
      ]
     }
    ],
    "source": [
     "e_aml.set_node(\n",
-    "    'lr3', grp='lr', edges = {'X': [('std', X_cont), (None, X_bin), ('ohe', None), ('std_cont_inter', None)]}, \n",
+    "    'lr3', grp='lr', edges = {'X': [('std', None), (None, X_bin), ('ohe', ohe_drop_first), ('std_cont_inter', None)]}, \n",
     ")\n",
     "e_aml.exp()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 92,
    "id": "b13104c2-8c49-4399-a0a9-8525e468e741",
    "metadata": {},
    "outputs": [
@@ -5286,10 +5092,16 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.952668</td>\n",
+       "      <td>0.952862</td>\n",
+       "      <td>0.954326</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>lr3</th>\n",
-       "      <td>0.950505</td>\n",
-       "      <td>0.950816</td>\n",
-       "      <td>0.951911</td>\n",
+       "      <td>0.952609</td>\n",
+       "      <td>0.952817</td>\n",
+       "      <td>0.954265</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>lr1</th>\n",
@@ -5297,24 +5109,18 @@
        "      <td>0.945591</td>\n",
        "      <td>0.946846</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr2</th>\n",
-       "      <td>0.938139</td>\n",
-       "      <td>0.938318</td>\n",
-       "      <td>0.939891</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "        valid  train_sub  valid_sub\n",
-       "lr3  0.950505   0.950816   0.951911\n",
-       "lr1  0.945429   0.945591   0.946846\n",
-       "lr2  0.938139   0.938318   0.939891"
+       "lr2  0.952668   0.952862   0.954326\n",
+       "lr3  0.952609   0.952817   0.954265\n",
+       "lr1  0.945429   0.945591   0.946846"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5325,19 +5131,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "425vstdn8m2",
    "metadata": {},
-   "source": [
-    "### 분석: 선형 모델 Feature Engineering\n",
-    "\n",
-    "- **lr3 (연속형 polynomial interaction)**: 0.9505 — baseline 대비 **+0.005** 개선, 세 모델 중 최고\n",
-    "  - Age×Cholesterol, Age×Max HR, Cholesterol×Max HR 상호작용 항이 선형 결정 경계 표현력을 확장\n",
-    "- **lr1 (baseline)**: 0.9454 — 표준화된 연속형 + OHE 범주형\n",
-    "- **lr2 (범주형 pair OHE 추가)**: 0.9381 — baseline 대비 **-0.007** 악화\n",
-    "  - Thallium×Chest pain type 등 pair 조합의 OHE는 희소 고차원 특성으로 다중공선성 및 과적합 유발\n",
-    "\n",
-    "→ 선형 모델에서는 연속형 상호작용 항이 유효하나, 범주형 조합 OHE는 역효과"
-   ]
+   "source": "### 분석: 선형 모델 Feature Engineering\n\n| 모델 | 구성 | valid AUC | baseline 대비 |\n|------|------|----------|--------------|\n| lr2 | OHE(pair) | **0.952668** | +0.007 |\n| lr3 | polynomial(연속형) | 0.952609 | +0.007 |\n| lr1 | OHE(X_nom+X_ord) | 0.945429 | — |\n\n- OHE pair와 polynomial interaction이 동급 수준으로 baseline 대비 +0.007 개선\n- 범주형 pair(OHE)가 연속형 polynomial보다 미세하게 우위\n- 두 방향 모두 트리 모델(0.9549)에는 여전히 0.002 하회"
   },
   {
    "cell_type": "markdown",
@@ -5356,7 +5151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 93,
    "id": "zpfiwhxmick",
    "metadata": {},
    "outputs": [
@@ -5388,7 +5183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 94,
    "id": "rtvh6bdgruh",
    "metadata": {},
    "outputs": [
@@ -5406,7 +5201,7 @@
    "source": [
     "e_aml.set_node(\n",
     "    'lr4', grp='lr',\n",
-    "    edges={'X': [('std', X_cont), (None, X_bin), ('ohe', None), ('te_pair', None)]}\n",
+    "    edges={'X': [('std', None), (None, X_bin), ('ohe', ohe_drop_first), ('te_pair', None)]}\n",
     ")\n",
     "e_aml.exp()\n",
     "e_aml.show_error_nodes()"
@@ -5414,7 +5209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 95,
    "id": "s0p6srmh4v",
    "metadata": {},
    "outputs": [
@@ -5446,10 +5241,22 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.952668</td>\n",
+       "      <td>0.952862</td>\n",
+       "      <td>0.954326</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>lr3</th>\n",
-       "      <td>0.950505</td>\n",
-       "      <td>0.950816</td>\n",
-       "      <td>0.951911</td>\n",
+       "      <td>0.952609</td>\n",
+       "      <td>0.952817</td>\n",
+       "      <td>0.954265</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr4</th>\n",
+       "      <td>0.952606</td>\n",
+       "      <td>0.952811</td>\n",
+       "      <td>0.954264</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>lr1</th>\n",
@@ -5457,31 +5264,19 @@
        "      <td>0.945591</td>\n",
        "      <td>0.946846</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr2</th>\n",
-       "      <td>0.938139</td>\n",
-       "      <td>0.938318</td>\n",
-       "      <td>0.939891</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lr4</th>\n",
-       "      <td>0.938044</td>\n",
-       "      <td>0.938233</td>\n",
-       "      <td>0.939720</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "        valid  train_sub  valid_sub\n",
-       "lr3  0.950505   0.950816   0.951911\n",
-       "lr1  0.945429   0.945591   0.946846\n",
-       "lr2  0.938139   0.938318   0.939891\n",
-       "lr4  0.938044   0.938233   0.939720"
+       "lr2  0.952668   0.952862   0.954326\n",
+       "lr3  0.952609   0.952817   0.954265\n",
+       "lr4  0.952606   0.952811   0.954264\n",
+       "lr1  0.945429   0.945591   0.946846"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5491,54 +5286,5077 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "mptyr3bnzy",
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "1dba1bda-6a4a-40e2-9c2c-79f59982c368",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) lr5 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n",
+      "No error nodes found\n"
+     ]
+    }
+   ],
    "source": [
-    "### 분석: TargetEncoder 효과 및 leakage 검증\n",
-    "\n",
-    "**lr4 vs lr2 비교** (범주형 pair 인코딩 방식 차이):\n",
-    "- lr2 (OHE): 각 pair 조합을 희소 이진 컬럼으로 확장 → 고차원, 다중공선성 → AUC 저하\n",
-    "- lr4 (TargetEncoder): 각 pair 조합을 타겟 조건부 확률 단일값으로 압축 → 저차원, 정보 보존\n",
-    "\n",
-    "**leakage 검증**:\n",
-    "- `train_sub ≈ valid_sub`: cross-fitting이 정상 동작 → leakage 없이 `fit_transform(X, y)` 처리\n",
-    "- `train_sub >> valid_sub`: leakage 발생 → `fit_transform`이 y 전체를 보고 인코딩한 것  \n",
-    "\n",
-    "`TransformProcessor.fit_process`는 `fit_transform(train_X, train_y)` 를 호출하고,  \n",
-    "`process`는 `transform(data)` 만 호출하므로 valid 데이터는 train에서 학습된 인코더로만 변환됨.  \n",
-    "TargetEncoder의 cv=5 cross-fitting은 train 내부 leakage를 추가로 방지."
+    "e_aml.set_node(\n",
+    "    'lr5', grp='lr',\n",
+    "    edges={'X': [('std', None), (None, X_bin), ('ohe', ohe_drop_first), ('te_pair', None), ('std_cont_inter', None)]}\n",
+    ")\n",
+    "e_aml.exp()\n",
+    "e_aml.show_error_nodes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "89f3f1d2-5b12-4ec5-a85b-f74e1881ef1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.952668</td>\n",
+       "      <td>0.952862</td>\n",
+       "      <td>0.954326</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr3</th>\n",
+       "      <td>0.952609</td>\n",
+       "      <td>0.952817</td>\n",
+       "      <td>0.954265</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr5</th>\n",
+       "      <td>0.952607</td>\n",
+       "      <td>0.952812</td>\n",
+       "      <td>0.954258</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr4</th>\n",
+       "      <td>0.952606</td>\n",
+       "      <td>0.952811</td>\n",
+       "      <td>0.954264</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr1</th>\n",
+       "      <td>0.945429</td>\n",
+       "      <td>0.945591</td>\n",
+       "      <td>0.946846</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        valid  train_sub  valid_sub\n",
+       "lr2  0.952668   0.952862   0.954326\n",
+       "lr3  0.952609   0.952817   0.954265\n",
+       "lr5  0.952607   0.952812   0.954258\n",
+       "lr4  0.952606   0.952811   0.954264\n",
+       "lr1  0.945429   0.945591   0.946846"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg('lr.*')[0].sort_values('valid', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "2972fbfe-a872-4de2-b331-7daf036cae0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) lr6 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.952668</td>\n",
+       "      <td>0.952862</td>\n",
+       "      <td>0.954326</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr6</th>\n",
+       "      <td>0.952664</td>\n",
+       "      <td>0.952863</td>\n",
+       "      <td>0.954325</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr3</th>\n",
+       "      <td>0.952609</td>\n",
+       "      <td>0.952817</td>\n",
+       "      <td>0.954265</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr5</th>\n",
+       "      <td>0.952607</td>\n",
+       "      <td>0.952812</td>\n",
+       "      <td>0.954258</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr4</th>\n",
+       "      <td>0.952606</td>\n",
+       "      <td>0.952811</td>\n",
+       "      <td>0.954264</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr1</th>\n",
+       "      <td>0.945429</td>\n",
+       "      <td>0.945591</td>\n",
+       "      <td>0.946846</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        valid  train_sub  valid_sub\n",
+       "lr2  0.952668   0.952862   0.954326\n",
+       "lr6  0.952664   0.952863   0.954325\n",
+       "lr3  0.952609   0.952817   0.954265\n",
+       "lr5  0.952607   0.952812   0.954258\n",
+       "lr4  0.952606   0.952811   0.954264\n",
+       "lr1  0.945429   0.945591   0.946846"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.set_node(\n",
+    "    'lr6', grp='lr',\n",
+    "    edges={'X': [('std', None), (None, X_bin), ('ohe', ohe_drop_first), ('ohe_pair', ohe_drop_first), ('std_cont_inter', None)]}\n",
+    ")\n",
+    "e_aml.exp()\n",
+    "e_aml.collectors['AUC'].get_metrics_agg('lr.*')[0].sort_values('valid', ascending=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aa9aad81-1afd-44ea-87ad-0592a1b9cac0",
+   "metadata": {},
+   "source": "### 분석: Logistic Regression 최종 결론\n\n| 모델 | 주요 구성 | valid AUC |\n|------|----------|----------|\n| lr2 (best) | OHE pair | **0.952668** |\n| lr6 | OHE pair + polynomial | 0.952664 |\n| lr3 | polynomial | 0.952609 |\n| lr5 | OHE pair + TE pair + polynomial | 0.952607 |\n| lr4 | OHE pair + TE pair | 0.952606 |\n| lr1 (baseline) | OHE only | 0.945429 |\n\n- lr2(OHE pair)이 최고. 이후 조합 추가는 유의미한 성능 차이 없음\n- OHE pair가 범주형 상호작용을 가장 효과적으로 반영\n- 트리 모델(0.9549~0.9552)과는 약 0.002~0.003 gap 유지 — 앙상블 다양성 목적으로 활용"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "id": "670682ec-ffd9-4b60-9d0b-61268eb69192",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```mermaid\n",
+       "graph LR\n",
+       "\n",
+       "    DataSource([DataSource])\n",
+       "    style DataSource fill:#fff9c4,stroke:#f57c00,stroke-width:3px\n",
+       "\n",
+       "    subgraph node_cat_pair[\"pre/cat_pair\"]\n",
+       "        cat_pair_dummy[ ]\n",
+       "        style cat_pair_dummy fill:none,stroke:none\n",
+       "    end\n",
+       "    style node_cat_pair fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
+       "\n",
+       "    subgraph node_lbl[\"pre/lbl\"]\n",
+       "        lbl_dummy[ ]\n",
+       "        style lbl_dummy fill:none,stroke:none\n",
+       "    end\n",
+       "    style node_lbl fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
+       "\n",
+       "    subgraph node_lr2[\"clf/lr/lr2\"]\n",
+       "        lr2_dummy[ ]\n",
+       "        style lr2_dummy fill:none,stroke:none\n",
+       "    end\n",
+       "    style node_lr2 fill:#ffcdd2,stroke:#c62828,stroke-width:3px\n",
+       "\n",
+       "    subgraph node_ohe[\"pre/ohe\"]\n",
+       "        ohe_dummy[ ]\n",
+       "        style ohe_dummy fill:none,stroke:none\n",
+       "    end\n",
+       "    style node_ohe fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
+       "\n",
+       "    subgraph node_ohe_pair[\"pre/ohe_pair\"]\n",
+       "        ohe_pair_dummy[ ]\n",
+       "        style ohe_pair_dummy fill:none,stroke:none\n",
+       "    end\n",
+       "    style node_ohe_pair fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
+       "\n",
+       "    subgraph node_std[\"pre/std\"]\n",
+       "        std_dummy[ ]\n",
+       "        style std_dummy fill:none,stroke:none\n",
+       "    end\n",
+       "    style node_std fill:#c8e6c9,stroke:#388e3c,stroke-width:2px\n",
+       "\n",
+       "    DataSource --> node_cat_pair\n",
+       "    DataSource -->|y| node_lbl\n",
+       "    DataSource --> node_lr2\n",
+       "    DataSource --> node_ohe\n",
+       "    DataSource --> node_std\n",
+       "    node_cat_pair --> node_ohe_pair\n",
+       "    node_lbl -->|y| node_lr2\n",
+       "    node_ohe --> node_lr2\n",
+       "    node_ohe_pair --> node_lr2\n",
+       "    node_std --> node_lr2\n",
+       "```\n",
+       "\n",
+       "**Path from DataSource to 'clf/lr/lr2' (5 path(s) found)**\n",
+       "\n",
+       "### Edges\n",
+       "\n",
+       "| Key | Node | Var |\n",
+       "|-----|------|-----|\n",
+       "| X | pre/std | * |\n",
+       "| X | Data Source | `['Exercise angina', 'FBS over 120', 'Sex']` |\n",
+       "| X | pre/ohe | `<function ohe_drop_first at 0x7f02318d2660>` |\n",
+       "| X | pre/ohe_pair | `<function ohe_drop_first at 0x7f02318d2660>` |\n",
+       "| y | pre/lbl | * |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Markdown(\n",
+    "    e_aml.desc_node('lr2', direction = 'LR')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "id": "9d9dd7f7-f334-48ca-9125-e59139248814",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb1</th>\n",
+       "      <td>0.955224</td>\n",
+       "      <td>0.956834</td>\n",
+       "      <td>0.956806</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb1</th>\n",
+       "      <td>0.954915</td>\n",
+       "      <td>0.958066</td>\n",
+       "      <td>0.956418</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_freq</th>\n",
+       "      <td>0.954906</td>\n",
+       "      <td>0.958477</td>\n",
+       "      <td>0.956405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb1</th>\n",
+       "      <td>0.954899</td>\n",
+       "      <td>0.958201</td>\n",
+       "      <td>0.956518</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_cat</th>\n",
+       "      <td>0.954893</td>\n",
+       "      <td>0.958117</td>\n",
+       "      <td>0.956490</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_cat</th>\n",
+       "      <td>0.954890</td>\n",
+       "      <td>0.957568</td>\n",
+       "      <td>0.956399</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_all_fe</th>\n",
+       "      <td>0.954852</td>\n",
+       "      <td>0.958741</td>\n",
+       "      <td>0.956475</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_cont</th>\n",
+       "      <td>0.954825</td>\n",
+       "      <td>0.958233</td>\n",
+       "      <td>0.956314</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_all_fe</th>\n",
+       "      <td>0.954811</td>\n",
+       "      <td>0.958360</td>\n",
+       "      <td>0.956428</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.952668</td>\n",
+       "      <td>0.952862</td>\n",
+       "      <td>0.954326</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               valid  train_sub  valid_sub\n",
+       "cb1         0.955224   0.956834   0.956806\n",
+       "xgb1        0.954915   0.958066   0.956418\n",
+       "xgb_freq    0.954906   0.958477   0.956405\n",
+       "lgb1        0.954899   0.958201   0.956518\n",
+       "xgb_cat     0.954893   0.958117   0.956490\n",
+       "lgb_cat     0.954890   0.957568   0.956399\n",
+       "lgb_all_fe  0.954852   0.958741   0.956475\n",
+       "xgb_cont    0.954825   0.958233   0.956314\n",
+       "xgb_all_fe  0.954811   0.958360   0.956428\n",
+       "lr2         0.952668   0.952862   0.954326"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg()[0].sort_values('valid', ascending=False).iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 종합: FE 탐색 결론 → HP 튜닝\n\n**최종 best:** cb1(0.9552) → 트리 모델은 FE 없이 baseline 유지\n\n트리 모델(XGB/LGB/CB)의 성능이 0.9549~0.9552에 밀집되고 FE 효과가 없어,\n다음 개선 수단으로 **Hyperparameter 튜닝**으로 전환."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c9d8b28",
    "metadata": {},
    "source": [
-    "## Feature Engineering 종합 결론\n",
+    "# Hyperparameter Tuning\n",
     "\n",
-    "| 모델 | Best valid AUC | FE 효과 |\n",
-    "|------|---------------|--------|\n",
-    "| CatBoost (cb1) | 0.9552 | 명시적 FE 불필요 — 범주형 native 처리가 핵심 |\n",
-    "| XGBoost baseline (xgb1) | 0.9549 | FE 변형 모두 baseline 이하, 최대 -0.0001 |\n",
-    "| LightGBM baseline (lgb1) | 0.9549 | 동일 경향 |\n",
-    "| LR + 연속형 interaction (lr3) | 0.9505 | polynomial 파생으로 +0.005 개선 |\n",
-    "| LR + 범주형 pair OHE (lr2) | 0.9381 | 오히려 -0.007 악화 |\n",
+    "CatBoost HP 튜닝. Optuna prior 구성을 위해 개별 파라미터 최적값을 순차 탐색."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7d13e31",
+   "metadata": {},
+   "source": [
+    "## CatBoost depth 탐색\n",
     "\n",
-    "### 핵심 인사이트\n",
-    "- 이 데이터셋은 트리 모델이 원본 피처만으로 충분히 information을 추출하며, 명시적 interaction 파생은 트리 모델에서 노이즈 역할\n",
-    "- CatBoost가 단일 모델 최고 성능 — 범주형 변수를 별도 인코딩 없이 처리하는 방식이 유효\n",
-    "- 선형 모델은 연속형 polynomial interaction(Age×Cholesterol, Age×Max HR 등)이 유의미하게 도움이 되나, 범주형 pair OHE는 다중공선성으로 역효과\n",
-    "- lr3(0.9505)는 트리 모델과 예측 방식이 달라 stacking 앙상블 구성 시 다양성 기여 가능"
+    "- cb 그룹 baseline 기준 (early stopping, AUC 기준)\n",
+    "- iterations=10000으로 충분히 키우고, early stopping으로 실제 최적 tree 수 자동 결정\n",
+    "- cat_features 미지정 시 CatBoost가 범주형을 ordinal로 처리 → 이 탐색은 ordinal 가정 하의 depth 민감도 파악"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "4dffe1ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e_aml.set_grp('cb_max_depth', parent='cb', params={'iterations': 10000})\n",
+    "\n",
+    "for d in range(3, 11):\n",
+    "    node_name = f'cb_max_depth_{d}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_max_depth',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={'depth': d}\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "9fa3348d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 8 node(s)\n",
+      "Exp 1/1 (100%) cb_max_depth_5 8/8 (100%)\n",
+      "Experimentation complete: 8 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.exp('cb_max_depth_.*')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "9c426ab3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No error nodes found\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.show_error_nodes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "87b7ffd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>0.955331</td>\n",
+       "      <td>0.956071</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_4</th>\n",
+       "      <td>0.955320</td>\n",
+       "      <td>0.956365</td>\n",
+       "      <td>0.956936</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_5</th>\n",
+       "      <td>0.955282</td>\n",
+       "      <td>0.956752</td>\n",
+       "      <td>0.956910</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_6</th>\n",
+       "      <td>0.955232</td>\n",
+       "      <td>0.957414</td>\n",
+       "      <td>0.956873</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_7</th>\n",
+       "      <td>0.955159</td>\n",
+       "      <td>0.958020</td>\n",
+       "      <td>0.956764</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_8</th>\n",
+       "      <td>0.955046</td>\n",
+       "      <td>0.958710</td>\n",
+       "      <td>0.956616</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_9</th>\n",
+       "      <td>0.954943</td>\n",
+       "      <td>0.959506</td>\n",
+       "      <td>0.956471</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_10</th>\n",
+       "      <td>0.954764</td>\n",
+       "      <td>0.961128</td>\n",
+       "      <td>0.956225</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    valid  train_sub  valid_sub\n",
+       "cb_max_depth_3   0.955331   0.956071   0.956928\n",
+       "cb_max_depth_4   0.955320   0.956365   0.956936\n",
+       "cb_max_depth_5   0.955282   0.956752   0.956910\n",
+       "cb_max_depth_6   0.955232   0.957414   0.956873\n",
+       "cb_max_depth_7   0.955159   0.958020   0.956764\n",
+       "cb_max_depth_8   0.955046   0.958710   0.956616\n",
+       "cb_max_depth_9   0.954943   0.959506   0.956471\n",
+       "cb_max_depth_10  0.954764   0.961128   0.956225"
+      ]
+     },
+     "execution_count": 104,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    'cb_max_depth_.*'\n",
+    ")[0].sort_values('valid', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: depth sweep 결과\n\n| depth | valid AUC | train_sub |\n|-------|----------|-----------|\n| 3 (best) | **0.955331** | 0.956071 |\n| 4 | 0.955320 | 0.956365 |\n| 5 | 0.955282 | 0.956752 |\n| 6 | 0.955232 | 0.957414 |\n| 10 | 0.954764 | 0.961128 |\n\n- depth 증가 → train_sub 단조 증가(overfitting), valid 단조 감소\n- CatBoost의 symmetric tree는 depth=3에서 균형 최적\n- baseline cb1(depth default=6)보다 depth=3이 valid +0.0001\n- depth=2 추가 탐색 필요"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "03cba60f-9b51-4d8b-ba47-b6bbcbd54b24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) cb_max_depth_2 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "d = 2\n",
+    "node_name = f'cb_max_depth_{d}'\n",
+    "e_aml.set_node(\n",
+    "    node_name, grp='cb_max_depth',\n",
+    "    edges={'X': [(None, X_all)]},\n",
+    "    params={'depth': d}\n",
+    ")\n",
+    "e_aml.exp()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: depth 추가 탐색 (depth=2)\n\n| depth | valid AUC |\n|-------|----------|\n| 3 (최적) | **0.955331** |\n| 2 | 0.955236 |\n| 4 | 0.955320 |\n\n- depth=2는 depth=3보다 낮음 → underfitting 진입 구간\n- **최종 확정: depth=3**. 이후 파라미터 탐색은 depth=3 고정."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "f5ad8797-c68c-42ec-a89c-530b82485ba1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>0.955331</td>\n",
+       "      <td>0.956071</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_4</th>\n",
+       "      <td>0.955320</td>\n",
+       "      <td>0.956365</td>\n",
+       "      <td>0.956936</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_5</th>\n",
+       "      <td>0.955282</td>\n",
+       "      <td>0.956752</td>\n",
+       "      <td>0.956910</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_2</th>\n",
+       "      <td>0.955236</td>\n",
+       "      <td>0.955666</td>\n",
+       "      <td>0.956805</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_6</th>\n",
+       "      <td>0.955232</td>\n",
+       "      <td>0.957414</td>\n",
+       "      <td>0.956873</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   valid  train_sub  valid_sub\n",
+       "cb_max_depth_3  0.955331   0.956071   0.956928\n",
+       "cb_max_depth_4  0.955320   0.956365   0.956936\n",
+       "cb_max_depth_5  0.955282   0.956752   0.956910\n",
+       "cb_max_depth_2  0.955236   0.955666   0.956805\n",
+       "cb_max_depth_6  0.955232   0.957414   0.956873"
+      ]
+     },
+     "execution_count": 106,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    None\n",
+    ")[0].sort_values('valid', ascending=False).iloc[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "d1e70a78-a1b2-44b3-8102-29b2c6dd17eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 5 node(s)\n",
+      "Exp 1/1 (100%) cb_learning_rate_0.02 5/5 (100%))\n",
+      "Experimentation complete: 5 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.set_grp('cb_learning_rate', parent='cb', params={'iterations': 10000, 'depth': 3})\n",
+    "\n",
+    "for learning_rate in [0.02, 0.0075, 0.005, 0.0025, 0.0001]:\n",
+    "    node_name = f'cb_learning_rate_{learning_rate}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_learning_rate',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={'learning_rate': learning_rate}\n",
+    "    )\n",
+    "e_aml.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "id": "8e10b2d9-f9e4-4ea8-a976-b66a474d1d30",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>0.955331</td>\n",
+       "      <td>0.956071</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_learning_rate_0.02</th>\n",
+       "      <td>0.955329</td>\n",
+       "      <td>0.956100</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_4</th>\n",
+       "      <td>0.955320</td>\n",
+       "      <td>0.956365</td>\n",
+       "      <td>0.956936</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_5</th>\n",
+       "      <td>0.955282</td>\n",
+       "      <td>0.956752</td>\n",
+       "      <td>0.956910</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_2</th>\n",
+       "      <td>0.955236</td>\n",
+       "      <td>0.955666</td>\n",
+       "      <td>0.956805</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          valid  train_sub  valid_sub\n",
+       "cb_max_depth_3         0.955331   0.956071   0.956928\n",
+       "cb_learning_rate_0.02  0.955329   0.956100   0.956928\n",
+       "cb_max_depth_4         0.955320   0.956365   0.956936\n",
+       "cb_max_depth_5         0.955282   0.956752   0.956910\n",
+       "cb_max_depth_2         0.955236   0.955666   0.956805"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    None\n",
+    ")[0].sort_values('valid', ascending=False).iloc[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: learning_rate\n\n- lr=0.02가 depth=3과 동급(0.9553), lr이 낮아질수록 성능 하락\n- early stopping이 iterations를 자동 조절하므로 lr 감소 → 더 많은 tree 필요 (비효율)\n- **탐색 방향: 상한 미탐색 구간(lr > 0.02) 추가 탐색 필요** → Optuna 2차 탐색에서 확인"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "id": "180d6c79-e9aa-4d6b-b8d1-d628c0df53e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 3 node(s)\n",
+      "Exp 1/1 (100%) cb_rsm_0.25 3/3 (100%)\n",
+      "Experimentation complete: 3 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.set_grp('cb_rsm', parent='cb', params={'iterations': 10000, 'depth': 3})\n",
+    "\n",
+    "for rsm in [0.75, 0.5, 0.25]:\n",
+    "    node_name = f'cb_rsm_{rsm}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_rsm',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={'rsm': rsm}\n",
+    "    )\n",
+    "e_aml.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "id": "44af68a4-3656-4459-88d0-6264a9649230",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_rsm_0.75</th>\n",
+       "      <td>0.955354</td>\n",
+       "      <td>0.956264</td>\n",
+       "      <td>0.956959</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>0.955331</td>\n",
+       "      <td>0.956071</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_learning_rate_0.02</th>\n",
+       "      <td>0.955329</td>\n",
+       "      <td>0.956100</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_4</th>\n",
+       "      <td>0.955320</td>\n",
+       "      <td>0.956365</td>\n",
+       "      <td>0.956936</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_rsm_0.5</th>\n",
+       "      <td>0.955312</td>\n",
+       "      <td>0.956218</td>\n",
+       "      <td>0.956927</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          valid  train_sub  valid_sub\n",
+       "cb_rsm_0.75            0.955354   0.956264   0.956959\n",
+       "cb_max_depth_3         0.955331   0.956071   0.956928\n",
+       "cb_learning_rate_0.02  0.955329   0.956100   0.956928\n",
+       "cb_max_depth_4         0.955320   0.956365   0.956936\n",
+       "cb_rsm_0.5             0.955312   0.956218   0.956927"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    None\n",
+    ")[0].sort_values('valid', ascending=False).iloc[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: rsm (Column Subsampling)\n\n- rsm=0.75가 1위(0.9554), rsm=0.5도 근소 차이로 2위권\n- rsm=1.0(default)보다 feature subsampling이 정규화 효과\n- 이 데이터는 변수 수(11개)가 적어 rsm=0.75 수준이 적당한 다양성 확보\n- **최종 확정: rsm=0.75**"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "id": "b4cb781c-8439-40e3-92b2-87deba8b1f21",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 3 node(s)\n",
+      "Exp 1/1 (100%) cb_subsample_0.75 3/3 (100%)\n",
+      "Experimentation complete: 3 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.set_grp('cb_subsample', parent='cb', params={'iterations': 10000, 'depth': 3, 'rsm': 0.75})\n",
+    "\n",
+    "for subsample in [0.75, 0.5, 0.25]:\n",
+    "    node_name = f'cb_subsample_{subsample}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_rsm',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={'subsample': subsample}\n",
+    "    )\n",
+    "e_aml.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "id": "e83ec809-35a0-47d4-a5ec-5fb5887d47c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_rsm_0.75</th>\n",
+       "      <td>0.955354</td>\n",
+       "      <td>0.956264</td>\n",
+       "      <td>0.956959</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_subsample_0.5</th>\n",
+       "      <td>0.955334</td>\n",
+       "      <td>0.956207</td>\n",
+       "      <td>0.956955</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>0.955331</td>\n",
+       "      <td>0.956071</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_learning_rate_0.02</th>\n",
+       "      <td>0.955329</td>\n",
+       "      <td>0.956100</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_subsample_0.75</th>\n",
+       "      <td>0.955323</td>\n",
+       "      <td>0.956082</td>\n",
+       "      <td>0.956928</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          valid  train_sub  valid_sub\n",
+       "cb_rsm_0.75            0.955354   0.956264   0.956959\n",
+       "cb_subsample_0.5       0.955334   0.956207   0.956955\n",
+       "cb_max_depth_3         0.955331   0.956071   0.956928\n",
+       "cb_learning_rate_0.02  0.955329   0.956100   0.956928\n",
+       "cb_subsample_0.75      0.955323   0.956082   0.956928"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    None\n",
+    ")[0].sort_values('valid', ascending=False).iloc[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: subsample\n\n- subsample=0.5가 rsm_0.75와 동급(0.9553), subsample=0.75도 근접\n- rsm 대비 subsample의 단독 기여는 미미\n- rsm=0.75 + subsample=default(bootstrap) 조합 유지\n- **최종 확정: subsample 기본값 사용**"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "id": "6516fb7a-54af-4adc-83a0-c556af36b5c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finalize 'cb_max_depth_3'\n",
+      "Finalize 'cb_max_depth_4'\n",
+      "Finalize 'cb_max_depth_5'\n",
+      "Finalize 'cb_max_depth_6'\n",
+      "Finalize 'cb_max_depth_7'\n",
+      "Finalize 'cb_max_depth_8'\n",
+      "Finalize 'cb_max_depth_9'\n",
+      "Finalize 'cb_max_depth_10'\n",
+      "Finalize 'cb_max_depth_2'\n",
+      "Finalize 'cb_learning_rate_0.02'\n",
+      "Finalize 'cb_learning_rate_0.0075'\n",
+      "Finalize 'cb_learning_rate_0.005'\n",
+      "Finalize 'cb_learning_rate_0.0025'\n",
+      "Finalize 'cb_learning_rate_0.0001'\n",
+      "Finalize 'cb_rsm_0.75'\n",
+      "Finalize 'cb_rsm_0.5'\n",
+      "Finalize 'cb_rsm_0.25'\n",
+      "Finalize 'cb_subsample_0.75'\n",
+      "Finalize 'cb_subsample_0.5'\n",
+      "Finalize 'cb_subsample_0.25'\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.finalize('cb_.*')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "id": "e196a989-8bc9-4b83-86b7-44160bde791f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 2 node(s)\n",
+      "Exp 1/1 (100%) cb_border_count_511 2/2 (100%)\n",
+      "Experimentation complete: 2 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.set_grp('cb_border_count', parent='cb', params={'iterations': 10000, 'depth': 3, 'rsm': 0.75})\n",
+    "\n",
+    "for border_count in [127, 511]:\n",
+    "    node_name = f'cb_border_count_{border_count}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_border_count',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={'border_count': border_count}\n",
+    "    )\n",
+    "e_aml.exp('cb_border_count_.*')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "id": "3c106960-acca-45f7-86db-ef8eb8550ab3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "      <th>valid_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_border_count_511</th>\n",
+       "      <td>0.955354</td>\n",
+       "      <td>0.956264</td>\n",
+       "      <td>0.956959</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_border_count_127</th>\n",
+       "      <td>0.955323</td>\n",
+       "      <td>0.956110</td>\n",
+       "      <td>0.956914</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        valid  train_sub  valid_sub\n",
+       "cb_border_count_511  0.955354   0.956264   0.956959\n",
+       "cb_border_count_127  0.955323   0.956110   0.956914"
+      ]
+     },
+     "execution_count": 115,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    'cb_border_count.*'\n",
+    ")[0].sort_values('valid', ascending=False).iloc[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: border_count\n\n- border_count=511 vs 127 — 사실상 동일 (0.9554)\n- border_count는 연속형 변수 이산화 분할 수. 이 데이터는 변수 수가 적고 값 범위도 좁아 기본값으로 충분\n- **최종 확정: border_count=default 유지**"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 116,
+   "id": "7298820e-f6f4-4996-b84f-e85bc47ef62e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finalize 'cb_border_count_127'\n",
+      "Finalize 'cb_border_count_511'\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.finalize('cb_.*')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## CatBoost Optuna 탐색\n\n개별 파라미터 탐색 결과로 얻은 prior:\n- depth=3, rsm=0.75, subsample=default(bootstrap), border_count=default\n\n탐색 범위: depth(3~5), learning_rate(0.005~0.015), l2_leaf_reg(1e-3~10), rsm(0.5~1.0), subsample(0.5~1.0)\ntrial마다 exp+finalize → AUC 반환 (50 trials)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70c29a0f-057d-4b38-8896-6801236f3a62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import optuna\n",
+    "from IPython.display import clear_output\n",
+    "\n",
+    "e_aml.set_grp('cb_optuna', parent='cb', params={'iterations': 10000})\n",
+    "def objective(trial):\n",
+    "    trial_number = trial.number\n",
+    "    node_name = f'cb_optuna_{trial_number}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_optuna',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={\n",
+    "            \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.005, 0.015),\n",
+    "            \"depth\": trial.suggest_int(\"depth\", 3, 5),\n",
+    "            \"l2_leaf_reg\": trial.suggest_float(\"l2_leaf_reg\", 1e-3, 10, log=True),\n",
+    "            \"rsm\": trial.suggest_float(\"rsm\", 0.5, 1.0), \n",
+    "            \"subsample\": trial.suggest_float(\"subsample\", 0.5, 1.0),\n",
+    "        }\n",
+    "    )\n",
+    "    e_aml.exp(node_name)\n",
+    "    e_aml.finalize(node_name)\n",
+    "    clear_output()\n",
+    "    return e_aml.collectors['AUC'].get_metrics_agg(node_name)[0].iloc[0]['valid']\n",
+    "\n",
+    "# Study 생성 및 최적화\n",
+    "study = optuna.create_study(direction=\"maximize\")\n",
+    "study.optimize(objective, n_trials=50)\n",
+    "\n",
+    "print(\"Best Score:\", study.best_value)\n",
+    "print(\"Best Params:\", study.best_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "id": "2de8af08-be22-4422-955c-6584bd77b0d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"5\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>depth</th>\n",
+       "      <th>l2_leaf_reg</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>rsm</th>\n",
+       "      <th>subsample</th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_33</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1.479891</td>\n",
+       "      <td>0.013043</td>\n",
+       "      <td>0.668498</td>\n",
+       "      <td>0.962132</td>\n",
+       "      <td>0.955329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_28</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0.084098</td>\n",
+       "      <td>0.013898</td>\n",
+       "      <td>0.752706</td>\n",
+       "      <td>0.995564</td>\n",
+       "      <td>0.955329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_46</th>\n",
+       "      <td>3</td>\n",
+       "      <td>3.007111</td>\n",
+       "      <td>0.013057</td>\n",
+       "      <td>0.868617</td>\n",
+       "      <td>0.908254</td>\n",
+       "      <td>0.955324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_42</th>\n",
+       "      <td>3</td>\n",
+       "      <td>2.729726</td>\n",
+       "      <td>0.012293</td>\n",
+       "      <td>0.871871</td>\n",
+       "      <td>0.935666</td>\n",
+       "      <td>0.955324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_39</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1.105251</td>\n",
+       "      <td>0.012136</td>\n",
+       "      <td>0.955694</td>\n",
+       "      <td>0.913699</td>\n",
+       "      <td>0.955324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_47</th>\n",
+       "      <td>3</td>\n",
+       "      <td>6.394268</td>\n",
+       "      <td>0.014984</td>\n",
+       "      <td>0.922567</td>\n",
+       "      <td>0.902889</td>\n",
+       "      <td>0.955318</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_43</th>\n",
+       "      <td>3</td>\n",
+       "      <td>2.777438</td>\n",
+       "      <td>0.013063</td>\n",
+       "      <td>0.875396</td>\n",
+       "      <td>0.925907</td>\n",
+       "      <td>0.955317</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_25</th>\n",
+       "      <td>4</td>\n",
+       "      <td>0.102012</td>\n",
+       "      <td>0.011701</td>\n",
+       "      <td>0.741056</td>\n",
+       "      <td>0.995647</td>\n",
+       "      <td>0.955313</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_49</th>\n",
+       "      <td>3</td>\n",
+       "      <td>3.743680</td>\n",
+       "      <td>0.014026</td>\n",
+       "      <td>0.980209</td>\n",
+       "      <td>0.942806</td>\n",
+       "      <td>0.955311</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_34</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1.404035</td>\n",
+       "      <td>0.012298</td>\n",
+       "      <td>0.742573</td>\n",
+       "      <td>0.999678</td>\n",
+       "      <td>0.955309</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             params                                                     AUC\n",
+       "              depth l2_leaf_reg learning_rate       rsm subsample     valid\n",
+       "cb_optuna_33      3    1.479891      0.013043  0.668498  0.962132  0.955329\n",
+       "cb_optuna_28      3    0.084098      0.013898  0.752706  0.995564  0.955329\n",
+       "cb_optuna_46      3    3.007111      0.013057  0.868617  0.908254  0.955324\n",
+       "cb_optuna_42      3    2.729726      0.012293  0.871871  0.935666  0.955324\n",
+       "cb_optuna_39      3    1.105251      0.012136  0.955694  0.913699  0.955324\n",
+       "cb_optuna_47      3    6.394268      0.014984  0.922567  0.902889  0.955318\n",
+       "cb_optuna_43      3    2.777438      0.013063  0.875396  0.925907  0.955317\n",
+       "cb_optuna_25      4    0.102012      0.011701  0.741056  0.995647  0.955313\n",
+       "cb_optuna_49      3    3.743680      0.014026  0.980209  0.942806  0.955311\n",
+       "cb_optuna_34      3    1.404035      0.012298  0.742573  0.999678  0.955309"
+      ]
+     },
+     "execution_count": 192,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_cb_optuna =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('cb_optuna.*')\n",
+    ")['CatBoostClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'cb_optuna.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_cb_optuna.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 212,
+   "id": "255d047e-fc80-4365-9084-343cad9051df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'cb_optuna_33'"
+      ]
+     },
+     "execution_count": 212,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best_node = df_cb_optuna.index[0]\n",
+    "best_node"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: CatBoost Optuna1 결과\n\n상위 노드 공통 패턴:\n- **depth: 모두 3** — 탐색 범위 3~5 중 3이 최우선\n- **learning_rate: 0.013~0.014** — 1차 탐색 상한(0.015)에 붙은 결과 → 상한이 낮음\n- **rsm: 0.5~1.0 범위에서 유효** — 0.67~0.87 구간에 집중\n- **subsample: 영향 없음** — 0.5~1.0 고르게 분포, 성능 차이 없음\n- **l2_leaf_reg: 신호 약함** — 0.08~3.0 넓게 분포\n\n→ learning_rate 상한을 높여 재탐색 필요, subsample은 탐색 제외 가능"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "id": "4a6833c3-0f14-43d3-aae8-486eb488ab89",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collect 1/1 (100%) cb1 2/2 (100%)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<mllabs.collector._model_attr.ModelAttrCollector at 0x7f02319d4cb0>"
+      ]
+     },
+     "execution_count": 154,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Forget Collecting evals_results\n",
+    "# After finalize, cannot obtain the instance.\n",
+    "e_aml.add_collector(\n",
+    "    ModelAttrCollector('cb_evals_results', Connector(processor=cb.CatBoostClassifier), 'evals_result')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 156,
+   "id": "ec229f71-2037-4b68-9f72-1e6199196736",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reinitialize 'cb_optuna_33'\n",
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) cb_optuna_33 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Before execute exp, No needs to reinitialize\n",
+    "e_aml.reinitialize([best_node])\n",
+    "e_aml.exp([best_node])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 193,
+   "id": "da68a155-640c-4bfc-8313-c1b1d6d297f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cb2              994.0\n",
+       "cb1              998.0\n",
+       "cb_optuna_33    9913.0\n",
+       "Name: (evals_result, best_iteration), dtype: float64"
+      ]
+     },
+     "execution_count": 193,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['cb_evals_results'].get_attrs()\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation', 'AUC')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "s_best_iteration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 203,
+   "id": "7c62fd84-d650-42a4-96f8-b4be68c8c986",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjUAAAKyCAYAAACdeVx6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAADitElEQVR4nOzde3wU5dn/8W9Om03ICRMCCYZwlCASCCAROVqoUSgi8ihGVAQK1WI9ICpUFMSnorUgnipPsYAFVOgPRFv6YDmqHERFELCKJEajnCQREpKQbA7z+4MnK0tOm2Q3u7P5vF+vvGBn7p29djKZuWaumfv2MwzDEAAAAAAAAAAAgJfz93QAAAAAAAAAAAAAzqCoAQAAAAAAAAAATIGiBgAAAAAAAAAAMAWKGgAAAAAAAAAAwBQoagAAAAAAAAAAAFOgqAEAAAAAAAAAAEyBogYAAAAAAAAAADAFihoAAAAAAAAAAMAUAj0dQHNWUVGhY8eOKTw8XH5+fp4OBwDQjBmGobNnzyo+Pl7+/tzz4K3IHQAA3oC8wRzIGwAA3sAdeQNFDQ86duyYEhISPB0GAAB233//vS699FJPh4EakDsAALwJeYN3I28AAHgTV+YNFDU8KDw8XNL5X2hERISHowEANGf5+flKSEiwH5vgncgdAADegLzBHMgbAADewB15A0UND6p8/DMiIoIEAwDgFeiawLuROwAAvAl5g3cjbwAAeBNX5g10fgkAAAAAAAAAAEyBogYAAAAAAAAAADAFihoAAAAAAAAAAMAUKGoAAAAAAAAAAABToKgBAAAAAAAAAABMgaIGAAAAAAAAAAAwhUBPBwDXOJlfrNOFNuUXlykiJFAtQy1qHWH1dFgAAMDL5RXZlFNgU35xqSJCghTTwqLIUIunw3IJX/5uAAAAAJznDecG3hCDr6Co4QOycws16+2D2pmRa582sHO0nh7TQ+2iW3gwMgAA4M2OnTmnR9ce0IdHcuzTBneJ0TNjkxUfFeLByBrPl78bAAAAAOd5w7mBN8TgS+h+yuRO5hdXKWhI0o6MXP3+7YM6mV/socgAAIA3yyuyVUmqJemDIzmaufaA8opsHoqs8Xz5uwEAAABwnjecG3hDDL6GoobJnS60VSloVNqRkavThfxRAACAqnIKbFWS6kofHMlRToF5cwhf/m4AAAAAnOcN5wbeEIOvofspk8svLlNCyxC9Mr63AgP8dfbc+T7ZSssrNG3VZ8ovLvN0iAAAwAvlF5fWOv9sHfObSkP6nTXLd3NGfb4/ffQCAADAm9SUnzZl3lp5bhBqCdCkgR2UkhClkrIKWYMC9Fn2aRWWuP/cwJfOT7wFRQ2Ta9kiUH+b3E+z1x+qMqbG3yb3U1lFhQejAwAA3irCGlTr/PA65jeFhvY7a4bv5oz6fH/66AUAAIA3qSk//e8br9C8f/5Hm7/80WG6u/LWCGuQQi0BejE9Rct2ZunlrRn2eQM6R+u/el/q8s+sLobamOX8xJvQ/ZTJhQQFViloSOe7nnp8/SGFBFG3AgAAVcWEWTS4S0y18wZ3iVFMmGfv8G9Mv7Pe/t2cUZ/vTx+9AAAA8Ca15ae/f/ugkuIiqkx3V94aE2bR47+6XMt2ZlW5frozI1dPvHPI7fmyL5yfeBuKGiZ3tris1jE1ztL9FAAAqEZkqEXPjE2uklwP7hKjZ8cme7zbosb0O+vt380Z9fn+9NELAAAAb1JbfrojI1cpCVFVprsrb40Mtah3u6gar582Rb7sC+cn3obb+E0u/xx9sgEAgIaJjwrRS+kpyimw6WxxqcKtQYoJ845xGBrb76w3fzdn1Of700cvAAAAvEld+WlJWfXd5bsrby2yldc6vynyZbOfn3gbihomFxESVONAN0t3ZNEnGwAAqFVkqHcm0q7od9Zbv5sz6vP96aMXNWHweAAA4Al15afBgdV3HuSuvNVb8mWznJ+YIYekqGFyUSFBWnZXX2WeKnSYHh9p1bK7+ioqhJNYAABgPpX9zn5QzWPrzaHf2Qu//8U3sLQMDVKYNbDathdrDusK1WPweAAA4Cm15acDO0dr3/dnqkx3Z94aE2bRL7vFqmtcRJWbwg8fzydfvoBZckjG1DC5UEuADEPacPC4Jr/+qX676jNNWv6JNhw8LkN+CrUEeDpEAACAemvu/c5Wfv9fdovVi+kp2pd92p7rpS/Zo4f//rmOnTnn0La5ritUxeDxAADAk2rLT58e00OHj+dXme7OvDUy9Pxg4Rfm1JOWf6L92af1+K8uJ1/+P2bKIf0MwzA8HURzlZ+fr8jISOXl5SkiIqJBy/gup1C/X3+w2sFuBnSO1tM39lBiTIvGhgoA8HGuOCbB/Zrj76ny0efm2u/syfxizVizXx9Wk+sN7hKjl9JT7Oujua8r/CzzxwINW/h+jfO3TB+iTrFhTRgRfE1zPB6ZEb8nAJ5WU37a1HlrXpFN9765r9rByy/OqZszd+WQ7jge0f2UyRXayqotaEjSzoxcFdrKmjgioOmYoY8/ADADb96fmqXfWXcpKC6rtqAhnb9jKqfAZl8/zX1d4WcMHg8AABrLFecINeWnTZ235hTYqi1oSFVz6ubMTDkkRQ2TK7SV1zq/qI75gFmZpY8/APB27E+9m5lOLOA9vGUwTAAAYE6+do5ATu0cM+WQjKlhcnUNBB7JQOHwQWbq4w8AvBn7U+9nphMLeI/KwTmrw+DxAACgNr54jkBO7Rwz5ZA8qWFyseHBGt4tVklxEUpJiFJJWYWsQQH6LPu0vjqer9jwYE+HCLgcjw0CgGuwP/V+lScWH9TQ/6+nTyy8ueuy5qxycM6Zaw84bDsMHg8AAOrii+cI3pxTe1M+baYckqKGyUWGWjTnV5frwwzHP8q2kVaN63OpV21sgKvw2CAAuIYv7k+96aTAFbz5xMLXuiXwNfFRIXopPYXB4wEAQL00xTlCU+fs3ppTe2M+bZYckqKGyeUV2XQ8v7jKdEPS8fxiRYQEed1GBzQWjw0CgGtEWIMUagnQpIEdqjzxuXRHlun2p954UuAK3nhiUVe3BC+lp5CDegEGjwcAAPXl7msunsrZmzKndqZo4835tBlySIoaJpdXVKryCkMbDh7Xzoxc+/QBnaN17zWdlVdU6vUbIVBfMWEW/bJbrLpW0+3a4eP5Hu+KAwDMIibMoqV3XamXth7Ry1sz7NMHdI7W0ruutO9PzfD0gzefFLiCt51Y+GK3BAAAAHBvV02eztndkVNffK5kDfTXnHe/0OYvf7S3qa5oQz7dOBQ1TK6swtCSD79RSruWmjSgg8PF3SUffqPZIy73dIiAy0WGWvQE3a4BQINVJt5552wyDEMp7VpqX/YZFdnKJUn7ss8oK6dQ0S0sOvJjgUrLK7QzM1dLd2SpyFbulU8/cFLQtHyx6zIAAIC6mOFmn8ZyZ1dNvpazV/fUycDO0bprQAftysy1n19VV7RpaD7dHLZBZ1DUMLmS8nLd1b+DLEF+ahEcqILicoVbAzWwc7T6JV6ikvJyT4cIuFxekU0nzxarY6sWDtt9qMVfJ8/S7RoA1KYy8d773WlNGthBfdu11LWXt9bIHnHKKShRRYWh6DCL/nMsX9k/FdlvmIiPtOqV23pr2hufeeXTD1xkb1oXdktQXRdmLb1kuwAAAObkjRduzd7V6YU3NoUGB8rfz0+B/n6KrmbduqurJl/K2SufOtn73Wnd+4vODrnwibxz+s2Qjnp+0xF7+4uLNg3p5svs26ArUdQwuYAAP8W3tGrOu184dD81sHO05t7QXRUyPBgd4B75RaVq2cKiPd/8pNYRVpWUVehcablO5p1Tv46XKJ9u1wCgWhcm3i+mp+iNPd+pV0KUnt34lT2PCLUE6K8T+uofnx/Th9V0bVmZnHvbnVSMt9S0Krsl+PT/tqVlO7McujBrridX8H3eeJENAHyNN1649XS3SY1V3Tod0DlaEwd00Px/faknR19RZd26o6smX8rZcwps9vOqi3PhAZ2jNedX3fU/739jf1pDciza1Lebr8Zug76Ww1DUMDlrQIDm/uOLarufmv+vLzVnVHdPhwi4nCHpx/ySaseSaR/TQm0juYACANWpfNz73l901rKdWUpp11LLdmY57EsnDeygl7dlOEyTZH/96HVJ9juOvOlOKlf1/etryb67VHZL8P7Xp6psQ5J5TvCB+vDGi2wA4Gu8tXhg5m6TalqnlflbSruWTbZuq8vZK5/6vbpjtPLO2ZR5qsAUOXh+cakmDexQbS68MyNXT/3zi/PnVhcUOy4s2tS3m6/GbIO+mMP4ezoASXrllVfUvn17Wa1Wpaam6uOPP66xbWlpqebNm6dOnTrJarWqZ8+e2rhxo0ObuXPnys/Pz+EnKSnJoc3QoUOrtLn77rvt83Nzc3XdddcpPj5ewcHBSkhI0L333qv8/HyH5Wzfvl29e/dWcHCwOnfurOXLlzd+hdRDUWm57riqveIjrQ7T4yOtuv2q9ioqpfsp+J4y4+exZP46oa/+PL63lt51pVLatdSSD79RmcETSoAvI29ouMrHvVMSorQzI1d927Wssi+99vLW2pd9ptr3X5yse9udVI+N7Ka/TuirpXddqXt/0VmhloB69f177Mw53fvmPg1b+L7G/HmXhi14X797c5+OnTnXBNGbT3xUiPomtqyyXVSqPLkCfEFdF9nyitjWvRV5A2Auzly49QQzd5tU2zrdmZGrlISoJlu3lRfyB3eJkXS+oPFieor2ZZ/Wba/t0U2v7q5XDp5XZFPmjwXal31amacKmvR4HGENsp9XVefD/1u3laq70aqym68t04do/W+v1pbpQ/RSeoriqik0NGYMjppymDnvHNLJ/GKPrcPG8PiTGqtXr9b06dO1ePFipaamatGiRUpLS9Phw4cVGxtbpf3s2bO1cuVKLVmyRElJSXrvvfc0ZswY7dq1SykpKfZ23bt31+bNm+2vAwOrftUpU6Zo3rx59tehoaH2//v7+2v06NH67//+b7Vq1UoZGRmaNm2afvrpJ73xxhuSpKysLI0cOVJ33323Vq1apS1btujXv/614uLilJaW5pL1Uxc/SdYg/2rvWL/3ms7ya5IogKZVUna+mHc8z/EAFx9pVZ92LVVSRjEP8FXkDY1T+bh3SVmFQi0Biouyat+O0/a7h0ItAXp8ZDet/s1V+uH0OQUHnn/6s3KAcEn2f+vz9IO7VXfn0aAuMfrXfYPUMtS5cZa89a5Ab1dQUlbrfG8+wQfqw8x36DZn5A2A+XiieODMk7pm7japrnVaUlYhqenytgvH66gwDM37xxcNeurX008fxIRZ9G1uYa1tKtdtbTdaOdvNV0O3wZpymFBLgMb1a6cZa/Y7dDtslic4PF7UWLhwoaZMmaKJEydKkhYvXqwNGzZo6dKlmjlzZpX2K1as0GOPPaYRI0ZIku655x5t3rxZCxYs0MqVK+3tAgMD1aZNm1o/OzQ0tMY2LVu21D333GN/nZiYqN/+9rd67rnn7NMWL16sDh06aMGCBZKkbt26aceOHXr++eebLMkICvC337F+cfdTSz78RrNHXt4kcQBNyd/PT6GW6h80C7X4y9+Pch7gq8gbGicmzKJfdovVpS1D9LdJ/fTD6XOaPLCjUtq11FsfZ+uZsclatjNLs94+ZH/PgM7RejE9Rfe9uU9FtnIF+vvV6+kHd6upGPHhkRw98c4hvZSeUsM7HbnzgqUvd2ll5hN8oD7MfIduc0beAJhPU+cWzl4Yd1VXp55Q1zoNDjx/faUp87bKC/mZPxY4XFC/UE05eF6RTT+eLVH2T0WaOKCDeiZE2W/CasobkiJDLbq0Ze0X/ttHh2rL9CEuGWQ9Jsyi+Tf1UGx4sMP136U7stQ3sWWN22BNOUxNXWeZ5aYuj3Y/ZbPZtHfvXg0fPtw+zd/fX8OHD9fu3burfU9JSYmsVseulkJCQrRjxw6HaUeOHFF8fLw6duyo8ePHKzs7u8qyVq1apZiYGF1xxRWaNWuWioqKaoz12LFjWrdunYYMGWKftnv3bofYJSktLa3G2N2hpKxct6Umal/2aU1+/VP9dtVnmrT8k/OPbaUmcsc6fFJwgL8qDGnDweMO2/2Gg8dVYZyfD8D3kDc0XmSoRY//6nI9t/Er/dfi3Zr8+qf2vOG1CVfqjT3fVdsf7LKdWZo0sIMGdYlRq/DgGh+J9gRXdVHgrguWvt6lVeUJfnW8/QQfqA8KeOZD3gCYU1PmFvXpWvDibpMujMlbbvapSW3rdEDnaO37/ozH8rb65uCVufUvn//A4VzmxfQUhVoCJDVtN2VtIqy1bq9to0LUKTbMJdtHoa1c/zpwvMr136V3Xak/1rIN1pTD1NZ1lhm6kfXolb+cnByVl5erdevWDtNbt26tEydOVPuetLQ0LVy4UEeOHFFFRYU2bdqkdevW6fjx4/Y2qampWr58uTZu3KhXX31VWVlZGjRokM6ePWtvc9ttt2nlypXatm2bZs2apRUrVuj222+v8nnp6ekKDQ1V27ZtFRERoddee80+78SJE9XGnp+fr3Pnqp6olpSUKD8/3+Gnsfz8/GockGbZzizuWIdPqjBU65gaFQypAfik5pY3SK7PHfKKbHps/aEqd0PtzMjVgvcO6/L4SEnnH0W+9xed7fvYyQM7asQVbfTc2GQlRrfwqpM2VxUj3HHBsjn0wW/mE3ygPijgmQ95g2uuOQBNrabc4pfdYjX/ph7KKbC5rO//+t4cU5/xD7xJTet0QOdoTRzQQYeP53ssb6tPDl7bgOeVN2FVaqonKJsqF7Z/94yq3/3P2zIU8n8FnerUlMNUdo1VE29/CtXj3U/V1wsvvKApU6YoKSlJfn5+6tSpkyZOnKilS5fa21x//fX2/ycnJys1NVWJiYlas2aNJk+eLEmaOnWqvU2PHj0UFxenYcOGKTMzU506dbLPe/755zVnzhx9/fXXmjVrlqZPn64///nPDYp9/vz5evLJJxv03hoZVQftrLQzI1eMlwxfVFJex5ga5TyhBOA8M+cNkutzhwtP3EItAZo0sINSEqLsjy/HhFkcuqGqHGtDOj9GxbNjk10Wi6u4qhjhji4Fmksf/Bf2i3y2uFTh1iCXPGIPeJPKixYz1x5w2E9QwPMt5A2Ad7g4t4gICZIlwF8z1x106fgJDbk5xtnxD1zJFV2ZXrhO886VKtQSoAB/PwX4++lPN/f02HGsPjl4XQOeTxrwc1GjKZ+gbIpcuDHnFTXlMFEh5n4K1aNFjZiYGAUEBOjkyZMO00+ePFlj35OtWrXS+vXrVVxcrNzcXMXHx2vmzJnq2LFjjZ8TFRWlyy67TBkZGTW2SU1NlSRlZGQ4JBlt2rRRmzZtlJSUpEsuuUSDBg3S448/rri4OLVp06ba2CMiIhQSUnWHWpmkVMrPz1dCQkKNMTmjyFb74IyVg3kCvsTf30/WIH9tOHjcoag3oHO07r2ms/z9eUIJ8EXNLW+QXJ87VJ64hVoC9GJ6StXCRedovTbhSr245esqN0186KV9q7qqGOGOC5bNqQ9+T5zgA02NAp65kDe45poD4CkX5hZ5RTbd++a+Gp9+bWh+aoauBV05GLY35mv1ycGdHfDcE09QunvdNva8orocJswaaNpxYiQPFzUsFov69OmjLVu26MYbb5QkVVRUaMuWLbr33ntrfa/ValXbtm1VWlqqtWvX6pZbbqmxbUFBgTIzM3XHHXfU2Gb//v2SpLi4uBrbVFSc/+MoKSmRJPXv31//+te/HNps2rRJ/fv3r/b9wcHBCg4OrnH5DREZUvsGFllH1Q0wI4u/v/62+1tNGtBBM69PUkFxucKtgTqZX6y/7f5Wj6QleTpEAG7Q3PIGyfW5Q+WJ22+GdNSP+cWaNKCDxqcmOgwyt+C9w+rZLkpbvzpV5f113QXkiQGxXVmMcPUFSzOcKAOoH2+8IITqkTcA7tPUOZ+7nn715ODfzqzDuroy9babjRrK2RzcmQHPffUJSlecV1SXw5j5KVSPdz81ffp0TZgwQX379lW/fv20aNEiFRYWauLEiZKkO++8U23bttX8+fMlSXv27NHRo0fVq1cvHT16VHPnzlVFRYUeeeQR+zJnzJihUaNGKTExUceOHdOcOXMUEBCg9PR0SVJmZqbeeOMNjRgxQtHR0Tpw4IAefPBBDR48WMnJ57tV+Ne//qWTJ0/qyiuvVFhYmL744gs9/PDDGjBggNq3by9Juvvuu/Xyyy/rkUce0aRJk7R161atWbNGGzZsaLL1FxNm0S+7xaprXIRD9xGfZZ/W4eP5Xl9VAxqipLxcDwzvqnn//MLhTuKBnaP1+K+60/0U4MPIGxqnMm+4vnucnrxoHzqgc7ReTE/RfW/u010D2te4jJruAnLlXWT15apihKtP0D15ogwAIG8A3METOZ+7nn71VNeCzq7Dmoo5oZYAJSdE6Xhesb7JKWyym4ncyZmbBmrLrQd1iVHnVmE+U+i5mLvOK8z8FKrHixrjxo3TqVOn9MQTT+jEiRPq1auXNm7caB8QKzs7W/7+P49nXlxcrNmzZ+ubb75RWFiYRowYoRUrVigqKsre5ocfflB6erpyc3PVqlUrDRw4UB999JFatWol6fwdG5s3b7YnNAkJCRo7dqxmz55tX0ZISIiWLFmiBx98UCUlJUpISNBNN92kmTNn2tt06NBBGzZs0IMPPqgXXnhBl156qV577TWlpaW5ea39LDLUojm/ulw/5J1Ti+BA+x3rAztH69Y+l5piIwTqKzggQLPfOVSla5QdGbl66p9f6KnRV3goMgDuRt7QOJGhFs29obtmrj1QZR9a+XrSwA61DhpX3V1ArrqLrDFFhcbePe2OE3T64PddnngqCUD9kTcAruWpJwfc+fRrU1/Urc86rK6YU1M3sk11M5Gz3JEr1ZVb13fAdjPlc+48rzDrU6h+hsFQ0p6Sn5+vyMhI5eXlKSIiokHLyCuyKbfQph/PFjsUNQpKShUbblW0F/9BAg315fF8jX11V5UBbiu7Tll7z9XqFtewvymguXLFMQnu54rfU+aPBRq28P0a5/91Ql+FBAXottf2VBlMvGVokDq2ClPrCKukn08Efiqy6WxxmX0/fPGYXlumD1Gn2LBa4/Lkkx419dNcGUNjT9Ar15PZ7n5C9Ty5rQIN5eoLN+QN5sDvCa5WVx7pTM7XEHlFNv3uzX013qVuprvz67MOq2t77y86a1/26So3KEnesy5ckSvVdtxyRW597Mw5PfHOISVd0PNNy9AgtbskVG1bhnptwcOs5xXuOB55/EkNNE7BuVJVGIZe2ppRpRueuTd0V8G5UlNs3EB9FJaUVntnQmXXKYUlZR6MDgC8W12P70tSYnSoftktVuP6tavxLjA/SY9cdLJyYRdWFxY26uoSwNP9Bburn+ZKZr37CVV5elsFGoJCHABXcVc3UHXxpadf67MOq+tyKCUhyiE3v5Ar8tbGckWuVNdxq7G5dV6RTU+8c0i3VnOuMyyplZ4Y1V2z1x/yyuMm5xU/86+7CbxZmaQ5735RbTc8c9/9QlzahS+KbhGsZTuzqu06ZdnOLEW3YAcPADWp6/H9S1uGqG3LUP33mB56vZp9beUJyfavT1U5WancD08a2MFhel1dAjhTVHAnT52gw3w8va0C9VXXxaW8IrZZAM5zZzdQdansJmrL9CFa/9urtWX6EL2UnlLvLoc8rT7rsLKYM7hLjH1abd3ESp7PWxubKzXFcSunwKakuIhqryt1i4/U798+yHHTBChqmFyRrbzaR86k84WNi7t/AHxBablR43a/MyNXpeX0qgcANam846s6g7vEqM3/dS1VUFymD2vY135wJEex4cHVztuZkauUhCiHZdY1cJ2niwqePEGHuXh6WwXqi0IcAFeqK49s6GDFzooMtahTbJh6tWupTrFhprxjvb7r8OJiTseYFrUu39N5a2NzpaY4buUXlyolIara60o1TXfl58M1KGqY3NlznFih+Sm01f4MUlEd8wGgOavuji+p6uP7dZ2Q1HaXWOU8Z7sE8HRRwdMn6DAPT2+rQH1RiAPgSs7mkahZQ9bhhcWcuEirV+etjc2VmuK4FWENqvFcxtufhMHPGFPD5CJCat8Z1LUzAcyICwoA0DiVd3zVNshcXfva4MCa741pHx2qLdOHOD1wXXX9BVdqqrv+fKWfZriXp7dVoL7ImwG4mjN5JGrXmHXo7XlrY3OlpjhuxYRZdDK/+uXUdo7jqs+Ha1DUMLmWLSwa2DlaO6p5NGpg52i1ZGwB+CAuKABA49U1yFxd+9ofz5ZU+77BXWLU9v8G8KtPLJ4+OeMEHc7whm0VqA/yZgDuwGDFjdeYdejNeWtjc6WmOG5FhlqUGB1a7fXUfd+fqfE6K8dN7+JnGAadz3tIfn6+IiMjlZeXp4iIiAYvJzu3UL9/+6DDH9zAztF6ekwPtYuuva89wKyOnTlX40HSbAOFAd7AVcckuFdT/55q29dK0qMu3g/nFdm88uQMuBjbKszEHXkzeYM58HsC4CmNyZWa6nrPDz8VadZFg4L/slusHv/V5Zq9/hDXm1zIHccjihoe5Mpf6Mn8Yp0utCm/uEwR1kC1bGFR6/8b6BPwVQ7bfUigWoay3QMNxUmvObjj91R5wpFfXKqIkCDFtHA84ajthIQLuwBgDq7eX5M3mAO/J8C16sqb4TpNdZ5R0+dwnuNa7jge0f2Uj2gdYeViLpqVY2fO6dG1Bxwq6oO7xOiZscmKp3IOAE5xZl9a26PxdD0AAObA/hoAGodrEE2rqY5bNX0Ox03vV/voJwDghfKKbFWSCUn64EiOZq49oLwim4ciAwDzYF8KAAAA1I28GfA+FDUAmE5Oga1KMlHpgyM5yikgoQCAurAvBQAAAOpG3gx4H7qf8hH064fmJL+4VKGWAE0a2EEpCVEqKauQNShAn2Wf1tIdWTpbXOrpEAHAq53ML5atvEJvTrlK4dZAncwv1qNrDzickLEvBQAAAM5fg6iNL+XNZr2+aNa40XAUNXwA/fqhuYkMCdKL6SlatjNLL2/NsE8f0DlaL6anKCIkyIPRAYB3y84t1Ky3D2pnRq592sDO0Vr166s0/rWP7IWNcCv7UgAAACCijrzYV/Jms15fNGvcaBy6nzI5+vVDc9QiOFDLdmY5XJCTpJ0ZuVq+M0stgqnXAkB1TuYXVyloSNKOjFw99c8v9OzYZEnnTwJiwrizCQAAAIgJs2hwl5hq5/lK3mzW64tmjRuNR1HD5OjXD81RQXFZlQtylXZk5KqguKyJIwIAczhdaKt1/xkbEazBXWL07NhkHtcGAAAAJEWGWvTM2OQqhQ1fypvNen3RrHGj8bid2eSaU79+QCW2ewBomPw6ir7nbOV6KT3FJ07MAAAAAFeJjwrRS+kpyimw6WxxqcKtQYoJ851xG8x6ncWscaPxKGqYXHPp1w+4ENs9mjsGQUNDRVhrT/0irEFOb0tshwAAAGhOIkN9N99tzHUWT54XcH2o+aKoYXKV/fp9UM2jVr7Srx9wMbZ7NGcMgobGaNnCooGdo7Wjmi6oBnaOVssWzu0/2Q4BAAAA39HQ6yyePi/g+lDzxZgaJtcc+vUDLsZ2j+Yqr8imJ945pJ4JUfrrhL768/jeWnrXlUpOiNKcdw4xCBrq1DrCqqfH9NDAztEO0wd2jtbTY3qodYS1zmUwGB/cLa/IpswfC7Qv+7QyTxWwTQEAALhZQ66zeMN5AdeH6uaruTVPavgAX+/XD6gO2z2ao9xCm8anJup43jmH6fGRVvVp11K5hTb+BlCndtEt9Mf/6qm8c6XKP1eqyJAgRYQEOX0nlTOD8bEdoqE8fbcfAABAc1Xf6ywXnxeEWgI0aWAHpSREqaSsQsfziyXJ7ecGXB+qmS/n1hQ1fIQv9+sH1ITtHs1NuWHIGuSvDQePa+cF3QcN6Byte6/prArD8GB0MIvGJrYMxgd3qetuPwaxBwAAcK/6XGe58Lwg1BKgF9NTtGxnll7emmGf3lQX0Lk+VJWv59Z0PwUAgEkE+vnp5W0ZDgUNSdqZkauXt2UowM/PQ5HBLFzxiDiD8cFdnHkKCAAAAN7hwvOCSQM7aNnOrCrnqnRR6zm+nlvzpIaPyCuyKafApvziUkWEBCmmBRVKAPA150rLqySJlXZm5OpcaXkTRwSzySmwae93p3XvLzrbHwu3BgXos+zTWrojy6muoxiMD+7CU0AAAADmceF5QUpClMMTGheii9q6ueO6rq/n1hQ1fIAv948GAPhZoa32okVRHfOBgpLSah8LH9A5Wi+mp6iwpO7EtnIwvplrDzgUNhiMD43FU0AAAADmceF5QUlZRa1tzX4B3Z3cdV3X13Nrihom5+v9owEAfhYVUnvSEVnHfCAqxKI/vne42i7MJOnpG3s4tRwG44M78BQQAACAuVSeFxzPK661ndkvoLuLO6/r+npuzZgaJufr/aMBAH4WGx6sQV1iqp03qEuMYsODmzgimI2tvKLWLsxs5bXfYXWhyFCLOsWGqVe7luoUG0ZBA41Webff4Iv2czwFBAAA4L0iQy2Ki7RWyeEq+cIFdHdx53VdX8+teVLD5Hy9fzQAwM8iQy16lm5/0AgFJWW1zi+sYz7gbjwFBAAAYD50Udsw7r6u68u5NUUNk/P1/tEAAI58OSmB+5E3wAwiQ9mnAQAAmA3nqvXXFOdnvppbU9QwOV/vHw0AUJWvJiVwP/IGAAAAAO7CuWr9cH7WcIypYXK+3j8aAABwHfIGAAAAAPAOnJ81HE9q+AAe7wKA5iWvyKacApvyi0sVERKkmBbs8+E88gZ4C/ZlANA8sf8HgJ9xftYwFDV8BI93AUDzcOzMOT269oA+vGjwtWfGJis+KsSDkcFMyBvgaezLAKB5Yv8PAFVxflZ/XtH91CuvvKL27dvLarUqNTVVH3/8cY1tS0tLNW/ePHXq1ElWq1U9e/bUxo0bHdrMnTtXfn5+Dj9JSUkObYYOHVqlzd13322f//nnnys9PV0JCQkKCQlRt27d9MILLzgsY/v27VWW4efnpxMnTrhgrQAA4CivyFblJFCSPjiSo5lrDyivyOahyJoWeQNgbuzLADQl8gbvwf4fAOAqHn9SY/Xq1Zo+fboWL16s1NRULVq0SGlpaTp8+LBiY2OrtJ89e7ZWrlypJUuWKCkpSe+9957GjBmjXbt2KSUlxd6ue/fu2rx5s/11YGDVrzplyhTNmzfP/jo0NNT+/7179yo2NlYrV65UQkKCdu3apalTpyogIED33nuvw3IOHz6siIgI++vq4gYAoLFyCmxVTgIrfXAkRzkFNp+/u4O8ATA/9mUAmgp5g3dh/w8AcBWPFzUWLlyoKVOmaOLEiZKkxYsXa8OGDVq6dKlmzpxZpf2KFSv02GOPacSIEZKke+65R5s3b9aCBQu0cuVKe7vAwEC1adOm1s8ODQ2tsc2kSZMcXnfs2FG7d+/WunXrqiQZsbGxioqKqvO7AgDQGPnFpbXOP1vHfF9A3gCYH/syAE2FvMG7sP8HALiKR7ufstls2rt3r4YPH26f5u/vr+HDh2v37t3VvqekpERWq9VhWkhIiHbs2OEw7ciRI4qPj1fHjh01fvx4ZWdnV1nWqlWrFBMToyuuuEKzZs1SUVFRrfHm5eXpkksuqTK9V69eiouL0y9/+Uvt3LmzxveXlJQoPz/f4QcAAGdFWINqnR9ex3yza255Q2X85A7wNc19XwagaZA3eF/ewP4fAOAqHn1SIycnR+Xl5WrdurXD9NatW+urr76q9j1paWlauHChBg8erE6dOmnLli1at26dysvL7W1SU1O1fPlyde3aVcePH9eTTz6pQYMG6dChQwoPD5ck3XbbbUpMTFR8fLwOHDigRx99VIcPH9a6deuq/dxdu3Zp9erV2rBhg31aXFycFi9erL59+6qkpESvvfaahg4dqj179qh3795VljF//nw9+eST9V5PAABIUkyYRb/sFquucRFKSYhSSVmFrEEB+iz7tA4fz1dMmG8/rt/c8gbJfblDXpFNOQU25ReXKiIkSDEtGJgOTScmzKLBXWL0QTVdkAzuEuPz+zIATYO8wfuw/wfQXHH+5Xp+hmEYnvrwY8eOqW3bttq1a5f69+9vn/7II4/o/fff1549e6q859SpU5oyZYr+8Y9/yM/PT506ddLw4cO1dOlSnTt3rtrPOXPmjBITE7Vw4UJNnjy52jZbt27VsGHDlJGRoU6dOjnMO3TokK655hrdf//9mj17dq3faciQIWrXrp1WrFhRZV5JSYlKSkrsr/Pz85WQkKC8vDyHPjIBAKjJ97mF+jAjR60jrPaixsm8cxrYOUYJ0S0avNz8/HxFRkZ69TGpueUNkntyh2NnzlUZpHNwlxg9MzZZ8VEhDVomUF/HzpzTzLUHHC5sDe4So2fHJiuO7dDncCLve8gbfubreYOrsf93PfaxgHfj/Ms9eYNHn9SIiYlRQECATp486TD95MmTNfY92apVK61fv17FxcXKzc1VfHy8Zs6cqY4dO9b4OVFRUbrsssuUkZFRY5vU1FRJqpJk/Oc//9GwYcM0derUOhMMSerXr1+VR1MrBQcHKzg4uM5lAABQnbwim47mFWvDwePamZFrnz6gc7Q6tApTREiQT5/ANLe8QXJ97pBXZKuSUEvnB+ecufaAXkpP8eltCN4jPipEL6WnKKfAprPFpQq3BikmjIswvogTeXgKeYN3Yv/vWuxjAe/G+Zf7eHRMDYvFoj59+mjLli32aRUVFdqyZYvDnRTVsVqtatu2rcrKyrR27VqNHj26xrYFBQXKzMxUXFxcjW32798vSQ5tvvjiC11zzTWaMGGC/vCHPzj1nfbv31/r5wAA0FBnikr10tYjDgUNSdqZkauXth7RmSLfHlyRvKHxcgpsVRLqSh8cyVFOga3JYgEiQy3qFBumXu1aqlNsGCd0PqiuE/m8IvY5cB/yBu/F/t812McC3o/zL/fx6JMakjR9+nRNmDBBffv2Vb9+/bRo0SIVFhZq4sSJkqQ777xTbdu21fz58yVJe/bs0dGjR9WrVy8dPXpUc+fOVUVFhR555BH7MmfMmKFRo0YpMTFRx44d05w5cxQQEKD09HRJUmZmpt544w2NGDFC0dHROnDggB588EENHjxYycnJks4/AvqLX/xCaWlpmj59uk6cOCFJCggIUKtWrSRJixYtUocOHdS9e3cVFxfrtdde09atW/Xvf/+7ydYfAKD5KLSVVSloVNqZkatCW1kTR9T0yBsaJ7+49sLX2TrmA0B9OHMiz8VMuBN5A3wZ+1jA+3H+5T4eL2qMGzdOp06d0hNPPKETJ06oV69e2rhxo30wr+zsbPn7//xASXFxsWbPnq1vvvlGYWFhGjFihFasWKGoqCh7mx9++EHp6enKzc1Vq1atNHDgQH300Uf25MBisWjz5s32hCYhIUFjx451eNzz//2//6dTp05p5cqVWrlypX16YmKivv32W0mSzWbTQw89pKNHjyo0NFTJycnavHmzrrnmGjeuMQBAc1VoK691flEd830BeUPjRFiDap0fXsd8AKgPTuThaeQN8GXsYwHvx/mX+3h0oPDmzgyDqwEAvMeRk2f1y+c/qHH+pgcHq0vr8AYtm2OSOTT295RXZNPv3tznMDhnpcFdYujTFYBLZf5YoGEL369x/pbpQ9QpNqwJI4KrkDeYA78n38Y+FvB+nH+d547jkUfH1AAAAM6LDQ/WoC4x1c4b1CVGseHePTAkPC8y1KJnxiZr8EXb0eAuMXp2bHKzSKgBNJ2YMEuV/U2lwV1iFBPGPgcAGop9LOD9OP9yH57U8CDumgAA1NexM+c0c+0Bhzs9KhOiuKiQBi+XY5I5uOr3lFdkU06BTWeLSxVuDVJMmIWEGoBbuOu4Bc8ibzAHfk++j30sYA7N/fzLHccjj4+pAQAAnBcfFaKX0lOadUKExosMZZsB0DQ4bgGA+7CPBcyB8y/Xo6gBAIDJkBABAMyE4xYAuA/7WADNEWNqAAAAAAAAAAAAU6CoAQAAAAAAAAAATIGiBgAAAAAAAAAAMAWKGgAAAAAAAAAAwBQoagAAAAAAAAAAAFMI9HQAcI28IptyCmzKLy5VREiQYlpYFBlq8XRYAAAAtSKHAQAAaL7IBQE0BEUNH3DszDk9uvaAPjySY582uEuMnhmbrPioEA9GBgAAUDNyGAAAgOaLXBBAQ9H9lMnlFdmqHAAk6YMjOZq59oDyimweigwAAKBm5DAAAADNF7kggMagqGFyOQW2KgeASh8cyVFOAQcBAADgfchhAAAAmi9yQQCNQVHD5PKLS2udf7aO+QAAAJ5ADgMAANB8kQsCaAyKGiYXYQ2qdX54HfMBAAA8gRwGAACg+SIXBNAYFDVMLibMosFdYqqdN7hLjGLCLE0cEQAAQN3IYQAAAJovckEAjUFRw+QiQy16ZmxylQPB4C4xenZssiJDOQgAAADvQw4DAADQfJELAmiMQE8HgMaLjwrRS+kpyimw6WxxqcKtQYoJs3AAAAAAXo0cBgAAoPkiFwTQUBQ1fERkKDt9AABgPuQwAAAAzRe5IICGoPspAAAAAAAAAABgChQ1AAAAAAAAAACAKVDUAAAAAAAAAAAApkBRAwAAAAAAAAAAmAJFDQAAAAAAAAAAYAoUNQAAAAAAAAAAgClQ1AAAAAAAAAAAAKZAUQMAAAAAAAAAAJgCRQ0AAAAAAAAAAGAKFDUAAAAAAAAAAIApBHo6ALhGXpFNOQU25ReXKiIkSDEtLIoMtXg6LAAAAPIUAACAapAjAUDDUNTwAcfOnNOjaw/owyM59mmDu8TombHJio8K8WBkAACguSNPAQAAqIocCQAaziu6n3rllVfUvn17Wa1Wpaam6uOPP66xbWlpqebNm6dOnTrJarWqZ8+e2rhxo0ObuXPnys/Pz+EnKSnJoc3QoUOrtLn77rvt8z///HOlp6crISFBISEh6tatm1544YUq8Wzfvl29e/dWcHCwOnfurOXLlzduZdRTXpGtykFQkj44kqOZaw8or8jWpPEAAOBu5A3mQZ4CAPA08gZ4I3IkAGgcjz+psXr1ak2fPl2LFy9WamqqFi1apLS0NB0+fFixsbFV2s+ePVsrV67UkiVLlJSUpPfee09jxozRrl27lJKSYm/XvXt3bd682f46MLDqV50yZYrmzZtnfx0aGmr//969exUbG6uVK1cqISFBu3bt0tSpUxUQEKB7771XkpSVlaWRI0fq7rvv1qpVq7Rlyxb9+te/VlxcnNLS0lyyfuqSU2DT3u9O695fdFZKQpRKyipkDQrQZ9mntXRHlnIKbDy6CADwGeQNrtMU3R3kFNiqnKxX+uBIDnkKAMCtyBvgrVyVI9F9FYDmys8wDMOTAaSmpurKK6/Uyy+/LEmqqKhQQkKCfve732nmzJlV2sfHx+uxxx7TtGnT7NPGjh2rkJAQrVy5UtL5OyfWr1+v/fv31/i5Q4cOVa9evbRo0SKnY502bZq+/PJLbd26VZL06KOPasOGDTp06JC9za233qozZ85UuZujOvn5+YqMjFReXp4iIiKcjuNCn39/WqcKbFq2M0s7M3Lt0wd0jtbEAR0UG2ZRckLLBi0bANB8uOKY1BSac94gue731FTdHezLPq0xf95V4/z1v71avdqRpwCA2ZA3NK+8Aa7nihyJ7qsAmIU7jkce7X7KZrNp7969Gj58uH2av7+/hg8frt27d1f7npKSElmtVodpISEh2rFjh8O0I0eOKD4+Xh07dtT48eOVnZ1dZVmrVq1STEyMrrjiCs2aNUtFRUW1xpuXl6dLLrnE/nr37t0OsUtSWlparbHn5+c7/DRWVIilSkFDknZm5GrZzixFhlChBwD4huaWN1TG7+rcoSm7O4iwBtU6P7yO+QAANBR5g2vyBrhHY3Mkuq8C0Nx5tKiRk5Oj8vJytW7d2mF669atdeLEiWrfk5aWpoULF+rIkSOqqKjQpk2btG7dOh0/ftzeJjU1VcuXL9fGjRv16quvKisrS4MGDdLZs2ftbW677TatXLlS27Zt06xZs7RixQrdfvvtNca6a9curV69WlOnTrVPO3HiRLWx5+fn69y5c1WWMX/+fEVGRtp/EhISal9BTrCVV1QpaFTamZErW3lFoz8DAABv0NzyBsk9uYMz3R24SkyYRYO7xFQ7b3CXGMWEcfMFAMA9yBtckzfAPRqbIzVlPgcA3sjjY2rU1wsvvKApU6YoKSlJfn5+6tSpkyZOnKilS5fa21x//fX2/ycnJys1NVWJiYlas2aNJk+eLEkOyUKPHj0UFxenYcOGKTMzU506dXL4zEOHDmn06NGaM2eOrr322gbHPmvWLE2fPt3+Oj8/v9FJRkFJWa3zC+uYDwCALzNz3iC5J3fILy6tdf7ZOubXR2SoRc+MTdbMtQf0wUVdIzw7Npk+nwEAXoW8AU2lsTlSU+ZzAOCNPFrUiImJUUBAgE6ePOkw/eTJk2rTpk2172nVqpXWr1+v4uJi5ebmKj4+XjNnzlTHjh1r/JyoqChddtllysjIqLFNamqqJCkjI8MhyfjPf/6jYcOGaerUqZo9e7bDe9q0aVNt7BEREQoJqdp/YXBwsIKDg2uMoSHo1gEA0Fw0t7xB8o3cIT4qRC+lpyinwKazxaUKtwYpJoxBLAEA7kXeAG/XmByJa0EAmjuPdj9lsVjUp08fbdmyxT6toqJCW7ZsUf/+/Wt9r9VqVdu2bVVWVqa1a9dq9OjRNbYtKChQZmam4uLiamxTOcjXhW2++OILXXPNNZowYYL+8Ic/VHlP//79HWKXpE2bNtUZuyvRrQMAoLkgb3ANT+QOkaEWdYoNU692LdUpNoyCBgDA7cgbYAYNzZG4FgSguXPqSY0DBw44vcDk5OR6BTB9+nRNmDBBffv2Vb9+/bRo0SIVFhZq4sSJkqQ777xTbdu21fz58yVJe/bs0dGjR9WrVy8dPXpUc+fOVUVFhR555BH7MmfMmKFRo0YpMTFRx44d05w5cxQQEKD09HRJUmZmpt544w2NGDFC0dHROnDggB588EENHjzYHv+hQ4f0i1/8QmlpaZo+fbq9z82AgAC1atVKknT33Xfr5Zdf1iOPPKJJkyZp69atWrNmjTZs2FCvddAYdOsAAPBG7sodyBsaj9wBAOBtyBu8N2+AdyKfA9DsGU7w8/Mz/P397f/W9tMQL730ktGuXTvDYrEY/fr1Mz766CP7vCFDhhgTJkywv96+fbvRrVs3Izg42IiOjjbuuOMO4+jRow7LGzdunBEXF2dYLBajbdu2xrhx44yMjAz7/OzsbGPw4MHGJZdcYgQHBxudO3c2Hn74YSMvL8/eZs6cOYakKj+JiYkOn7Vt2zajV69ehsViMTp27GgsW7bM6e+dl5dnSHL43IY6U1hiZJw8a+z77icj4+RZ40xhSaOXCQBoPlx5TDIM9+YOzTVvMAxyBwCAdyBvaH55A7wT+RwAM3DH8cjPMAyjrsLHd999Z///vn37NGPGDD388MP2xx53796tBQsW6I9//KNuvPFGV9RamoX8/HxFRkYqLy9PERERng4HANCMufqYRO7gHuQOAABvQN5gDuQNAABv4I7jkVPdTyUmJtr/f/PNN+vFF1/UiBEj7NOSk5OVkJCgxx9/nAQDAACQOwAAAKeRNwAAgPqo90DhBw8eVIcOHapM79Chg/7zn/+4JCgAAOA7yB0AAICzyBsAAEBd6l3U6Natm+bPny+bzWafZrPZNH/+fHXr1s2lwQEAAPMjdwAAAM4ibwAAAHVxqvupCy1evFijRo3SpZdequTkZEnSgQMH5Ofnp3/84x8uDxAAAJgbuQMAAHAWeQMAAKiLUwOFX6ywsFCrVq3SV199Jen8nRS33XabWrRo4fIAfRmDdgEAvIW7j0nkDq5B7gAA8AbkDeZA3gAA8AYeGyj8Yi1atNDUqVNdEgAAAPB95A4AAMBZ5A0AAKA2ThU13n33XV1//fUKCgrSu+++W2vbG264wSWBAQAA8yJ3AAAAziJvAAAA9eFU91P+/v46ceKEYmNj5e9f89jifn5+Ki8vd2mAvoxHQQEA3sLVxyRyB/cgdwAAeAPyBnMgbwAAeAOPdT9VUVFR7f8BAACqQ+4AAACcRd4AAADqo+ZbIAAAAAAAAAAAALyIU09qvPjii04v8L777mtwMAAAwDeQOwAAAGeRNwAAgPpwakyNDh06OLcwPz998803jQ6quaB/SwCAt3D1MYncwT3IHQAA3oC8wRzIGwAA3sBjY2pkZWW55MMAAEDzQO4AAACcRd4AAADqgzE1AAAAAAAAAACAKTj1pMbFfvjhB7377rvKzs6WzWZzmLdw4UKXBAYAAHwHuQMAAHAWeQMAAKhNvYsaW7Zs0Q033KCOHTvqq6++0hVXXKFvv/1WhmGod+/e7ogRAACYGLkDAABwFnkDAACoS727n5o1a5ZmzJihgwcPymq1au3atfr+++81ZMgQ3Xzzze6IEQAAmBi5AwAAcBZ5AwAAqEu9ixpffvml7rzzTklSYGCgzp07p7CwMM2bN0/PPvusywMEAADmRu4AAACcRd4AAADqUu+iRosWLex9WsbFxSkzM9M+Lycnx3WRAQAAn0DuAAAAnEXeAAAA6lLvMTWuuuoq7dixQ926ddOIESP00EMP6eDBg1q3bp2uuuoqd8QIAABMjNwBAAA4i7wBAADUpd5FjYULF6qgoECS9OSTT6qgoECrV69Wly5dtHDhQpcHCAAAzI3cAQAAOIu8AQAA1KXeRY2nn35at99+u6Tzj4UuXrzY5UEBAADfQe4AAACcRd4AAADqUu8xNU6dOqXrrrtOCQkJevjhh/X555+7Iy4AAOAjyB0AAICzyBsAAEBd6l3UeOedd3T8+HE9/vjj+uSTT9S7d291795dTz/9tL799ls3hAgAAMyM3AEAADiLvAEAANTFzzAMozEL+OGHH/Tmm29q6dKlOnLkiMrKylwVm8/Lz89XZGSk8vLyFBER4elwAADNWFMek8gdGo7cAQDgDcgbzIG8AQDgDdxxPKr3kxoXKi0t1aeffqo9e/bo22+/VevWrV0SFAAA8E3kDgAAwFnkDQAAoDoNKmps27ZNU6ZMUevWrXXXXXcpIiJC//znP/XDDz+4Oj4AAOADyB0AAICzyBsAAEBtAuv7hrZt2+qnn37Sddddp7/85S8aNWqUgoOD3REbAADwAeQOAADAWeQNAACgLvUuasydO1c333yzoqKi3BAOAADwNeQOAADAWeQNAACgLvUuakyZMsUdcQAAAB9F7gAAAJxF3gAAAOrSqIHCAQAAAAAAAAAAmorHixqvvPKK2rdvL6vVqtTUVH388cc1ti0tLdW8efPUqVMnWa1W9ezZUxs3bnRoM3fuXPn5+Tn8JCUlObQZOnRolTZ33323Q5v77rtPffr0UXBwsHr16lUllm+//bbKMvz8/PTRRx81fGUAAIA6kTsAAABnkTcAAOB76t39lCutXr1a06dP1+LFi5WamqpFixYpLS1Nhw8fVmxsbJX2s2fP1sqVK7VkyRIlJSXpvffe05gxY7Rr1y6lpKTY23Xv3l2bN2+2vw4MrPo1p0yZonnz5tlfh4aGVmkzadIk7dmzRwcOHKjxO2zevFndu3e3v46Ojq77iwMAgAYhdwAAAM4ibwAAwDd5tKixcOFCTZkyRRMnTpQkLV68WBs2bNDSpUs1c+bMKu1XrFihxx57TCNGjJAk3XPPPdq8ebMWLFiglStX2tsFBgaqTZs2tX52aGhorW1efPFFSdKpU6dqTTCio6Pr/CwAAOAa5A4AAMBZ5A0AAPgmj3U/ZbPZtHfvXg0fPvznYPz9NXz4cO3evbva95SUlMhqtTpMCwkJ0Y4dOxymHTlyRPHx8erYsaPGjx+v7OzsKstatWqVYmJidMUVV2jWrFkqKipq0Pe44YYbFBsbq4EDB+rdd99t0DIAAEDdyB0AAICzyBsAAPBdHntSIycnR+Xl5WrdurXD9NatW+urr76q9j1paWlauHChBg8erE6dOmnLli1at26dysvL7W1SU1O1fPlyde3aVcePH9eTTz6pQYMG6dChQwoPD5ck3XbbbUpMTFR8fLwOHDigRx99VIcPH9a6deucjj8sLEwLFizQgAED5O/vr7Vr1+rGG2/U+vXrdcMNN1T7npKSEpWUlNhf5+fnO/15AAA0d+QO5A4AADiLvIG8AQDguzza/VR9vfDCC5oyZYqSkpLk5+enTp06aeLEiVq6dKm9zfXXX2//f3JyslJTU5WYmKg1a9Zo8uTJkqSpU6fa2/To0UNxcXEaNmyYMjMz1alTJ6diiYmJ0fTp0+2vr7zySh07dkzPPfdcjQnG/Pnz9eSTT9brOwMAgIYjdwAAAM4ibwAAwBw81v1UTEyMAgICdPLkSYfpJ0+erLG/yFatWmn9+vUqLCzUd999p6+++kphYWHq2LFjjZ8TFRWlyy67TBkZGTW2SU1NlaRa2zgjNTW11mXMmjVLeXl59p/vv/++UZ8HAEBzQu5A7gAAgLPIG8gbAAC+y2NFDYvFoj59+mjLli32aRUVFdqyZYv69+9f63utVqvatm2rsrIyrV27VqNHj66xbUFBgTIzMxUXF1djm/3790tSrW2csX///lqXERwcrIiICIcfAADgHHIHcgcAAJxF3kDeAADwXR7tfmr69OmaMGGC+vbtq379+mnRokUqLCzUxIkTJUl33nmn2rZtq/nz50uS9uzZo6NHj6pXr146evSo5s6dq4qKCj3yyCP2Zc6YMUOjRo1SYmKijh07pjlz5iggIEDp6emSpMzMTL3xxhsaMWKEoqOjdeDAAT344IMaPHiwkpOT7cvJyMhQQUGBTpw4oXPnztmTkMsvv1wWi0Wvv/66LBaLUlJSJEnr1q3T0qVL9dprrzXFqgMAoFkidwAAAM4ibwAAwDd5tKgxbtw4nTp1Sk888YROnDihXr16aePGjfaBvLKzs+Xv//PDJMXFxZo9e7a++eYbhYWFacSIEVqxYoWioqLsbX744Qelp6crNzdXrVq10sCBA/XRRx+pVatWks7frbF582Z7MpOQkKCxY8dq9uzZDrH9+te/1vvvv29/XZlIZGVlqX379pKkp556St99950CAwOVlJSk1atX67/+67/csaoAAIDIHQAAgPPIGwAA8E1+hmEYng6iucrPz1dkZKTy8vJ4LBQA4FEck8yB3xMAwBtwPDIHfk8AAG/gjuORx8bUAAAAAAAAAAAAqA+KGgAAAAAAAAAAwBQoagAAAAAAAAAAAFOgqAEAAAAAAAAAAEyBogYAAAAAAAAAADCFQE8HANfIK7Ipp8Cm/OJSRYQEKaaFRZGhFk+HBQAAgCZETggAQM04TgKAb6Co4QOOnTmnR9ce0IdHcuzTBneJ0TNjkxUfFeLByAAAANBUyAkBAKgZx0kA8B10P2VyeUW2KgdlSfrgSI5mrj2gvCKbhyIDAABAUyEnBACgZhwnAcC3UNQwuZwCW5WDcqUPjuQop4ADMwAAgK8jJwQAoGYcJwHAt1DUMLn84tJa55+tYz4AAADMj5wQAICacZwEAN9CUcPkIqxBtc4Pr2M+AAAAzI+cEACAmnGcBADfQlHD5GLCLBrcJabaeYO7xCgmzNLEEQEAAKCpkRMCAFAzjpMA4FsoaphcZKhFz4xNrnJwHtwlRs+OTVZkKAdmAAAAX0dOCABAzThOAoBvCfR0AGi8+KgQvZSeopwCm84WlyrcGqSYMAsHZQAAgGaEnBAAgJpxnAQA30FRw0dEhnIgBgAAaO7ICQEAqBnHSQDwDXQ/BQAAAAAAAAAATIGiBgAAAAAAAAAAMAWKGgAAAAAAAAAAwBQoagAAAAAAAAAAAFOgqAEAAAAAAAAAAEyBogYAAAAAAAAAADAFihoAAAAAAAAAAMAUKGoAAAAAAAAAAABToKgBAAAAAAAAAABMgaIGAAAAAAAAAAAwBYoaAAAAAAAAAADAFChqAAAAAAAAAAAAU6CoAQAAAAAAAAAATIGiBgAAAAAAAAAAMAWKGgAAAAAAAAAAwBQoagAAAAAAAAAAAFOgqAEAAAAAAAAAAEzB40WNV155Re3bt5fValVqaqo+/vjjGtuWlpZq3rx56tSpk6xWq3r27KmNGzc6tJk7d678/PwcfpKSkhzaDB06tEqbu+++26HNfffdpz59+ig4OFi9evWqNp4DBw5o0KBBslqtSkhI0B//+MeGrQQAAOA0cgcAAOAs8gYAAHxPoCc/fPXq1Zo+fboWL16s1NRULVq0SGlpaTp8+LBiY2OrtJ89e7ZWrlypJUuWKCkpSe+9957GjBmjXbt2KSUlxd6ue/fu2rx5s/11YGDVrzllyhTNmzfP/jo0NLRKm0mTJmnPnj06cOBAlXn5+fm69tprNXz4cC1evFgHDx7UpEmTFBUVpalTp9Z7XQAAgLqROwAAAGeRNwAA4Js8WtRYuHChpkyZookTJ0qSFi9erA0bNmjp0qWaOXNmlfYrVqzQY489phEjRkiS7rnnHm3evFkLFizQypUr7e0CAwPVpk2bWj87NDS01jYvvviiJOnUqVPVJhirVq2SzWbT0qVLZbFY1L17d+3fv18LFy4kwQAAwE3IHQAAgLPIGwAA8E0e637KZrNp7969Gj58+M/B+Ptr+PDh2r17d7XvKSkpkdVqdZgWEhKiHTt2OEw7cuSI4uPj1bFjR40fP17Z2dlVlrVq1SrFxMToiiuu0KxZs1RUVFSv+Hfv3q3BgwfLYrHYp1Xe8XH69Oka48/Pz3f4AQAAziF3IHcAAMBZ5A3kDQAA3+WxokZOTo7Ky8vVunVrh+mtW7fWiRMnqn1PWlqaFi5cqCNHjqiiokKbNm3SunXrdPz4cXub1NRULV++XBs3btSrr76qrKwsDRo0SGfPnrW3ue2227Ry5Upt27ZNs2bN0ooVK3T77bfXK/4TJ05UG3vlvOrMnz9fkZGR9p+EhIR6fSYAAM0ZuQO5AwAAziJvIG8AAPguj3Y/VV8vvPCCpkyZoqSkJPn5+alTp06aOHGili5dam9z/fXX2/+fnJys1NRUJSYmas2aNZo8ebIkOTyq2aNHD8XFxWnYsGHKzMxUp06d3Bb/rFmzNH36dPvr/Px8kgwAANyI3AEAADiLvAEAAHPw2JMaMTExCggI0MmTJx2mnzx5ssZ+J1u1aqX169ersLBQ3333nb766iuFhYWpY8eONX5OVFSULrvsMmVkZNTYJjU1VZJqbXOxNm3aVBt75bzqBAcHKyIiwuEHAAA4h9yB3AEAAGeRN5A3AAB8l8eKGhaLRX369NGWLVvs0yoqKrRlyxb179+/1vdarVa1bdtWZWVlWrt2rUaPHl1j24KCAmVmZiouLq7GNvv375ekWttcrH///vrggw9UWlpqn7Zp0yZ17dpVLVu2dHo5AADAOeQOAADAWeQNAAD4Lo8VNSRp+vTpWrJkiV5//XV9+eWXuueee1RYWKiJEydKku68807NmjXL3n7Pnj1at26dvvnmG3344Ye67rrrVFFRoUceecTeZsaMGXr//ff17bffateuXRozZowCAgKUnp4uScrMzNRTTz2lvXv36ttvv9W7776rO++8U4MHD1ZycrJ9ORkZGdq/f79OnDihc+fOaf/+/dq/f79sNpuk831kWiwWTZ48WV988YVWr16tF154weFRTwAA4FrkDgAAwFnkDQAA+CaPjqkxbtw4nTp1Sk888YROnDihXr16aePGjfbBr7Kzs+Xv/3Pdpbi4WLNnz9Y333yjsLAwjRgxQitWrFBUVJS9zQ8//KD09HTl5uaqVatWGjhwoD766CO1atVK0vm7NTZv3qxFixapsLBQCQkJGjt2rGbPnu0Q269//Wu9//779tcpKSmSpKysLLVv316RkZH697//rWnTpqlPnz6KiYnRE0884dB3JgAAcC1yBwAA4CzyBgAAfJOfYRiGp4NorvLz8xUZGam8vDz6ugQAeBTHJHPg9wQA8AYcj8yB3xMAwBu443jk0e6nAAAAAAAAAAAAnEVRAwAAAAAAAAAAmAJFDQAAAAAAAAAAYAoUNQAAAAAAAAAAgClQ1AAAAAAAAAAAAKZAUQMAAAAAAAAAAJgCRQ0AAAAAAAAAAGAKFDUAAAAAAAAAAIApUNQAAAAAAAAAAACmQFEDAAAAAAAAAACYAkUNAAAAAAAAAABgChQ1AAAAAAAAAACAKVDUAAAAAAAAAAAApkBRAwAAAAAAAAAAmAJFDQAAAAAAAAAAYAoUNQAAAAAAAAAAgClQ1AAAAAAAAAAAAKZAUQMAAAAAAAAAAJgCRQ0AAAAAAAAAAGAKFDUAAAAAAAAAAIApUNQAAAAAAAAAAACmQFEDAAAAAAAAAACYAkUNAAAAAAAAAABgChQ1AAAAAAAAAACAKVDUAAAAAAAAAAAApkBRAwAAAAAAAAAAmAJFDQAAAAAAAAAAYAoUNQAAAAAAAAAAgClQ1AAAAAAAAAAAAKZAUQMAAAAAAAAAAJgCRQ0AAAAAAAAAAGAKXlHUeOWVV9S+fXtZrValpqbq448/rrFtaWmp5s2bp06dOslqtapnz57auHGjQ5u5c+fKz8/P4ScpKcmhzdChQ6u0ufvuux3aZGdna+TIkQoNDVVsbKwefvhhlZWV2edv3769yjL8/Px04sQJF6wVAABQHfIGAADgLPIGAAB8T6CnA1i9erWmT5+uxYsXKzU1VYsWLVJaWpoOHz6s2NjYKu1nz56tlStXasmSJUpKStJ7772nMWPGaNeuXUpJSbG36969uzZv3mx/HRhY9atOmTJF8+bNs78ODQ21/7+8vFwjR45UmzZttGvXLh0/flx33nmngoKC9PTTTzss5/Dhw4qIiLC/ri5uAADQeOQNAADAWeQNAAD4KMPD+vXrZ0ybNs3+ury83IiPjzfmz59fbfu4uDjj5Zdfdph20003GePHj7e/njNnjtGzZ89aP3fIkCHG/fffX+P8f/3rX4a/v79x4sQJ+7RXX33ViIiIMEpKSgzDMIxt27YZkozTp0/X+lk1ycvLMyQZeXl5DXo/AACuYpZjUnPOGwzDPL8nAIBvM8vxiLzBHL8nAIBvc8fxyKPdT9lsNu3du1fDhw+3T/P399fw4cO1e/fuat9TUlIiq9XqMC0kJEQ7duxwmHbkyBHFx8erY8eOGj9+vLKzs6ssa9WqVYqJidEVV1yhWbNmqaioyD5v9+7d6tGjh1q3bm2flpaWpvz8fH3xxRcOy+nVq5fi4uL0y1/+Ujt37nR+BQAAAKeRNwAAAGeRNwAA4Ls82v1UTk6OysvLHQ7kktS6dWt99dVX1b4nLS1NCxcu1ODBg9WpUydt2bJF69atU3l5ub1Namqqli9frq5du+r48eN68sknNWjQIB06dEjh4eGSpNtuu02JiYmKj4/XgQMH9Oijj+rw4cNat26dJOnEiRPVxlU5T5Li4uK0ePFi9e3bVyUlJXrttdc0dOhQ7dmzR717964Se0lJiUpKSuyv8/Pz67vKAABotppb3iCROwAA0FDkDeQNAADf5fExNerrhRde0JQpU5SUlCQ/Pz916tRJEydO1NKlS+1trr/+evv/k5OTlZqaqsTERK1Zs0aTJ0+WJE2dOtXepkePHoqLi9OwYcOUmZmpTp06ORVL165d1bVrV/vrq6++WpmZmXr++ee1YsWKKu3nz5+vJ598st7fGQAANIyZ8waJ3AEAgKZE3gAAgDl4tPupmJgYBQQE6OTJkw7TT548qTZt2lT7nlatWmn9+vUqLCzUd999p6+++kphYWHq2LFjjZ8TFRWlyy67TBkZGTW2SU1NlSR7mzZt2lQbV+W8mvTr16/Gz5k1a5by8vLsP99//32NywEAAI6aW94gkTsAANBQ5A3kDQAA3+XRoobFYlGfPn20ZcsW+7SKigpt2bJF/fv3r/W9VqtVbdu2VVlZmdauXavRo0fX2LagoECZmZmKi4ursc3+/fslyd6mf//+OnjwoH788Ud7m02bNikiIkKXX355rcup6XOCg4MVERHh8AMAAJzT3PIGidwBAICGIm8gbwAA+C6Pdz81ffp0TZgwQX379lW/fv20aNEiFRYWauLEiZKkO++8U23bttX8+fMlSXv27NHRo0fVq1cvHT16VHPnzlVFRYUeeeQR+zJnzJihUaNGKTExUceOHdOcOXMUEBCg9PR0SVJmZqbeeOMNjRgxQtHR0Tpw4IAefPBBDR48WMnJyZKka6+9VpdffrnuuOMO/fGPf9SJEyc0e/ZsTZs2TcHBwZKkRYsWqUOHDurevbuKi4v12muvaevWrfr3v//dlKsQAIBmg7wBAAA4i7wBAADf5PGixrhx43Tq1Ck98cQTOnHihHr16qWNGzfaB8nKzs6Wv//PD5QUFxdr9uzZ+uabbxQWFqYRI0ZoxYoVioqKsrf54YcflJ6ertzcXLVq1UoDBw7URx99pFatWkk6f8fG5s2b7QlNQkKCxo4dq9mzZ9uXERAQoH/+85+655571L9/f7Vo0UITJkzQvHnz7G1sNpseeughHT16VKGhoUpOTtbmzZt1zTXXuHmtAQDQPJE3AAAAZ5E3AADgm/wMwzA8HURzlZ+fr8jISOXl5fFYKADAozgmmQO/JwCAN+B4ZA78ngAA3sAdxyOPjqkBAAAAAAAAAADgLIoaAAAAAAAAAADAFChqAAAAAAAAAAAAU6CoAQAAAAAAAAAATIGiBgAAAAAAAAAAMAWKGgAAAAAAAAAAwBQoagAAAAAAAAAAAFOgqAEAAAAAAAAAAEyBogYAAAAAAAAAADCFQE8HANfIK7Ipp8Cm/OJSRYQEKaaFRZGhFk+HBQAAvBB5AwAAcBZ5AwDA21DU8AHHzpzTo2sP6MMjOfZpg7vE6JmxyYqPCvFgZAAAwNuQNwAAAGeRNwAAvBHdT5lcXpGtSoIhSR8cydHMtQeUV2TzUGQAAMDbkDcAAABnkTcAALwVRQ2TyymwVUkwKn1wJEc5BSQZAADgPPIGAADgLPIGAIC3oqhhcvnFpbXOP1vHfAAA0HyQNwAAAGeRNwAAvBVFDZOLsAbVOj+8jvkAAKD5IG8AAADOIm8AAHgrihomFxNm0eAuMdXOG9wlRjFhliaOCAAAeCvyBgAA4CzyBgCAt6KoYXKRoRY9Mza5SqIxuEuMnh2brMhQkgwAAHAeeQMAAHAWeQMAwFsFejoANF58VIheSk9RToFNZ4tLFW4NUkyYhQQDAABUQd4AAACcRd4AAPBGFDV8RGQoSQUAAHAOeQMAAHAWeQMAwNvQ/RQAAAAAAAAAADAFihoAAAAAAAAAAMAUKGoAAAAAAAAAAABToKgBAAAAAAAAAABMgaIGAAAAAAAAAAAwhUBPB9CcGYYhScrPz/dwJACA5q7yWFR5bIJ3IncAAHgD8gZzIG8AAHgDd+QNFDU86OzZs5KkhIQED0cCAMB5Z8+eVWRkpKfDQA3IHQAA3oS8wbuRNwAAvIkr8wY/g1srPKaiokLHjh1TeHi4/Pz8Gr28/Px8JSQk6Pvvv1dERIQLImw6Zo5dIn5PMnPsEvF7mpnjd3XshmHo7Nmzio+Pl78/vVN6K1fmDmbe/j2J9dZwrLuGYb01HOuuYZxZb+QN5uDqaw7ehL/v+mOd1R/rrP5YZ/XXHNaZO/IGntTwIH9/f1166aUuX25ERIRp/wjMHLtE/J5k5tgl4vc0M8fvyti509L7uSN3MPP270mst4Zj3TUM663hWHcNU9d6I2/wfu665uBN+PuuP9ZZ/bHO6o91Vn++vs5cnTdwSwUAAAAAAAAAADAFihoAAAAAAAAAAMAUKGr4kODgYM2ZM0fBwcGeDqXezBy7RPyeZObYJeL3NDPHb+bY4R3YhhqG9dZwrLuGYb01HOuuYVhvMAO20/pjndUf66z+WGf1xzprGAYKBwAAAAAAAAAApsCTGgAAAAAAAAAAwBQoagAAAAAAAAAAAFOgqAEAAAAAAAAAAEyBogYAAAAAAAAAADAFihpe6NVXX1VycrIiIiIUERGh/v3763//939rfc/f//53JSUlyWq1qkePHvrXv/7lMN8wDD3xxBOKi4tTSEiIhg8friNHjnhF/EuWLNGgQYPUsmVLtWzZUsOHD9fHH3/s0Oauu+6Sn5+fw891113nFfEvX768SmxWq9WhTVOt//rGPnTo0Cqx+/n5aeTIkfY2TbnuL/bMM8/Iz89PDzzwQK3tvGn7v5Az8Xvb9l+f2L1p27+YM/F70/Y/d+7cKp+TlJRU63u8dbuHObzyyitq3769rFarUlNTq+x3UNX8+fN15ZVXKjw8XLGxsbrxxht1+PBhT4dlOs4e23He0aNHdfvttys6OlohISHq0aOHPv30U0+H5dXKy8v1+OOPq0OHDgoJCVGnTp301FNPyTAMT4fmdT744AONGjVK8fHx8vPz0/r16x3mk0vAneqbi7gq992wYYNSU1MVEhKili1b6sYbb3Tl13IrT6yzr7/+WqNHj1ZMTIwiIiI0cOBAbdu2zeXfzV1cvc7WrVuna6+9VtHR0fLz89P+/furLKO4uFjTpk1TdHS0wsLCNHbsWJ08edKVX8utmnqd/fTTT/rd736nrl27KiQkRO3atdN9992nvLw8V381t/HEdlbJMAxdf/311R7HfR1FDS906aWX6plnntHevXv16aef6he/+IVGjx6tL774otr2u3btUnp6uiZPnqx9+/bpxhtv1I033qhDhw7Z2/zxj3/Uiy++qMWLF2vPnj1q0aKF0tLSVFxc7PH4t2/frvT0dG3btk27d+9WQkKCrr32Wh09etSh3XXXXafjx4/bf958802Xx96Q+CUpIiLCIbbvvvvOYX5Trf/6xr5u3TqHuA8dOqSAgADdfPPNDu2aat1f6JNPPtH//M//KDk5udZ23rb91zd+b9v+6xO75D3b/oWcjd/btv/u3bs7fM6OHTtqbOut2z3MYfXq1Zo+fbrmzJmjzz77TD179lRaWpp+/PFHT4fm1d5//31NmzZNH330kTZt2qTS0lJde+21Kiws9HRoplGf4wuk06dPa8CAAQoKCtL//u//6j//+Y8WLFigli1bejo0r/bss8/q1Vdf1csvv6wvv/xSzz77rP74xz/qpZde8nRoXqewsFA9e/bUK6+8Uu18cgm4S31zEVflvmvXrtUdd9yhiRMn6vPPP9fOnTt12223uf37uoKn1tmvfvUrlZWVaevWrdq7d6969uypX/3qVzpx4oTbv3NjuWOdFRYWauDAgXr22Wdr/NwHH3xQ//jHP/T3v/9d77//vo4dO6abbrrJ5d/PHTyxzo4dO6Zjx47pT3/6kw4dOqTly5dr48aNmjx5slu+o6t5ajurtGjRIvn5+bns+5iKAVNo2bKl8dprr1U775ZbbjFGjhzpMC01NdX4zW9+YxiGYVRUVBht2rQxnnvuOfv8M2fOGMHBwcabb77pvqAvUFv8FysrKzPCw8ON119/3T5twoQJxujRo90UXd1qi3/ZsmVGZGRkje/19Pqvz7p//vnnjfDwcKOgoMA+zRPr/uzZs0aXLl2MTZs2GUOGDDHuv//+Gtt64/Zfn/gv5untvz6xe+O235h178ntf86cOUbPnj2dbu+N2z3Mo1+/fsa0adPsr8vLy434+Hhj/vz5HozKfH788UdDkvH+++97OhRTaMz+ubl69NFHjYEDB3o6DNMZOXKkMWnSJIdpN910kzF+/HgPRWQOkoy3337b/ppcAu5U31zEFblvaWmp0bZtW6fPjb2NJ9bZqVOnDEnGBx98YG+Tn59vSDI2bdrksu/mLq5eZxfKysoyJBn79u1zmH7mzBkjKCjI+Pvf/26f9uWXXxqSjN27dzfi2zQNT6yz6qxZs8awWCxGaWlp/b6AB3hyne3bt89o27atcfz48SrH8eaAJzW8XHl5ud566y0VFhaqf//+1bbZvXu3hg8f7jAtLS1Nu3fvliRlZWXpxIkTDm0iIyOVmppqb+MuzsR/saKiIpWWluqSSy5xmL59+3bFxsaqa9euuueee5Sbm+uOkB04G39BQYESExOVkJBQ5ckIT63/hqz7v/71r7r11lvVokULh+lNve6nTZumkSNHVtmuq+ON23994r+Yp7f/+sbubdt+Y9a9p7f/I0eOKD4+Xh07dtT48eOVnZ1dY1tv3O5hDjabTXv37nXYNvz9/TV8+HC2jXqqfCT+4v01qteY/XNz9e6776pv3766+eabFRsbq5SUFC1ZssTTYXm9q6++Wlu2bNHXX38tSfr888+1Y8cOXX/99R6OzFzIJeAuDclFXJH7fvbZZzp69Kj8/f2VkpKiuLg4XX/99Q53R3srT62z6Ohode3aVX/7299UWFiosrIy/c///I9iY2PVp08fV39Nl3LHOnPG3r17VVpa6rCcpKQktWvXzuv3nZ5aZ9XJy8tTRESEAgMDG7Ucd/PkOisqKtJtt92mV155RW3atKl/8D7Au7eOZuzgwYPq37+/iouLFRYWprfffluXX355tW1PnDih1q1bO0xr3bq1/XHAyn9ra+Nq9Yn/Yo8++qji4+Md/sivu+463XTTTerQoYMyMzP1+9//Xtdff712796tgIAAj8bftWtXLV26VMnJycrLy9Of/vQnXX311friiy906aWXNvn6b+i6//jjj3Xo0CH99a9/dZje1Ov+rbfe0meffaZPPvnEqfbetv3XN/6LeXL7r2/s3rbtN2bde3r7T01N1fLly9W1a1cdP35cTz75pAYNGqRDhw4pPDy8Sntv2+5hHjk5OSovL6922/jqq688FJX5VFRU6IEHHtCAAQN0xRVXeDocr9fYY2Nz9c033+jVV1/V9OnT9fvf/16ffPKJ7rvvPlksFk2YMMHT4XmtmTNnKj8/X0lJSQoICFB5ebn+8Ic/aPz48Z4OzVTIJeAuDclFXJH7fvPNN5LOj2W3cOFCtW/fXgsWLNDQoUP19ddfe/VNCp5aZ35+ftq8ebNuvPFGhYeHy9/fX7Gxsdq4caPXd4XojnXmjBMnTshisSgqKqpRy/EET62z6uJ46qmnNHXq1AYvo6l4cp09+OCDuvrqqzV69Oj6Be1DKGp4qa5du2r//v3Ky8vT//t//08TJkzQ+++/73RhwNMaGv8zzzyjt956S9u3b3cYcPjWW2+1/79Hjx5KTk5Wp06dtH37dg0bNsyj8ffv39/hSYirr75a3bp10//8z//oqaeecnlsdWnouv/rX/+qHj16qF+/fg7Tm3Ldf//997r//vu1adOmKgNOm0Fj4/fk9t+Q2L1p22/suvf09n/h3aPJyclKTU1VYmKi1qxZY5q+RIHmZNq0aTp06FCtY9/gPLMf2z2poqJCffv21dNPPy1JSklJ0aFDh7R48WKKGrVYs2aNVq1apTfeeEPdu3fX/v379cADDyg+Pp71BjRjFRUVkqTHHntMY8eOlSQtW7ZMl156qf7+97/rN7/5jSfD80qGYWjatGmKjY3Vhx9+qJCQEL322msaNWqUPvnkE8XFxXk6RPiY/Px8jRw5Updffrnmzp3r6XC81rvvvqutW7dq3759ng7Fo+h+yktZLBZ17txZffr00fz589WzZ0+98MIL1bZt06aNTp486TDt5MmT9sePKv+trY2r1Sf+Sn/605/0zDPP6N///nedA0h27NhRMTExysjIcGXYdg2Jv1JQUJBSUlLssTX1+m9I7IWFhXrrrbecunjqznW/d+9e/fjjj+rdu7cCAwMVGBio999/Xy+++KICAwNVXl5e5T3etP03JP5Knt7+GxN7JU9u+42J31u2/wtFRUXpsssuq/FzvGm7h7nExMQoICCAbaMR7r33Xv3zn//Utm3bdOmll3o6HK/niuNLcxUXF1flppRu3brV2j0hpIcfflgzZ87Urbfeqh49euiOO+7Qgw8+qPnz53s6NFMhl4C7NCQXcUXuW3kB/sL9anBwsDp27Oj1+1VPrbOtW7fqn//8p9566y0NGDBAvXv31p///GeFhITo9ddfd8l3cxd3rDNntGnTRjabTWfOnGnUcjzBU+us0tmzZ3XdddcpPDxcb7/9toKCguq9jKbmqXW2detWZWZmKioqyp5fS9LYsWM1dOjQ+n0JE6OoYRIVFRUqKSmpdl7//v21ZcsWh2mbNm2y30HdoUMHtWnTxqFNfn6+9uzZ4/RYC41VW/yS9Mc//lFPPfWUNm7cqL59+9a5vB9++EG5ublNdmdAXfFfqLy8XAcPHrTH5un170zsf//731VSUqLbb7+9zuW5c90PGzZMBw8e1P79++0/ffv21fjx47V///5qu/vxpu2/IfFL3rH9NzT2C3ly229M/N6y/V+ooKBAmZmZNX6ON233MBeLxaI+ffo4bBsVFRXasmUL20YdDMPQvffeq7fffltbt25Vhw4dPB2SKbji+NJcDRgwQIcPH3aY9vXXXysxMdFDEZlDUVGR/P0dT3MDAgLsd2nDOeQScJeG5CKuyH379Omj4OBgh/1qaWmpvv32W6/fr3pqnRUVFUlSlX2qv7+/1+9T3bHOnNGnTx8FBQU5LOfw4cPKzs72+n2np9aZdH7bu/baa2WxWPTuu++a5uleT62zmTNn6sCBAw75tSQ9//zzWrZsWf2/iFl5eqRyVDVz5kzj/fffN7KysowDBw4YM2fONPz8/Ix///vfhmEYxh133GHMnDnT3n7nzp1GYGCg8ac//cn48ssvjTlz5hhBQUHGwYMH7W2eeeYZIyoqynjnnXeMAwcOGKNHjzY6dOhgnDt3zuPxP/PMM4bFYjH+3//7f8bx48ftP2fPnjUMwzDOnj1rzJgxw9i9e7eRlZVlbN682ejdu7fRpUsXo7i42OPxP/nkk8Z7771nZGZmGnv37jVuvfVWw2q1Gl988YXDd2yK9V/f2CsNHDjQGDduXJXpTb3uqzNkyBDj/vvvt7/29u2/vvF72/Zfn9i9adtvSPyVvGH7f+ihh4zt27cbWVlZxs6dO43hw4cbMTExxo8//lht7N6+3cO7vfXWW0ZwcLCxfPly4z//+Y8xdepUIyoqyjhx4oSnQ/Nq99xzjxEZGWls377dYX9dVFTk6dBM5+L9M6r38ccfG4GBgcYf/vAH48iRI8aqVauM0NBQY+XKlZ4OzatNmDDBaNu2rfHPf/7TyMrKMtatW2fExMQYjzzyiKdD8zpnz5419u3bZ+zbt8+QZCxcuNDYt2+f8d133xmGQS4B96krF3FX7nv//fcbbdu2Nd577z3jq6++MiZPnmzExsYaP/30U9N9+QbyxDo7deqUER0dbdx0003G/v37jcOHDxszZswwgoKCjP379zftCmgAd6yz3NxcY9++fcaGDRsMScZbb71l7Nu3zzh+/Li9zd133220a9fO2Lp1q/Hpp58a/fv3N/r37990X7wRPLHO8vLyjNTUVKNHjx5GRkaGQ55dVlbWtCugATy1nV1MkvH222+77Xt6I4oaXmjSpElGYmKiYbFYjFatWhnDhg2zX5Q2jPMnghMmTHB4z5o1a4zLLrvMsFgsRvfu3Y0NGzY4zK+oqDAef/xxo3Xr1kZwcLAxbNgw4/Dhw14Rf2JioiGpys+cOXMMwzCMoqIi49prrzVatWplBAUFGYmJicaUKVPcdvGlvvE/8MADRrt27QyLxWK0bt3aGDFihPHZZ585LLOp1n9Dtp2vvvrKkOTQrlJTr/vqXHzhw9u3/4vVFb+3bf/1id2btv2GxG8Y3rP9jxs3zoiLizMsFovRtm1bY9y4cUZGRkatsXvzdg/v99JLL9n/fvv162d89NFHng7J61W3r5ZkLFu2zNOhmQ5FDef94x//MK644gojODjYSEpKMv7yl794OiSvl5+fb9x///1Gu3btDKvVanTs2NF47LHHjJKSEk+H5nW2bdtW7X6tMucgl4A71ZaLuCv3tdlsxkMPPWTExsYa4eHhxvDhw41Dhw657Tu6mifW2SeffGJce+21xiWXXGKEh4cbV111lfGvf/3Lbd/R1Vy9zpYtW1br+bthGMa5c+eM3/72t0bLli2N0NBQY8yYMbVejPY2Tb3OajoWSTKysrLc/G1dwxPb2cWaY1HDzzAMw9VPfwAAAAAAAAAAALgaY2oAAAAAAAAAAABToKgBAAAAAAAAAABMgaIGAAAAAAAAAAAwBYoaAAAAAAAAAADAFChqAAAAAAAAAAAAU6CoAQAAAAAAAAAATIGiBgAAAAAAAAAAMAWKGgAAAAAAAAAAwBQoagDwKkOHDtUDDzzg9s/x8/PT+vXr3f45AAA0d646tn/77bfy8/PT/v37G72sC3311Ve66qqrZLVa1atXL5cuGwAAOGqqc/66zJ07l+M+YGIUNQD4NBIVAAC8Q2lpqR599FH16NFDLVq0UHx8vO68804dO3bMo3HNmTNHLVq00OHDh7VlyxaPxgIAAJrGjBkzTHPcv+uuu3TjjTd6OgzAq1DUAAAAAOB2RUVF+uyzz/T444/rs88+07p163T48GHdcMMNHo0rMzNTAwcOVGJioqKjo+v9/tLSUjdEBQAAGsJmsznVLiwsrEHHfVcihwAajqIGAI8pLCzUnXfeqbCwMMXFxWnBggUO80tKSjRjxgy1bdtWLVq0UGpqqrZv326fv3z5ckVFRWn9+vXq0qWLrFar0tLS9P3339vnP/nkk/r888/l5+cnPz8/LV++3P7+nJwcjRkzRqGhoerSpYvefffdpvjaAAA0S5GRkdq0aZNuueUWde3aVVdddZVefvll7d27V9nZ2Q1a5qFDh3T99dcrLCxMrVu31h133KGcnBz7/I0bN2rgwIGKiopSdHS0fvWrXykzM9M+38/PT3v37tW8efPk5+enuXPn1vp5lV1grV69WkOGDJHVatWqVaskSa+99pq6desmq9WqpKQk/fnPf3Z4765du9SrVy9ZrVb17dtX69evd0t3WgAAmEVd5/y5ublKT09X27ZtFRoaqh49eujNN990WMbQoUN177336oEHHlBMTIzS0tK0fft2+fn5acuWLerbt69CQ0N19dVX6/Dhw/b3XdyrQ+XTEH/6058UFxen6OhoTZs2zaHwcPz4cY0cOVIhISHq0KGD3njjDbVv316LFi1y6vv6+fnp1Vdf1Q033KAWLVroD3/4g8rLyzV58mR16NBBISEh6tq1q1544QWHOF9//XW988479usalevo+++/1y233KKoqChdcsklGj16tL799lun1z9gZhQ1AHjMww8/rPfff1/vvPOO/v3vf2v79u367LPP7PPvvfde7d69W2+99ZYOHDigm2++Wdddd52OHDlib1NUVKQ//OEP+tvf/qadO3fqzJkzuvXWWyVJ48aN00MPPaTu3bvr+PHjOn78uMaNG2d/75NPPqlbbrlFBw4c0IgRIzR+/Hj99NNPTbcCAABo5vLy8uTn56eoqKh6v/fMmTP6xS9+oZSUFH366afauHGjTp48qVtuucXeprCwUNOnT9enn36qLVu2yN/fX2PGjFFFRYWk8xcnunfvroceekjHjx/XjBkznPrsmTNn6v7779eXX36ptLQ0rVq1Sk888YT+8Ic/6Msvv9TTTz+txx9/XK+//rokKT8/X6NGjVKPHj302Wef6amnntKjjz5a7+8MAIAvqeucv7i4WH369NGGDRt06NAhTZ06VXfccYc+/vhjh+W8/vrrslgs2rlzpxYvXmyf/thjj2nBggX69NNPFRgYqEmTJtUaz7Zt25SZmalt27bp9ddf1/Llyx1ujKzsNnP79u1au3at/vKXv+jHH3+s13eeO3euxowZo4MHD2rSpEmqqKjQpZdeqr///e/6z3/+oyeeeEK///3vtWbNGknnu8m65ZZbdN1119mva1x99dUqLS1VWlqawsPD9eGHH2rnzp0KCwvTdddd5/TTKoCpGQDgAWfPnjUsFouxZs0a+7Tc3FwjJCTEuP/++43vvvvOCAgIMI4ePerwvmHDhhmzZs0yDMMwli1bZkgyPvroI/v8L7/80pBk7NmzxzAMw5gzZ47Rs2fPKp8vyZg9e7b9dUFBgSHJ+N///V9Xfk0AAJq9IUOGGPfff3+V6efOnTN69+5t3HbbbU4tJysry5Bk7Nu3zzAMw3jqqaeMa6+91qHN999/b0gyDh8+XO0yTp06ZUgyDh48aJ/Ws2dPY86cOfWKYdGiRQ7TO3XqZLzxxhsO05566imjf//+hmEYxquvvmpER0cb586ds89fsmSJw/cBAKA5qMwLnDnnr87IkSONhx56yGF5KSkpDm22bdtmSDI2b95sn7ZhwwZDkv1YfPG1ggkTJhiJiYlGWVmZfdrNN99sjBs3zjCMn681fPLJJ/b5R44cMSQZzz//vFPfXZLxwAMP1Nlu2rRpxtixYx1iGz16tEObFStWGF27djUqKirs00pKSoyQkBDjvffecyoewMwCPVFIAYDMzEzZbDalpqbap11yySXq2rWrJOngwYMqLy/XZZdd5vC+kpISh34vAwMDdeWVV9pfJyUlKSoqSl9++aX69etXawzJycn2/7do0UIRERH1vssCAADUX2lpqW655RYZhqFXX321Qcv4/PPPtW3bNoWFhVWZl5mZqcsuu0xHjhzRE088oT179ignJ8f+hEZ2drauuOKKBsfft29f+/8LCwuVmZmpyZMna8qUKfbpZWVlioyMlCQdPnxYycnJslqt9vl15SkAAPgyZ875y8vL9fTTT2vNmjU6evSobDabSkpKFBoa6vCePn36VPsZF57zx8XFSZJ+/PFHtWvXrtr23bt3V0BAgMN7Dh48KOn8sTwwMFC9e/e2z+/cubNatmzp7FeW5JhDVHrllVe0dOlSZWdn69y5c7LZbA5dY1Xn888/V0ZGhsLDwx2mFxcXO3S1CfgqihoAvFJBQYECAgK0d+9eh6RCUrUXLxoiKCjI4bWfn5/9YgcAAHCPyoLGd999p61btyoiIqJByykoKNCoUaP07LPPVplXeeFi1KhRSkxM1JIlSxQfH6+KigpdccUVje6WoUWLFg5xSNKSJUscbtaQVCWHAQAA5zlzzv/cc8/phRde0KJFi9SjRw+1aNFCDzzwQJXj+IXH5QtdeM7v5+cnSbWe8zfFNYKLY33rrbc0Y8YMLViwQP3791d4eLiee+457dmzp9blFBQUqE+fPvaxvS7UqlUrl8YMeCOKGgA8olOnTgoKCtKePXvsd0mcPn1aX3/9tYYMGaKUlBSVl5frxx9/1KBBg2pcTllZmT799FP73Y6HDx/WmTNn1K1bN0mSxWJReXm5+78QAACoU2VB48iRI9q2bZvD05f11bt3b61du1bt27dXYGDV05rc3FwdPnxYS5YssecSO3bsaPDn1aR169aKj4/XN998o/Hjx1fbpmvXrlq5cqVKSkoUHBwsSfrkk09cHgsAAGbhzDn/zp07NXr0aN1+++2Szhckvv76a11++eVNGaqk88fysrIy7du3z/5kSEZGhk6fPt2o5e7cuVNXX321fvvb39qnXfykRXXXNXr37q3Vq1crNja2wTeIAGbGQOEAPCIsLEyTJ0/Www8/rK1bt+rQoUO666675O9/frd02WWXafz48brzzju1bt06ZWVl6eOPP9b8+fO1YcMG+3KCgoL0u9/9Tnv27NHevXt111136aqrrrIXOdq3b6+srCzt379fOTk5Kikp8cj3BQCguSstLdV//dd/6dNPP9WqVatUXl6uEydO6MSJEw16cmLatGn66aeflJ6erk8++USZmZl67733NHHiRJWXl6tly5aKjo7WX/7yF2VkZGjr1q2aPn26G76Z9OSTT2r+/Pl68cUX9fXXX+vgwYNatmyZFi5cKEm67bbbVFFRoalTp+rLL7/Ue++9pz/96U+Sfr5zFACA5sSZc/4uXbpo06ZN2rVrl7788kv95je/0cmTJz0Sb1JSkoYPH66pU6fq448/1r59+zR16lSFhIQ06ljepUsXffrpp3rvvff09ddf6/HHH69y40P79u114MABHT58WDk5OSotLdX48eMVExOj0aNH68MPP1RWVpa2b9+u++67Tz/88ENjvy7g9ShqAPCY5557ToMGDdKoUaM0fPhwDRw40KEvzGXLlunOO+/UQw89pK5du+rGG2/UJ5984tD/ZWhoqB599FHddtttGjBggMLCwrR69Wr7/LFjx+q6667TNddco1atWunNN99s0u8IAADOO3r0qN5991398MMP6tWrl+Li4uw/u3btqvfy4uPjtXPnTpWXl+vaa69Vjx499MADDygqKkr+/v7y9/fXW2+9pb179+qKK67Qgw8+qOeee84N30z69a9/rddee03Lli1Tjx49NGTIEC1fvlwdOnSQJEVEROgf//iH9u/fr169eumxxx7TE088IUkO42wAANCc1HXOP3v2bPXu3VtpaWkaOnSo2rRpoxtvvNFj8f7tb39T69atNXjwYI0ZM0ZTpkxReHh4o47lv/nNb3TTTTdp3LhxSk1NVW5ursNTG5I0ZcoUde3aVX379lWrVq20c+dOhYaG6oMPPlC7du100003qVu3bpo8ebKKi4t5cgPNgp9hGIangwCAhli+fLkeeOABnTlzxtOhAAAA1MuqVas0ceJE5eXlKSQkxNPhAACAevrhhx+UkJCgzZs3a9iwYZ4OB2hWGFMDAAAAANzsb3/7mzp27Ki2bdvq888/16OPPqpbbrmFggYAACaxdetWFRQUqEePHjp+/LgeeeQRtW/fXoMHD/Z0aECzQ/dTAAAAADzu6aefVlhYWLU/119/veljOHHihG6//XZ169ZNDz74oG6++Wb95S9/cVHkAADA3UpLS/X73/9e3bt315gxY9SqVStt375dQUFBWrVqVY05RPfu3T0dOuBz6H4KAAAAgMf99NNP+umnn6qdFxISorZt2zaLGAAAgPmcPXu2xkHMg4KClJiY2MQRAb6NogYAAAAAAAAAADAFup8CAAAAAAAAAACmQFEDAAAAAAAAAACYAkUNAAAAAAAAAABgChQ1AAAAAAAAAACAKVDUAAAAAAAAAAAApkBRAwAAAAAAAAAAmAJFDQAAAAAAAAAAYAoUNQAAAAAAAAAAgClQ1AAAAAAAAAAAAKZAUQMAAAAAAAAAAJgCRQ0AAAAAAAAAAGAKFDUAAAAAAAAAAIApUNQAAAAAAAAAAACmQFEDAAAAAAAAAACYAkUNAAAAAAAAN/rggw80atQoxcfHy8/PT+vXr6/zPdu3b1fv3r0VHByszp07a/ny5W6PEwAAM6CoAQAAAAAA4EaFhYXq2bOnXnnlFafaZ2VlaeTIkbrmmmu0f/9+PfDAA/r1r3+t9957z82RAgDg/fwMwzA8HQQAAAAAAEBz4Ofnp7fffls33nhjjW0effRRbdiwQYcOHbJPu/XWW3XmzBlt3LixCaIEAMB7BXo6gOasoqJCx44dU3h4uPz8/DwdDgCgGTMMQ2fPnlV8fLz8/XmQ01uROwAAvAF5g/vt3r1bw4cPd5iWlpamBx54oMb3lJSUqKSkxP66oqJCP/30k6Kjo8kbAAAe4468gaKGBx07dkwJCQmeDgMAALvvv/9el156qafDQA3IHQAA3oS8wX1OnDih1q1bO0xr3bq18vPzde7cOYWEhFR5z/z58/Xkk082VYgAANSLK/MGihoeFB4eLun8LzQiIsLD0QAAmrP8/HwlJCTYj03wTuQOAABvQN7gnWbNmqXp06fbX+fl5aldu3bkDQAAj3JH3kBRw4MqH/+MiIggwQAAeAW6JvBu5A4AAG9C3uA+bdq00cmTJx2mnTx5UhEREdU+pSFJwcHBCg4OrjKdvAEA4A1cmTfQ+SUAAAAAAIAX6d+/v7Zs2eIwbdOmTerfv7+HIgIAwHtQ1AAAAAAAAHCjgoIC7d+/X/v375ckZWVlaf/+/crOzpZ0vuuoO++8097+7rvv1jfffKNHHnlEX331lf785z9rzZo1evDBBz0RPgAAXoWiBgAAAAAAgBt9+umnSklJUUpKiiRp+vTpSklJ0RNPPCFJOn78uL3AIUkdOnTQhg0btGnTJvXs2VMLFizQa6+9prS0NI/EDwCAN2FMDQAAAAAAADcaOnSoDMOocf7y5curfc++ffvcGBUAAObEkxoAAAAAAAAAAMAUKGoAAAAAAAAAAABToPspwOTyimzKKbApv7hUESFBimlhUWSoxdNheQTrAgAAAN6uqXJWcmMAAOCrKGoAJnbszDk9uvaAPjySY582uEuMnhmbrPioEA9G1vRYFwAAAPB2TZWzkhsDAABfRvdTgEnlFdmqnKhI0gdHcjRz7QHlFdk8FFnTY10AAADA2zVVzkpuDAAAfB1FDcCkcgpsVU5UKn1wJEc5Bc3nZIV1AQAAAG/XVDkruTEAAPB1dD8FmFR+cWmt88/WMd+XsC48i/6aAQCAN/D2nKSpclZyYwAA4OsoagAmFWENqnV+eB3zfQnrwnMq+2ve+91pTRrYQSkJUfo2p1AJLUPVOiLYqy4kNDVvv7ACAIAvqW4MiV92i9XcG7qruLSiwcdjVx7PmypnJTcGAAC+jqIGYFIxYRYN7hKjD6p5tHxwlxjFhDWfi6esC8+o7K9573en9WJ6ipbtzNLLWzPs85vzYJQMzgkAQNOpbgyJUEuAxvVrp0fWHtDOjFz79Pocj119PG+qnJXcGAAA+DrG1ABMKjLUomfGJmtwlxiH6YO7xOjZscnN6o5w1oVnVPbXPGlgBy3bmeVwwUBqvoNRMjgnAABNq7oxJBqbn7jjeN5UOSu5MQAA8HU8qQGYWHxUiF5KT1FOgU1ni0sVbg1STFjz7OKGddH0KvtrTkmIcnhC40KVg1E2p9+DM4NzNqf1AQCAu1U3hkRj8xN3Hc+bKmclNwYAAL6MogZgcpGhnJxUYl00rcr+mkvKKmpt502DUTbFOBcMzgkAQNOoPK6XVRhaeteV+iz7tJbuyFKRrbzR+Yk7j+dNlbOSGwMAAF9FUQMA0CCV/TUHBzr2ZBhqCbAPGl5SViGrJUB5RZ5/OqGpxrlgcE4AANyvuuP6gM7RejE9Rfe9ua9KfnKxC4/H1d70EMLxHAAAwFtR1AAANEhlf83vf31KAzpHa2dGrkItAV45aHhd/WK/lJ7isqILg3MCAOBeNR3XK8fPmDSwg/Z9f0YDO0drx0VjakiOx+Oabnp4ekwP/bJbrDZ9+WOt7wcAAEDTY6BwAECDxUeFaMQVbfSHG3toUJcYrx003Jl+sV2FwTkBAHCv2o7rOzNyNeKKNroppa2euan243FtNz38/u2DmntDd47nAAAAXognNQAAjVLZX/PL6Sk6nlfslYOGN/U4FwzOCQCA+9R1XLeVVejy+EhJqvV4XNdND8WlFRzPAQAAvBBFDQCm0BQDPKNxIkMt+iansNY2nhok2xPjXDA4JwAA7lGf43ptx2NnbnroFBtm2uM5+TMAAPBVFDUAeL2mGuAZjeetg2QzzgUAAL7DVcd1b81bXIH8GQAA+DLG1ADg1eoa4NlTYzSgepUXGarjyeKB2ce5yCuyKfPHAu3LPq3MUwVs9wCAZs1Vx/XG5C3efGwmfwYAAL6OJzUAeDVnBnj29gvSzUnlRYaZaw843D3pDcUDs45zwZ2WAABU5YrjekPzFm8/NpM/AwAAX0dRA4BXq+zrONQSoEkDOyglIUolZRWyBgXos+zTKizxzBgNqJk3Fw/MNs5FXXdavpSeYqrvAwCAK7niuF7fvMUMx+aLxwq5OI+2lZUrr4jCBgAAMC+KGoAJNOdB/iKsQQq1BOjF9BQt25mll7dmSDp/cjZ7ZDdZggK0L/t0s1sv3s5sxQNvxZ2WAICm0JxzTal+eUt9js2eWq8XjhVSXR4tedeTJQAAAPVFUQPwct7+ePuF3HHiFhNm0eO/ulzLdmZpZ0auJMeTs9+/fcje1lvXC9BQF99pebGzdcwHADSer1/wN1Ou6Q2cPTZ7cr1eOJD6pIEdHPLoSt70ZAkAAEB9UdQAvJgZHm+v5K4Tt8hQi3q3i9KsdQft0ypPzvZln9G9v+js0CXV+1+f0ogr2tTaZYAvX5iAb7nwTsvqhNcxHwDQOL5+wd9MuWZ9uSvnc+bYXNt6nfPOIf33mB4qKC5zWz564VghKQlRDk9oXBwPT30CAAAzoqjRzHGB17t5uusZZ7ePxpwQO/MZRbZyh9cpCVFauiOr2kfpB3SOVv+O0dV+nq9fmPB1zXF/deGdlhcb3CVGMWG+/f2BSs3x7x+e58sX/CvVN9f0xN9iQz7TnTmfM8fmmtZrqCVA4/q104w1+/XhBU9OuCq2i9fVczf31A+ni2p9D099AgAAM6Ko0Yxxgdf7ubLrmfqeENZn+2ho8cXZz7j4jriSsooaH6XfmZGrx985pJcvutDQHC5M+LLmur+68E7LDy767s+OTWabRbPQXP/+4XmevrmkKdQn1/TE32JDPtNdOd+FufTskZdrb/ZpPfXP/9hvvrnw2PxNTmG1y3BnV1A1rat5o69QqCWgyk1ClXjqEwAAmJG/pwOQpFdeeUXt27eX1WpVamqqPv744xrblpaWat68eerUqZOsVqt69uypjRs3OrSZO3eu/Pz8HH6SkpIc2gwdOrRKm7vvvts+Pzc3V9ddd53i4+MVHByshIQE3XvvvcrPz3dYzvbt29W7d28FBwerc+fOWr58eeNXSBOoK9nPK7K5/fMzfyzQvuzTyjxV4PbPMytXdT1z7Mw53fvmPg1b+L7G/HmXhi14X797c5+OnTlXbfv6bh8NKb7U5zMq74irFBzor5SEqConhJU+/L8LDRdy5sKEt+Dvw5Gn91eeFh8VopfSU7Rl+hCt/+3V2jJ9iF5KT1FcM76YS97QfDT3v394VnMY18jZXNMVf4v1zW8a+pnuyPkuzqWvXfSB/vfgcf3rvkF6d9rV2vrQED13c08V2cq1L/u0QiwBuvcXnRVqCXBYTm35a2Py0drW1RPvHNLjv7q82vfx1CcAADArjz+psXr1ak2fPl2LFy9WamqqFi1apLS0NB0+fFixsbFV2s+ePVsrV67UkiVLlJSUpPfee09jxozRrl27lJKSYm/XvXt3bd682f46MLDqV50yZYrmzZtnfx0aGmr/v7+/v0aPHq3//u//VqtWrZSRkaFp06bpp59+0htvvCFJysrK0siRI3X33Xdr1apV2rJli379618rLi5OaWlpLlk/7uLJO8+449J5ruh6piF3q9V3+2hI8aU+n3Hx3er7vj+jlISoWj/z4gsNZrkwwd9HVc3hTtm6RIbS1U4l8obmhb9/eFJzGNfI2VyzsX+LDclvGvqZrs756ioYvJSeokJbuWb8/XOHNgM7R+vF9BTd9+Y++1MSJWUVLo2tUl3r6rGR3ar8nnnqEwAAmJnHixoLFy7UlClTNHHiREnS4sWLtWHDBi1dulQzZ86s0n7FihV67LHHNGLECEnSPffco82bN2vBggVauXKlvV1gYKDatGlT62eHhobW2KZly5a655577K8TExP129/+Vs8995x92uLFi9WhQwctWLBAktStWzft2LFDzz//vNdfnPDUBV66AKofV3Q905ATwvpuHw0pvtT3MyrvVs8psKmwpFSWoIAa3nnehRca8opsCgkK0J/H95Y1KECfZZ/W0h1ZDo/he8OFCf4+qmeWghSaBnmDa5hljAr+/uFJzWFcI2dzzcb8LTY0v2noZ7q6GFVXLn2mqFSz3zlUpc2O/3siY9LADvbx36JC3FMoq2tdnbOV2/Pos8WlCrcGKSbMO/f7AAAAzvBoUcNms2nv3r2aNWuWfZq/v7+GDx+u3bt3V/uekpISWa1Wh2khISHasWOHw7QjR44oPj5eVqtV/fv31/z589WuXTuHNqtWrdLKlSvVpk0bjRo1So8//rjDXZcXOnbsmNatW6chQ4bYp+3evVvDhw93aJeWlqYHHnigzu/uaZ6684w7Luvvwov5DTkJacgJYX23j5pOiH/ZLVZzb+iunAKbvskpdLhw1pBt8MK71fOKbE5daKjuzsABF9055y0XJvj7qJ679ldmuaiLn5E3uIaZngi78O8/1BKgSQM7KCUhSiVlFbIGBaglf7Nwo+YyrpEzuWZ9jsUXH18D/fy097vT1b6vtvymocd/Vxej6sqlC21lNeZvOzJyNXvk5RqeFKtwa5DCrIFuKZQ5s6546hMAAPgSjxY1cnJyVF5ertat/3979x4XZZ3///8JKCcRKDm7hMFqmIl4WFnykCUbRT9L1239YKlLhVubn21ly6TI4264bRLWWnxW17WbWtmmue3qh1LKWvP0yTS10lXUyAME7gqCyiDM74++zDpxkIEZZi7mcb/d5nZjrut9zbzmzcy8X3O9rut9hVstDw8P16FDh5rdJjU1VXl5eRo9erTi4uJUVFSk9evXq77+P0dcJyUlaeXKlbrhhht05swZzZ8/X6NGjdLBgwfVs2dPSdLkyZMVExOjqKgo7d+/X08++aQOHz6s9evXWz1fenq6/vrXv+rixYsaN26cli9fbllXWlrabOxVVVW6ePGi/PysdwzU1taqtrbWcv+782x3JmcdecYRl+3TkR8h7flB2J73x3d/EAf6dZe3l6dmrz/Q7I6zjr4H27KjoaUjAz++4si5/V+fc5kdE3w+mueI7ysj7dTFf7hb3iDZP3cw2hlhjZ//T776t15MH6w/f3zccsSzxOcWjtfRg0uM4mq5ZlvH4ubG11F9Q5pMw3SllvKb9o7/9i5GXS2XrmnhAtyNLtXVK/G6ayz3HVEoc4ezigAAAK7k9OmnbLVkyRJlZmYqPj5eHh4eiouLU0ZGhlasWGFpc+edd1r+TkhIUFJSkmJiYvTmm2/qwQcflCRNnz7d0mbgwIGKjIzU2LFjVVxcrLi4OMu6F154QXPnztU///lPZWdnKysrSy+//HK7Ys/NzdX8+fPbta29OevIM3eYm9jVtOdHTnPvD39vLz3z/92oIdcF/7+zLkxNjmz/7pkUM17f2+qOs46+B6+2o6G1Mx8+PnpWz9x1ozJHXt+m5+qMo/r5fDTP3t9XRtupi44xct4g2T93aOl70d/bSwnRwTpTeanJmXXO1Pj5//Cf5frzx8ebXGCXz63jcVYb1zWSOnYwyT+OVKjBbLaahulKLeU3HRn/7VmMuloubeuUUo4olLnLWUUAAACNnFrUCAkJkZeXl8rKyqyWl5WVtThndWhoqDZs2KBLly7p7NmzioqK0uzZsxUbG9vi8wQHB6tfv346erRpEt0oKSlJknT06FGrnRMRERGKiIhQfHy8rr32Wo0aNUrPPPOMIiMjFRER0WzsgYGBzR5t2bhzo1FVVZWio6NbjMnRnHHkGUcRdb72/sj57jUsAv289cyGg8pef8DqMVo6QrYtUynFhQV0+D3Y2o6Gq535cKmuvk3P1VlH9fP5aJk9v6+Y5su43C1vkOyfOzT3vejv7eXSZ0FEBftpWMw1VuPPlfjcOg5nteFKHT2Y5IER1zdZfrX8piPjv72KUVfLpf29vdp1AJG9v7Pc5awiAAAAyclFDW9vbw0dOlRFRUUaP368JKmhoUFFRUWaMWNGq9v6+vqqd+/eqqur07p16/TTn/60xbbV1dUqLi7WlClTWmyzb98+SVJkZGSLbRoaGiTJMg1EcnKyNm3aZNVm8+bNSk5ObnZ7Hx8f+fj4tPj4ztDZR55xFNF/dOaRj+39kdP4/rCcdXG07Ue2t3UqJUe+B+1x5kNnHtXP56N19nqvMM2Xcblb3iDZP3do7nvxgZHXu/xZENW1l1tdb+TPraueCcFZbWhORw4m+a625jeucKbM1XJpV8nfXKGvAAAAOoPTp5/KysrStGnTNGzYMA0fPlz5+fmqqalRRkaGJGnq1Knq3bu3cnNzJUm7du3SqVOnlJiYqFOnTmnevHlqaGjQrFmzLI/5+OOPa9y4cYqJidHp06c1d+5ceXl5KT09XZJUXFys1157TWlpaerVq5f279+vmTNnavTo0UpISJAkbdq0SWVlZfrBD36ggIAAff7553riiSc0YsQI9enTR5L08MMP6w9/+INmzZqlBx54QO+//77efPNNbdy4sRN70HiMeBRR4w6Hyosm+ft0k6eHh7p5eqhXO3c8OOPIx478yGnPke2uMJWSPc586Oyj+o34+TAaV3hvov3IGzqmue/FwdHBzU4JI7nOWRBd9XPrymdCcFab47hqIaujrvY5ve5afxVl3WLY/Ka1XNpe+VtXfW8AAADYm9OLGpMmTVJ5ebnmzJmj0tJSJSYmqrCw0HIhzZKSEnl6elraX7p0STk5OTp27JgCAgKUlpamVatWKTg42NLm5MmTSk9P19mzZxUaGqqRI0dq586dCg0NlfTtkZ5btmyx7AiJjo7WxIkTlZOTY3kMPz8/LVu2TDNnzlRtba2io6P14x//WLNnz7a0uf7667Vx40bNnDlTS5Ys0fe+9z0tX75cqampDu414zPSUUTN7XAY8f1eyhhxvXI3fan599xk044HIx752J4j211hKiV7nPngjKP6jfT5MKL2vjfZ0eAayBs6prnvxdrLDa1u4wpnQbjCmGJvrp4PcFabY7hyIaujrvY5Devp06XHzY7mb1e+N/y9vfTAyOt1c2wveXfz1DU9vMk7AAAAruBhNpvNzg7CXVVVVSkoKEiVlZUKDAx0djhoRksXu5a+LWwMvu4a7f/6nE07Hoq/qdbYvA9bXF+UdYviwgLaHbMjtDfm0+cutlhQiOzEH+6NO6Pbc+ScEf9fkuvsgHeVOL7L1vemPXZCuWpfNGJMMgZ7/Z+u/F707e6lO5b8o8W2rvI95ypjir24+vji6vEZUWt55ei+IS3mk64+flzpu59Tf28vPfP/3agh1wXrgqne5eN3Vl9f+d648jpHV04L6GrFL/IGY+D/BABwBY4Yj5x+pgbgytpywcM/vH/UpikYbDny0VV+xLb3CFlXmUqpI0fOGfHoYFc5CtRV4miOLe9NexxN7cp9Afd05fdi5QWTIb7nXGVMsRdXPxPCiOOfI9gzF2vPlF5GGz+u/JzW1NYp0M9bz2w4qOz1ByxtXDV+Z/b1le8NI1znCAAAwNk8r94EcF9X2+HQOGWHLTse2jov+OlzFzXj9b0am/ehJry8XWMXf6j/fn2vTp+72ObnspfG6UpG9w2xWt6WaZyC/L0VFxagxOuuUVxYgOF+hHXktTvD1XbAV14wuVUcrWnre7MtO6FaY4S+gHsz0vec0ceUK7n6dUKM9L5wFHvnYrYWsow6fjR+TmN69dAzfz2ofxx1/fid3ddXvjcGRwc3KWhcGc/V8g4AAAB3wJkaQCuutsPBp9u3dUFbdjy05chHV5xnu6sdIWsLI712V7mwq6vEYQ8dPZq6K/UFui4jfc91FUY4E8Kd3xeOyMVsLWQZffwwUvzOjvXK94YRrnMEAADgbJypAbSicYdDc0Z8v5f2fn3O5h0PbTnysaNHhjtKVzpC1lZGee2uMp2Jq8RhDx09mror9QW6NqN8z3UVRjkTwl3fF47IxVrLK5vLJ40+fhgpfmfHeuV7o/GgqZY4+ywuAAAAV8CZGkArGnc4fPfCpCO+30sZI67X2t0l7drxcLUjH539wwrG5SrTmbhKHPbQ0aOpu1JfALAvdz4TwtU5IhdrKa9sqZBl9PHDSPE7O9Yr3xt7vz6nEd/v1ewUVK5yFhcAAICzUdQAruLKHQ6VF+vk7+0lL08PeXl66Pl7B7V7x0NrF6929g8rGJerTGfiKnHYg607ob6rK/UFAPtrLR+A8zgqF7OlkGX08cNI8btCrI3vjbM1Jk0Y3Fvz3vm8yUXLXeksLgAAAGfyMJvNZmcH4a6qqqoUFBSkyspKBQYGOjscuJDKCyb99+t7W/xh5YxrasA4Tp+72OIO+MhgP7eLw14qL5jafTS1EfqCMckY+D8BncNVcjEjjB+tMVL8rhZrR/KOzsB4ZAz8nwAArsAR4xFFDSciweh8jT8Oqi7VKdCvu0J6uNaPgyu52g8rGIur/BB2lThcgav3BWOSMfB/gr0ZKTfqbK6Si7n6+HE1RorfSLE6G+ORMfB/AgC4AkeMR0w/Bbdx+txFPbluf5PTuBdNTFCUCxYJmGcbHeEq05m4ShyugL4A4GqMlht1NlfJxYw+fhgpfiPFCmNaunSpfv/736u0tFSDBg3SSy+9pOHDh7fYPj8/X6+88opKSkoUEhKin/zkJ8rNzZWvr28nRg0AgOvxdHYAQGeovGBq8qNdkj46UqHZ6/ar8oLJSZG1LsjfW3FhAUq87hrFhQXwIwsAANiFUXOjzkYuBsBe1q5dq6ysLM2dO1effvqpBg0apNTUVH3zzTfNtn/ttdc0e/ZszZ07V19++aX+9Kc/ae3atXrqqac6OXIAAFwPRQ24hYpqU5Mf7Y0+OlKhimp+uAMAAPdBbgQAnSsvL0+ZmZnKyMjQjTfeqIKCAvn7+2vFihXNtt++fbtGjBihyZMnq0+fPrr99tuVnp6u3bt3d3LkAAC4HooacAtVl+paXX/+KuuBrqzygknF31Rrb8m/VVxe3eLRuW1tBwCw5orfn+RGcHeu+LlE12UymbRnzx6lpKRYlnl6eiolJUU7duxodpubb75Ze/bssRQxjh07pk2bNiktLa1TYgYAwJVxTQ24hUDf7q2u73mV9UBX1db51Jl3HQDax1W/P8mN4M5c9XOJrquiokL19fUKDw+3Wh4eHq5Dhw41u83kyZNVUVGhkSNHymw26/Lly3r44YdbnX6qtrZWtbW1lvtVVVX2eQEAALgYztSAWwgJ8NboviHNrhvdN0QhAcyPDPfT1vnUmXcdANrHlb8/yY3grlz5cwlcaevWrXr22Wf18ssv69NPP9X69eu1ceNGLVy4sMVtcnNzFRQUZLlFR0d3YsQAAHQeihpwC0H+3lo0MaHJj/fRfUP0u4kJXPQRbqmt86kz7zoAtI8rf3+SG8FdufLnEl1XSEiIvLy8VFZWZrW8rKxMERERzW7zzDPPaMqUKXrooYc0cOBATZgwQc8++6xyc3PV0NDQ7DbZ2dmqrKy03L7++mu7vxYAAFwB00/BbUQF++ml9MGqqDbp/KU69fTtrpAAb360w221dT515l0HgPZx9e9PciO4I1f/XKJr8vb21tChQ1VUVKTx48dLkhoaGlRUVKQZM2Y0u82FCxfk6Wl9HKqXl5ckyWw2N7uNj4+PfHx87Bc4AAAuiqIG3EqQPz/U4XiVF0yqqDap6lKdAv26K6SHa77v2jqfOvOuA0D7GOH7k9wI7sYIn8uOMEoe6o6ysrI0bdo0DRs2TMOHD1d+fr5qamqUkZEhSZo6dap69+6t3NxcSdK4ceOUl5enwYMHKykpSUePHtUzzzyjcePGWYobAAC4K4oaAGBHRrrwZON86h81MwXDlfOpt7UdAMAa35+A6+nKn0sj5aHuaNKkSSovL9ecOXNUWlqqxMREFRYWWi4eXlJSYnVmRk5Ojjw8PJSTk6NTp04pNDRU48aN029/+1tnvQQAAFyGh7ml8xbhcFVVVQoKClJlZaUCAwM79bk5ggewv8oLJs14fW+z8zSP7huil9IHu9zn7PS5i5q9br/VD/vG+dQjr/jx29Z2MC5njkloO/5PxsP3p32Rw8IeuuLnsrPzUMYjY+D/BABwBY4YjzhTww1xBA/gGG258KSr7Xhp63zqzLsOAO3D96f9kMPCXrri59KIeSgAAEB7UdRwM5UXTE1+DErfJrqz1+13ySPJ4bo4WtKaUS882db51Jl3HQBs891x8vqQHnyPthM5LOytq+U1Rs1DAQAA2oOihpvhCB7YC0dLNtXVLzwJAGg7xkn7IocFWkceCgAA3Inn1ZugK+EIHtjD1Y6WrLxgclJkztV44cnmGP3CkwCAtmOctD9yWKB15KEAAMCdUNRwMxzBA3toy9GS7ijI31uLJiY0+UHZeOFJZx5BWnnBpOJvqrW35N8qLq9mhxoAOBDjpP2RwwKt+24e6u/tpRm3fV+vPZSkx8b2VUWNifwPAAB0GUw/5WYaj+D5qJkf2hzBg7biaMmWueKFJ5kCBQA6F+Ok/ZHDAlfXmIeerTHJLGneXw/qD+8ftawn/wMAAF0FZ2q4GVc+khzGwdGSrQvy91ZcWIASr7tGcWEBTj9DgylQAKBzMU7aHzks0DZB/t7q1cNb8975XP84etZqHfkfAADoKjhTww254pHkMBaOljQOLqwKAJ2PcdIxyGGBtiH/AwAAXR1nargpVzqSHMbD0ZLGwRQoAND5GCcdhxwWuDryPwAA0NVxpgaAduFoSWNgChQAcA7GSQDOQv4HAAC6OooaANotyJ+dM66OKVAAwHkYJwE4A/kfAADo6ph+CgC6MKZAAQAAcC/kfwAAoKvjTA0A6OK62hQolRdMqqg2qepSnQL9uiukh3FfCwAAcE+Ozme6Wv4HAABwJZc4U2Pp0qXq06ePfH19lZSUpN27d7fYtq6uTgsWLFBcXJx8fX01aNAgFRYWWrWZN2+ePDw8rG7x8fFWbcaMGdOkzcMPP2xZ/9lnnyk9PV3R0dHy8/NT//79tWTJEqvH2Lp1a5PH8PDwUGlpqR16BQDsp6tcWPX0uYua8fpejc37UBNe3q6xiz/Uf7++V6fPXXR2aOhE5A0AACPrrHymq+R/AAAA3+X0MzXWrl2rrKwsFRQUKCkpSfn5+UpNTdXhw4cVFhbWpH1OTo5Wr16tZcuWKT4+Xu+++64mTJig7du3a/DgwZZ2AwYM0JYtWyz3u3Vr+lIzMzO1YMECy31/f3/L33v27FFYWJhWr16t6Ohobd++XdOnT5eXl5dmzJhh9TiHDx9WYGCg5X5zcQMAOqbygklPrtuvf3xnfuiPjlRo9rr9eil9MD/W3QB5AwDAyMhnAAAAOs7pRY28vDxlZmYqIyNDklRQUKCNGzdqxYoVmj17dpP2q1at0tNPP620tDRJ0iOPPKItW7Zo8eLFWr16taVdt27dFBER0epz+/v7t9jmgQcesLofGxurHTt2aP369U12ToSFhSk4OPiqrxUA0H4V1aYmOwAafXSkQhXVJnYCuAHyBgCAkZHPAAAAdJxTp58ymUzas2ePUlJSLMs8PT2VkpKiHTt2NLtNbW2tfH19rZb5+flp27ZtVsuOHDmiqKgoxcbG6r777lNJSUmTx1qzZo1CQkJ00003KTs7WxcuXGg13srKSl177bVNlicmJioyMlI/+tGP9PHHH7e4fW1traqqqqxuAIC2qbpU1+r681dZD+Nzt7yhMX5yBwDoOshnAAAAOs6pZ2pUVFSovr5e4eHhVsvDw8N16NChZrdJTU1VXl6eRo8erbi4OBUVFWn9+vWqr6+3tElKStLKlSt1ww036MyZM5o/f75GjRqlgwcPqmfPnpKkyZMnKyYmRlFRUdq/f7+efPJJHT58WOvXr2/2ebdv3661a9dq48aNlmWRkZEqKCjQsGHDVFtbq+XLl2vMmDHatWuXhgwZ0uQxcnNzNX/+fJv7qS24cC6Ari7Qt3ur63teZT2Mz93yBsmxuQPQmchVgW+RzwAAAHSch9lsNjvryU+fPq3evXtr+/btSk5OtiyfNWuWPvzwQ+3atavJNuXl5crMzNTf/vY3eXh4KC4uTikpKVqxYoUuXmz+wmrnzp1TTEyM8vLy9OCDDzbb5v3339fYsWN19OhRxcXFWa07ePCgbr31Vj322GPKyclp9TXdcsstuu6667Rq1aom62pra1VbW2u5X1VVpejoaFVWVlrNrW2r0+cuNpmXdXTfEC2amKCoYL92Py4AuJLKCyb99+t79VEzUzaM7hvCHNQdVFVVpaCgoA6PSY7kbnmD5LjcAehM5KrAf3SVfMYIeQP4PwEAXIMjxiOnTj8VEhIiLy8vlZWVWS0vKytrcc7q0NBQbdiwQTU1Nfrqq6906NAhBQQEKDY2tsXnCQ4OVr9+/XT06NEW2yQlJUlSkzZffPGFxo4dq+nTp191x4QkDR8+vMXn8fHxUWBgoNWto652obnKC6YOP0dnqbxgUvE31dpb8m8Vl1cbKnYAjhfk761FExM0um+I1fLRfUP0u4kJhtgBgI5xt7xBckzuAHSmrpSrGgH5tOsjnwEAAOg4p04/5e3traFDh6qoqEjjx4+XJDU0NKioqKjJRTW/y9fXV71791ZdXZ3WrVunn/70py22ra6uVnFxsaZMmdJim3379kn6dmqIRp9//rluu+02TZs2Tb/97W/b9Jr27dtn9RiO1lUuNMcRfADaIirYTy+lD1ZFtUnnL9Wpp293hQQwhYm7IG8AjKer5KpGQD5tHOQzAAAAHePUooYkZWVladq0aRo2bJiGDx+u/Px81dTUKCMjQ5I0depU9e7dW7m5uZKkXbt26dSpU0pMTNSpU6c0b948NTQ0aNasWZbHfPzxxzVu3DjFxMTo9OnTmjt3rry8vJSeni5JKi4u1muvvaa0tDT16tVL+/fv18yZMzV69GglJCRI+nbqiNtuu02pqanKyspSaWmpJMnLy0uhoaGSpPz8fF1//fUaMGCALl26pOXLl+v999/Xe++912n91xUuNHe1I/iMcgo2gM4R5M+PfndG3gAYS1fIVY2AfNp4yGcAAADaz+lFjUmTJqm8vFxz5sxRaWmpEhMTVVhYaLkIaElJiTw9/zNL1qVLl5STk6Njx44pICBAaWlpWrVqlYKDgy1tTp48qfT0dJ09e1ahoaEaOXKkdu7cadmp4O3trS1btlh2hERHR2vixIlW00S89dZbKi8v1+rVq7V69WrL8piYGJ04cUKSZDKZ9Otf/1qnTp2Sv7+/EhIStGXLFt16660O7DFrXeFCcxzBBwBoK/IGwFi6Qq5qBOTTAAAAcCdOvVC4u7PHRVK6woXm9pb8WxNe3t7i+g2/uFmJ113TiREBgPvhQpLGwP8JRtMVclUjIJ9GZ2M8Mgb+TwAAV9DlLhSOjusKF5rjCD4AAICuqSvkqkZAPg0AAAB34vTpp9BxRr/QXEiAt0b3DWnxCL6QAGO8DgAAADRl9FzVCMinAQAA4E44U6OLCPL3VlxYgBKvu0ZxYQGG+pHIEXwAAABdm5FzVSMgnwYAAIA74UwNuASO4AMAAADaj3waAAAA7oKiBlxGkD8/ugAAAID2Ip8GAACAO2D6KQAAAAAAAAAAYAgUNQAAAAAAAAAAgCFQ1AAAAAAAAAAAAIZAUQMAAAAAAAAAABgCFwoHuqjKCyZVVJtUdalOgX7dFdKDC0cCALoOxjkAAAAAcE8UNYAu6PS5i3py3X7940iFZdnoviFaNDFBUcF+TowMAICOY5wDAAAAAPfF9FNAF1N5wdRkR48kfXSkQrPX7VflBZOTIgMAoOMY5wAAAADAvVHUALqYimpTkx09jT46UqGKanb2AACMi3EOAAAAANwbRQ2gi6m6VNfq+vNXWQ8AgCtjnAMAAAAA90ZRA+hiAn27t7q+51XWAwDgyhjnAAAAAMC9UdQAupiQAG+N7hvS7LrRfUMUEuDdyREBAGA/jHMAAAAA4N4oagBdTJC/txZNTGiyw2d03xD9bmKCgvzZ2QMAMC7GOQAAAABwb92cHQAA+4sK9tNL6YNVUW3S+Ut16unbXSEB3uzoAQB0CYxzAAAAAOC+KGoAXVSQPzt3AABdF+McAAAAALgnpp8CAAAAAAAAAACGQFEDAAAAAAAAAAAYAkUNAAAAAAAAB1u6dKn69OkjX19fJSUlaffu3a22P3funB599FFFRkbKx8dH/fr106ZNmzopWgAAXBfX1AAAAAAAAHCgtWvXKisrSwUFBUpKSlJ+fr5SU1N1+PBhhYWFNWlvMpn0ox/9SGFhYXrrrbfUu3dvffXVVwoODu784AEAcDEUNQAAAAAAABwoLy9PmZmZysjIkCQVFBRo48aNWrFihWbPnt2k/YoVK/Svf/1L27dvV/fu3SVJffr06cyQAQBwWUw/BQAAAAAA4CAmk0l79uxRSkqKZZmnp6dSUlK0Y8eOZrd55513lJycrEcffVTh4eG66aab9Oyzz6q+vr6zwgYAwGVxpgYAAAAAAICDVFRUqL6+XuHh4VbLw8PDdejQoWa3OXbsmN5//33dd9992rRpk44ePapf/OIXqqur09y5c5vdpra2VrW1tZb7VVVV9nsRAAC4EM7UAAAAAAAAcCENDQ0KCwvTH//4Rw0dOlSTJk3S008/rYKCgha3yc3NVVBQkOUWHR3diREDANB5KGoAAAAAAAA4SEhIiLy8vFRWVma1vKysTBEREc1uExkZqX79+snLy8uyrH///iotLZXJZGp2m+zsbFVWVlpuX3/9tf1eBAAALoSiBgAAAAAAgIN4e3tr6NChKioqsixraGhQUVGRkpOTm91mxIgROnr0qBoaGizL/vnPfyoyMlLe3t7NbuPj46PAwECrGwAAXRFFDQAADKbygknF31Rrb8m/VVxercoLzR+tBwAAYwbgGrKysrRs2TK9+uqr+vLLL/XII4+opqZGGRkZkqSpU6cqOzvb0v6RRx7Rv/71Lz322GP65z//qY0bN+rZZ5/Vo48+6qyXAACAy+BC4QAAGMjpcxf15Lr9+seRCsuy0X1DtGhigqKC/ZwYGQDA1TBmAK5j0qRJKi8v15w5c1RaWqrExEQVFhZaLh5eUlIiT8//HHcaHR2td999VzNnzlRCQoJ69+6txx57TE8++aSzXgIAAC7DJc7UWLp0qfr06SNfX18lJSVp9+7dLbatq6vTggULFBcXJ19fXw0aNEiFhYVWbebNmycPDw+rW3x8vFWbMWPGNGnz8MMPW9Z/9tlnSk9PV3R0tPz8/NS/f38tWbKkSTxbt27VkCFD5OPjo+9///tauXJlxzoDAIAWVF4wNdk5JUkfHanQ7HX73eboW/IGALg6xgzA9cyYMUNfffWVamtrtWvXLiUlJVnWbd26tUlekJycrJ07d+rSpUsqLi7WU089ZXWNDQAA3JXTz9RYu3atsrKyVFBQoKSkJOXn5ys1NVWHDx9WWFhYk/Y5OTlavXq1li1bpvj4eL377ruaMGGCtm/frsGDB1vaDRgwQFu2bLHc79at6UvNzMzUggULLPf9/f0tf+/Zs0dhYWFavXq1oqOjtX37dk2fPl1eXl6aMWOGJOn48eO666679PDDD2vNmjUqKirSQw89pMjISKWmptqlfwAAaFRRbWqyc6rRR0cqVFFtUpB/83MsdxXkDQDQNowZAAAA6KqcXtTIy8tTZmamZR7JgoICbdy4UStWrNDs2bObtF+1apWefvpppaWlSfp2nsktW7Zo8eLFWr16taVdt27dFBER0epz+/v7t9jmgQcesLofGxurHTt2aP369ZadEwUFBbr++uu1ePFiSVL//v21bds2vfDCC+ycAHBVlRdMqqg2qepSnQL9uiukhzc7F9Cqqkt1ra4/f5X1XQF5A4DOZtTxmjEDAAAAXZVTp58ymUzas2ePUlJSLMs8PT2VkpKiHTt2NLtNbW2tfH19rZb5+flp27ZtVsuOHDmiqKgoxcbG6r777lNJSUmTx1qzZo1CQkJ00003KTs7WxcuXGg13srKSl177bWW+zt27LCKXZJSU1NbjB0AGp0+d1EzXt+rsXkfasLL2zV28Yf679f36vS5i84ODS4s0Ld7q+t7XmW90ZE3AOhsRh6v3X3MAAAAQNfl1KJGRUWF6uvrLRfGahQeHq7S0tJmt0lNTVVeXp6OHDmihoYGbd68WevXr9eZM2csbZKSkrRy5UoVFhbqlVde0fHjxzVq1CidP3/e0mby5MlavXq1PvjgA2VnZ2vVqlW6//77W4x1+/btWrt2raZPn25ZVlpa2mzsVVVVunix6Q+d2tpaVVVVWd0AuB/muEZ7hQR4a3TfkGbXje4bopAA1z9yuCPcLW+QyB0AZzL6eO3uYwYAAAC6LqdPP2WrJUuWKDMzU/Hx8fLw8FBcXJwyMjK0YsUKS5s777zT8ndCQoKSkpIUExOjN998Uw8++KAkWe1kGDhwoCIjIzV27FgVFxcrLi7O6jkPHjyoe+65R3PnztXtt9/e7thzc3M1f/78dm8PoGtgjmu0V5C/txZNTNDsdfv10RXvodF9Q/S7iQm8b5ph5LxBIncAnMno4zVjBgAAALoqpxY1QkJC5OXlpbKyMqvlZWVlLc5ZHRoaqg0bNujSpUs6e/asoqKiNHv2bMXGxrb4PMHBwerXr5+OHj3aYpukpCRJ0tGjR612TnzxxRcaO3aspk+frpycHKttIiIimo09MDBQfn5+TZ4jOztbWVlZlvtVVVWKjo5uMSYAXRNzXKMjooL99FL6YFVUm3T+Up16+nZXSIAx5nfvKHfLGyRyB8CZusJ47c5jBgAAALoup04/5e3traFDh6qoqMiyrKGhQUVFRUpOTm51W19fX/Xu3VuXL1/WunXrdM8997TYtrq6WsXFxYqMjGyxzb59+yTJqs3nn3+uW2+9VdOmTdNvf/vbJtskJydbxS5JmzdvbjF2Hx8fBQYGWt0AuB/muEZHBfl7Ky4sQInXXaO4sAC32TnlbnmDRO4AOFNXGa/ddcwAAABA1+XUooYkZWVladmyZXr11Vf15Zdf6pFHHlFNTY0yMjIkSVOnTlV2dral/a5du7R+/XodO3ZM//jHP3THHXeooaFBs2bNsrR5/PHH9eGHH+rEiRPavn27JkyYIC8vL6Wnp0uSiouLtXDhQu3Zs0cnTpzQO++8o6lTp2r06NFKSEiQ9O3UEbfeeqtuv/12ZWVlqbS0VKWlpSovL7c8z8MPP6xjx45p1qxZOnTokF5++WW9+eabmjlzZmd0HQCDYo5roP3IGwB0FsZrAAAAwDW1afqp/fv3t/kBG3/ct9WkSZNUXl6uOXPmqLS0VImJiSosLLRcSLOkpESenv+pvVy6dEk5OTk6duyYAgIClJaWplWrVik4ONjS5uTJk0pPT9fZs2cVGhqqkSNHaufOnQoNDZX07ZGeW7ZsUX5+vmpqahQdHa2JEydaTRPx1ltvqby8XKtXr9bq1asty2NiYnTixAlJ0vXXX6+NGzdq5syZWrJkib73ve9p+fLlSk1NtakPALgX5riGO3BU7kDeAKCzMF4DAAAArsnDbDabr9bI09NTHh4eMpvN8vDwaLVtfX293YLr6qqqqhQUFKTKykqmkwDcUOUFE3Ncw2XYe0wid3AMcgeg8zFeA00xHhkD/ycAgCtwxHjUpjM1jh8/bvl77969evzxx/XEE09Y5oDesWOHFi9erOeee84uQQGAOwjyZ6cIui5yBwBdBeM1AAAA4FraVNSIiYmx/H3vvffqxRdfVFpammVZQkKCoqOj9cwzz2j8+PF2DxIAABgLuQMAAAAAAHAEmy8UfuDAAV1//fVNll9//fX64osv7BIUAADoOsgdAAAAAACAvdhc1Ojfv79yc3NlMpksy0wmk3Jzc9W/f3+7BgcAAIyP3AEAAAAAANhLm6afulJBQYHGjRun733ve0pISJAk7d+/Xx4eHvrb3/5m9wABAICxkTsAAAAAAAB7sbmoMXz4cB07dkxr1qzRoUOHJEmTJk3S5MmT1aNHD7sHCAAAjI3cAQAAAAAA2IvNRQ1J6tGjh6ZPn27vWAAAQBdF7gAAAAAAAOyhTUWNd955R3feeae6d++ud955p9W2d999t10CAwAAxkXuAAAAAAAAHKFNRY3x48ertLRUYWFhGj9+fIvtPDw8VF9fb6/YAACAQZE7AAAAAAAAR2hTUaOhoaHZvwEAAJpD7gAAAAAAABzB09kBAAAAAAAAAAAAtEWbztR48cUX2/yAv/zlL9sdDAAA6BrIHQAAAAAAgCO0qajxwgsvtOnBPDw82DEBAADIHQAAAAAAgEO0qahx/PhxR8cBAAC6EHIHAAAAAADgCFxTAwAAAAAAAAAAGEKbztT4rpMnT+qdd95RSUmJTCaT1bq8vDy7BAYAALoOcgcAAAAAAGAPNhc1ioqKdPfddys2NlaHDh3STTfdpBMnTshsNmvIkCGOiBEAABgYuQMAAAAAALAXm6efys7O1uOPP64DBw7I19dX69at09dff61bbrlF9957ryNiBAAABkbuAAAAAAAA7MXmosaXX36pqVOnSpK6deumixcvKiAgQAsWLNDvfvc7uwcIAACMjdwBAAAAAADYi81FjR49eljmwo6MjFRxcbFlXUVFhf0iAwAAXQK5AwAAAAAAsBebr6nxwx/+UNu2bVP//v2VlpamX//61zpw4IDWr1+vH/7wh46IEQAAGBi5AwAAAAAAsBebixp5eXmqrq6WJM2fP1/V1dVau3at+vbtq7y8PLsHCAAAjI3cAQAAAAAA2IvNRY1nn31W999/v6Rvp5MoKCiwe1AAAKDrIHcAAAAAAAD2YvM1NcrLy3XHHXcoOjpaTzzxhD777DNHxAUAALoIcgcAAAAAAGAvNhc1/vrXv+rMmTN65pln9H//938aMmSIBgwYoGeffVYnTpxwQIgAAMDIyB0AAAAAAIC9eJjNZnNHHuDkyZN6/fXXtWLFCh05ckSXL1+2V2xdXlVVlYKCglRZWanAwEBnhwMAcGOdOSaRO7QfuQMAwBUwHhkD/ycAgCtwxHhk85kaV6qrq9Mnn3yiXbt26cSJEwoPD7dLUAAAoGsidwAAAAAAAB3RrqLGBx98oMzMTIWHh+tnP/uZAgMD9fe//10nT560d3wAAKALIHcAAAAAAAD20M3WDXr37q1//etfuuOOO/THP/5R48aNk4+PjyNiAwAAXQC5AwAAAAAAsBebixrz5s3Tvffeq+DgYAeEAwAAuhpyBwAAAAAAYC82FzUyMzMdEQcAAOiiyB0AAAAAAIC9dOhC4QAAAAAAAAAAAJ3F6UWNpUuXqk+fPvL19VVSUpJ2797dYtu6ujotWLBAcXFx8vX11aBBg1RYWGjVZt68efLw8LC6xcfHW7UZM2ZMkzYPP/ywVZtf/vKXGjp0qHx8fJSYmNgklhMnTjR5DA8PD+3cubP9nQEAAK6K3AEAAAAAAPdl8/RT9rR27VplZWWpoKBASUlJys/PV2pqqg4fPqywsLAm7XNycrR69WotW7ZM8fHxevfddzVhwgRt375dgwcPtrQbMGCAtmzZYrnfrVvTl5mZmakFCxZY7vv7+zdp88ADD2jXrl3av39/i69hy5YtGjBggOV+r169rv7CAQBAu5A7AAAAAADg3pxa1MjLy1NmZqYyMjIkSQUFBdq4caNWrFih2bNnN2m/atUqPf3000pLS5MkPfLII9qyZYsWL16s1atXW9p169ZNERERrT63v79/q21efPFFSVJ5eXmrOyZ69ep11ecCAAD2Qe4AAAAAAIB7c9r0UyaTSXv27FFKSsp/gvH0VEpKinbs2NHsNrW1tfL19bVa5ufnp23btlktO3LkiKKiohQbG6v77rtPJSUlTR5rzZo1CgkJ0U033aTs7GxduHChXa/j7rvvVlhYmEaOHKl33nmn1ba1tbWqqqqyugEAgLYhdyB3AAAAAADAaUWNiooK1dfXKzw83Gp5eHi4SktLm90mNTVVeXl5OnLkiBoaGrR582atX79eZ86csbRJSkrSypUrVVhYqFdeeUXHjx/XqFGjdP78eUubyZMna/Xq1frggw+UnZ2tVatW6f7777cp/oCAAC1evFh/+ctftHHjRo0cOVLjx49vdedEbm6ugoKCLLfo6GibnhMAAHdG7kDuAACAkdlyXbArvfHGG/Lw8ND48eMdGyAAAAbh1OmnbLVkyRJlZmYqPj5eHh4eiouLU0ZGhlasWGFpc+edd1r+TkhIUFJSkmJiYvTmm2/qwQcflCRNnz7d0mbgwIGKjIzU2LFjVVxcrLi4uDbFEhISoqysLMv9H/zgBzp9+rR+//vf6+677252m+zsbKttqqqq2DkBAIADkTsAAABXYOt1wRqdOHFCjz/+uEaNGtWJ0QIA4NqcdqZGSEiIvLy8VFZWZrW8rKysxXmmQ0NDtWHDBtXU1Oirr77SoUOHFBAQoNjY2BafJzg4WP369dPRo0dbbJOUlCRJrbZpi6SkpFYfw8fHR4GBgVY3AADQNuQO5A4AABjVldcFu/HGG1VQUCB/f3+rAy2+q76+Xvfdd5/mz5/fau4CAIC7cVpRw9vbW0OHDlVRUZFlWUNDg4qKipScnNzqtr6+vurdu7cuX76sdevW6Z577mmxbXV1tYqLixUZGdlim3379klSq23aYt++fR1+DAAA0DxyBwAAYETtuS6YJC1YsEBhYWGWM0evhmtxAQDchVOnn8rKytK0adM0bNgwDR8+XPn5+aqpqVFGRoYkaerUqerdu7dyc3MlSbt27dKpU6eUmJioU6dOad68eWpoaNCsWbMsj/n4449r3LhxiomJ0enTpzV37lx5eXkpPT1dklRcXKzXXntNaWlp6tWrl/bv36+ZM2dq9OjRSkhIsDzO0aNHVV1drdLSUl28eNGy8+LGG2+Ut7e3Xn31VXl7e2vw4MGSpPXr12vFihVavnx5Z3QdAABuidwBAAAYTWvXBTt06FCz22zbtk1/+tOfLPlEW+Tm5mr+/PkdCRUAAENwalFj0qRJKi8v15w5c1RaWqrExEQVFhZaBvqSkhJ5ev7nZJJLly4pJydHx44dU0BAgNLS0rRq1SoFBwdb2pw8eVLp6ek6e/asQkNDNXLkSO3cuVOhoaGSvj3Kc8uWLZadINHR0Zo4caJycnKsYnvooYf04YcfWu437oA4fvy4+vTpI0lauHChvvrqK3Xr1k3x8fFau3atfvKTnziiqwAAgMgdAABA13f+/HlNmTJFy5YtU0hISJu341pcAAB34WE2m83ODsJdVVVVKSgoSJWVlcyRDQBwKsYkY+D/BABwBYxHtjGZTPL399dbb72l8ePHW5ZPmzZN586d01//+ler9vv27dPgwYPl5eVlWdbQ0CDp22mrDh8+rLi4uKs+L/8nAIArcMR45LRragAAAAAAAHR1tl4XLD4+XgcOHNC+ffsst7vvvlu33nqr9u3bx9kXAAC359TppwAAAAAAALo6W64L5uvrq5tuuslq+8apM7+7HAAAd0RRAwAAAAAAwIFsvS4YAABoGdfUcCLmtwQAuArGJGPg/wQAcAWMR8bA/wkA4AocMR5xpgYAwKVUXjCpotqkqkt1CvTrrpAe3gry93Z2WAAAoIsh5wAAADAmihoAAJdx+txFPbluv/5xpMKybHTfEC2amKCoYD8nRgYAALoScg4AAADjYsJGAIBLqLxgarJzQZI+OlKh2ev2q/KCyUmRAQCAroScAwAAwNgoagAAXEJFtanJzoVGHx2pUEU1OxgAAEDHkXMAAAAYG0UNAIBLqLpU1+r681dZDwAA0BbkHAAAAMZGUQMA4BICfbu3ur7nVdYDAAC0BTkHAACAsVHUAAC4hJAAb43uG9LsutF9QxQS4N3JEQEAgK6InAMAAMDYKGoAAFxCkL+3Fk1MaLKTYXTfEP1uYoKC/NnBAAAAOo6cAwAAwNi6OTsAAAAaRQX76aX0waqoNun8pTr19O2ukABvdi4AAAC7IucAAAAwLooaAACXEuTPDgUAAOB45BwAAADGxPRTAAAAAAAAAADAEChqAAAAAAAAAAAAQ6CoAQAAAAAAAAAADIGiBgAAAAAAAAAAMASKGgAAAAAAAAAAwBAoagAAAAAAAAAAAEOgqAEAAAAAAAAAAAyBogYAAAAAAAAAADAEihoAAAAAAAAAAMAQKGoAAAAAAAAAAABDoKgBAAAAAAAAAAAMgaIGAAAAAAAAAAAwBIoaAAAAAAAAAADAEChqAAAAAAAAAAAAQ6CoAQAAAAAAAAAADIGiBgAAAAAAAAAAMASKGgAAAAAAAAAAwBCcXtRYunSp+vTpI19fXyUlJWn37t0ttq2rq9OCBQsUFxcnX19fDRo0SIWFhVZt5s2bJw8PD6tbfHy8VZsxY8Y0afPwww9btfnlL3+poUOHysfHR4mJic3Gs3//fo0aNUq+vr6Kjo7Wc889175OAAAAbUbuAAAAAACA++rmzCdfu3atsrKyVFBQoKSkJOXn5ys1NVWHDx9WWFhYk/Y5OTlavXq1li1bpvj4eL377ruaMGGCtm/frsGDB1vaDRgwQFu2bLHc79at6cvMzMzUggULLPf9/f2btHnggQe0a9cu7d+/v8m6qqoq3X777UpJSVFBQYEOHDigBx54QMHBwZo+fbrNfQEAAK6O3AEAAAAAAPfm1KJGXl6eMjMzlZGRIUkqKCjQxo0btWLFCs2ePbtJ+1WrVunpp59WWlqaJOmRRx7Rli1btHjxYq1evdrSrlu3boqIiGj1uf39/Vtt8+KLL0qSysvLm90xsWbNGplMJq1YsULe3t4aMGCA9u3bp7y8PHZMAADgIOQOAAAAAAC4N6dNP2UymbRnzx6lpKT8JxhPT6WkpGjHjh3NblNbWytfX1+rZX5+ftq2bZvVsiNHjigqKkqxsbG67777VFJS0uSx1qxZo5CQEN10003Kzs7WhQsXbIp/x44dGj16tLy9vS3LGo8U/fe//91i/FVVVVY3AADQNuQO5A4AAAAAADitqFFRUaH6+nqFh4dbLQ8PD1dpaWmz26SmpiovL09HjhxRQ0ODNm/erPXr1+vMmTOWNklJSVq5cqUKCwv1yiuv6Pjx4xo1apTOnz9vaTN58mStXr1aH3zwgbKzs7Vq1Srdf//9NsVfWlrabOyN65qTm5uroKAgyy06Otqm5wQAwJ2RO5A7AAAAAADg1OmnbLVkyRJlZmYqPj5eHh4eiouLU0ZGhlasWGFpc+edd1r+TkhIUFJSkmJiYvTmm2/qwQcflCSrKR4GDhyoyMhIjR07VsXFxYqLi3NY/NnZ2crKyrLcr6qqYucEAAAORO4AAAAAAEDX4rQzNUJCQuTl5aWysjKr5WVlZS3OVx0aGqoNGzaopqZGX331lQ4dOqSAgADFxsa2+DzBwcHq16+fjh492mKbpKQkSWq1zXdFREQ0G3vjuub4+PgoMDDQ6gYAANqG3IHcAQAAAAAApxU1vL29NXToUBUVFVmWNTQ0qKioSMnJya1u6+vrq969e+vy5ctat26d7rnnnhbbVldXq7i4WJGRkS222bdvnyS12ua7kpOT9dFHH6murs6ybPPmzbrhhht0zTXXtPlxAABA25A7AAAAAAAApxU1JCkrK0vLli3Tq6++qi+//FKPPPKIampqlJGRIUmaOnWqsrOzLe137dql9evX69ixY/rHP/6hO+64Qw0NDZo1a5alzeOPP64PP/xQJ06c0Pbt2zVhwgR5eXkpPT1dklRcXKyFCxdqz549OnHihN555x1NnTpVo0ePVkJCguVxjh49qn379qm0tFQXL17Uvn37tG/fPplMJknfzq3t7e2tBx98UJ9//rnWrl2rJUuWWE0RAQAA7IvcAQAAAAAA9+bUa2pMmjRJ5eXlmjNnjkpLS5WYmKjCwkLLRTNLSkrk6fmfusulS5eUk5OjY8eOKSAgQGlpaVq1apWCg4MtbU6ePKn09HSdPXtWoaGhGjlypHbu3KnQ0FBJ3x7luWXLFuXn56umpkbR0dGaOHGicnJyrGJ76KGH9OGHH1ruDx48WJJ0/Phx9enTR0FBQXrvvff06KOPaujQoQoJCdGcOXOs5twGAAD2Re4AAAAAAIB78zCbzWZnB+GuqqqqFBQUpMrKSubIBgA4FWOSMfB/AgC4AsYjY+D/BABwBY4Yj5w6/RQAAAAAAAAAAEBbUdQAAAAAAAAAAACGQFEDAAAAAAAAAAAYAkUNAAAAAAAAAABgCBQ1AAAAAAAAAACAIVDUAAAAAAAAAAAAhkBRAwAAAAAAAAAAGAJFDQAAAAAAAAdbunSp+vTpI19fXyUlJWn37t0ttl22bJlGjRqla665Rtdcc41SUlJabQ8AgDuhqAEAAAAAAOBAa9euVVZWlubOnatPP/1UgwYNUmpqqr755ptm22/dulXp6en64IMPtGPHDkVHR+v222/XqVOnOjlyAABcD0UNAAAAAAAAB8rLy1NmZqYyMjJ04403qqCgQP7+/lqxYkWz7desWaNf/OIXSkxMVHx8vJYvX66GhgYVFRV1cuQAALgeihoAAAAAAAAOYjKZtGfPHqWkpFiWeXp6KiUlRTt27GjTY1y4cEF1dXW69tprW2xTW1urqqoqqxsAAF0RRQ0AAAAAAAAHqaioUH19vcLDw62Wh4eHq7S0tE2P8eSTTyoqKsqqMPJdubm5CgoKstyio6M7FDcAAK6KogYAAAAAAICLWrRokd544w29/fbb8vX1bbFddna2KisrLbevv/66E6MEAKDzdHN2AAAAAAAAAF1VSEiIvLy8VFZWZrW8rKxMERERrW77/PPPa9GiRdqyZYsSEhJabevj4yMfH58OxwsAgKvjTA0AAAAAAAAH8fb21tChQ60u8t140e/k5OQWt3vuuee0cOFCFRYWatiwYZ0RKgAAhsCZGgAAAAAAAA6UlZWladOmadiwYRo+fLjy8/NVU1OjjIwMSdLUqVPVu3dv5ebmSpJ+97vfac6cOXrttdfUp08fy7U3AgICFBAQ4LTXAQCAK6CoAQAAAAAA4ECTJk1SeXm55syZo9LSUiUmJqqwsNBy8fCSkhJ5ev5nMo1XXnlFJpNJP/nJT6weZ+7cuZo3b15nhg4AgMuhqAEAAAAAAOBgM2bM0IwZM5pdt3XrVqv7J06ccHxAAAAYFNfUAAAAAAAAAAAAhkBRAwAAAAAAAAAAGAJFDQAAAAAAAAAAYAgUNQAAAAAAAAAAgCFQ1AAAAAAAAAAAAIZAUQMAAAAAAAAAABgCRQ0AAAAAAAAAAGAIFDUAAAAAAAAAAIAhUNQAAAAAAAAAAACGQFEDAAAAAAAAAAAYAkUNAAAAAAAAAABgCBQ1AAAAAAAAAACAIVDUAAAAAAAAAAAAhuASRY2lS5eqT58+8vX1VVJSknbv3t1i27q6Oi1YsEBxcXHy9fXVoEGDVFhYaNVm3rx58vDwsLrFx8dbtRkzZkyTNg8//LBVm5KSEt11113y9/dXWFiYnnjiCV2+fNmyfuvWrU0ew8PDQ6WlpXboFQAA0BzyBgAAAAAA3Fc3Zwewdu1aZWVlqaCgQElJScrPz1dqaqoOHz6ssLCwJu1zcnK0evVqLVu2TPHx8Xr33Xc1YcIEbd++XYMHD7a0GzBggLZs2WK5361b05eamZmpBQsWWO77+/tb/q6vr9ddd92liIgIbd++XWfOnNHUqVPVvXt3Pfvss1aPc/jwYQUGBlruNxc3AADoOPIGAAAAAADcm9PP1MjLy1NmZqYyMjJ04403qqCgQP7+/lqxYkWz7VetWqWnnnpKaWlpio2N1SOPPKK0tDQtXrzYql23bt0UERFhuYWEhDR5LH9/f6s2V+5geO+99/TFF19o9erVSkxM1J133qmFCxdq6dKlMplMVo8TFhZm9Tienk7vVgAAuiTyBgAAAAAA3JtTf0WbTCbt2bNHKSkplmWenp5KSUnRjh07mt2mtrZWvr6+Vsv8/Py0bds2q2VHjhxRVFSUYmNjdd9996mkpKTJY61Zs0YhISG66aablJ2drQsXLljW7dixQwMHDlR4eLhlWWpqqqqqqvT5559bPU5iYqIiIyP1ox/9SB9//HHbOwAAALQZeQMAAAAAAHDq9FMVFRWqr6+32gEgSeHh4Tp06FCz26SmpiovL0+jR49WXFycioqKtH79etXX11vaJCUlaeXKlbrhhht05swZzZ8/X6NGjdLBgwfVs2dPSdLkyZMVExOjqKgo7d+/X08++aQOHz6s9evXS5JKS0ubjatxnSRFRkaqoKBAw4YNU21trZYvX64xY8Zo165dGjJkSJPYa2trVVtba7lfVVVla5cBAOC23C1vkMgdAAAAAAD4LqdfU8NWS5YsUWZmpuLj4+Xh4aG4uDhlZGRYTTtx5513Wv5OSEhQUlKSYmJi9Oabb+rBBx+UJE2fPt3SZuDAgYqMjNTYsWNVXFysuLi4NsVyww036IYbbrDcv/nmm1VcXKwXXnhBq1atatI+NzdX8+fPt/k1AwCA9jFy3iCROwAAAAAA8F1OnX4qJCREXl5eKisrs1peVlamiIiIZrcJDQ3Vhg0bVFNTo6+++kqHDh1SQECAYmNjW3ye4OBg9evXT0ePHm2xTVJSkiRZ2kRERDQbV+O6lgwfPrzF58nOzlZlZaXl9vXXX7f4OAAAwJq75Q0SuQMAAAAAAN/l1KKGt7e3hg4dqqKiIsuyhoYGFRUVKTk5udVtfX191bt3b12+fFnr1q3TPffc02Lb6upqFRcXKzIyssU2+/btkyRLm+TkZB04cEDffPONpc3mzZsVGBioG2+8sdXHael5fHx8FBgYaHUDAABt4255g0TuAAAAAADAdzl9+qmsrCxNmzZNw4YN0/Dhw5Wfn6+amhplZGRIkqZOnarevXsrNzdXkrRr1y6dOnVKiYmJOnXqlObNm6eGhgbNmjXL8piPP/64xo0bp5iYGJ0+fVpz586Vl5eX0tPTJUnFxcV67bXXlJaWpl69emn//v2aOXOmRo8erYSEBEnS7bffrhtvvFFTpkzRc889p9LSUuXk5OjRRx+Vj4+PJCk/P1/XX3+9BgwYoEuXLmn58uV6//339d5773VmFwIA4DbIGwAAAAAAcG9OL2pMmjRJ5eXlmjNnjkpLS5WYmKjCwkLLxTVLSkrk6fmfE0ouXbqknJwcHTt2TAEBAUpLS9OqVasUHBxsaXPy5Emlp6fr7NmzCg0N1ciRI7Vz506FhoZK+vZIzy1btlh2hERHR2vixInKycmxPIaXl5f+/ve/65FHHlFycrJ69OihadOmacGCBZY2JpNJv/71r3Xq1Cn5+/srISFBW7Zs0a233urgXgMAwD2RNwAAAAAA4N48zGaz2dlBuKuqqioFBQWpsrKS6SQAAE7FmGQM/J8AAK6A8cgY+D8BAFyBI8Yjp15TAwAAAAAAAAAAoK0oagAAAAAAAAAAAEOgqAEAAAAAAAAAAAyBogYAAAAAAAAAADAEihoAAAAAAAAAAMAQKGoAAAAAAAAAAABDoKgBAAAAAAAAAAAMgaIGAAAAAAAAAAAwBIoaAAAAAAAAAADAELo5OwAAANxR5QWTKqpNqrpUp0C/7grp4a0gf29nhwUAgMti7AQAAIBEUQMAgE53+txFPbluv/5xpMKybHTfEC2amKCoYD8nRgYAgGti7AQAAEAjpp8CAKATVV4wNdkpI0kfHanQ7HX7VXnB5KTIAABwTYydAAAAuBJFDQAAOlFFtanJTplGHx2pUEU1O2YAALgSYycAAACuRFEDAIBOVHWprtX156+yHgAAd8PYCQAAgCtR1AAAoBMF+nZvdX3Pq6wHAMDdMHYCAADgShQ1AADoRCEB3hrdN6TZdaP7higkwLuTIwIAwLUxdgIAAOBKFDUAAOhEQf7eWjQxocnOmdF9Q/S7iQkK8mfHDAAAV2LsBAAAwJW6OTsAAADcTVSwn15KH6yKapPOX6pTT9/uCgnwZqcMAAAtYOwEAABAI4oaAAA4QZA/O2IAALAFYycAAAAkpp8CAAAAAAAAAAAGQVEDAAAAAAAAAAAYAkUNAAAAAAAAB1u6dKn69OkjX19fJSUlaffu3a22/8tf/qL4+Hj5+vpq4MCB2rRpUydFCgCAa6OoAQAAAAAA4EBr165VVlaW5s6dq08//VSDBg1Samqqvvnmm2bbb9++Xenp6XrwwQe1d+9ejR8/XuPHj9fBgwc7OXIAAFwPRQ0AAAAAAAAHysvLU2ZmpjIyMnTjjTeqoKBA/v7+WrFiRbPtlyxZojvuuENPPPGE+vfvr4ULF2rIkCH6wx/+0MmRAwDgeihqAAAAAAAAOIjJZNKePXuUkpJiWebp6amUlBTt2LGj2W127Nhh1V6SUlNTW2wPAIA76ebsANyZ2WyWJFVVVTk5EgCAu2scixrHJrgmcgcAgCsgb7BNRUWF6uvrFR4ebrU8PDxchw4danab0tLSZtuXlpa2+Dy1tbWqra213K+srJRE3gAAcC5H5A0UNZzo/PnzkqTo6GgnRwIAwLfOnz+voKAgZ4eBFpA7AABcCXmDa8nNzdX8+fObLCdvAAC4grNnz9otb6Co4URRUVH6+uuv1bNnT3l4eLTatqqqStHR0fr6668VGBjYSRF2HfRfx9GHHUP/dRx92DFX6z+z2azz588rKirKCdGhrWzJHVrCZ8k29Jft6DPb0We2o89sZ88+I2+wTUhIiLy8vFRWVma1vKysTBEREc1uExERYVN7ScrOzlZWVpbl/rlz5xQTE6OSkhKKT3bA94590Z/2RX/aF/1pX5WVlbruuut07bXX2u0xKWo4kaenp773ve/ZtE1gYCAfpg6g/zqOPuwY+q/j6MOOaa3/+LHr+tqTO7SEz5Jt6C/b0We2o89sR5/Zzl59Rt7Qdt7e3ho6dKiKioo0fvx4SVJDQ4OKioo0Y8aMZrdJTk5WUVGRfvWrX1mWbd68WcnJyS0+j4+Pj3x8fJosDwoK4nNiR3zv2Bf9aV/0p33Rn/bl6Wm/y3tT1AAAAAAAAHCgrKwsTZs2TcOGDdPw4cOVn5+vmpoaZWRkSJKmTp2q3r17Kzc3V5L02GOP6ZZbbtHixYt111136Y033tAnn3yiP/7xj858GQAAuASKGgAAAAAAAA40adIklZeXa86cOSotLVViYqIKCwstFwMvKSmxOoL15ptv1muvvaacnBw99dRT6tu3rzZs2KCbbrrJWS8BAACXQVHDIHx8fDR37txmTyXF1dF/HUcfdgz913H0YcfQf2jEe8E29Jft6DPb0We2o89sR58534wZM1qcbmrr1q1Nlt17772699572/18/M/ti/60L/rTvuhP+6I/7csR/elhNpvNdns0AAAAAAAAAAAAB7Hf1TkAAAAAAAAAAAAciKIGAAAAAAAAAAAwBIoaAAAAAAAAAADAEChquJClS5eqT58+8vX1VVJSknbv3t1i25UrV8rDw8Pq5uvr24nRuh5b+k+Szp07p0cffVSRkZHy8fFRv379tGnTpk6K1jXZ0odjxoxp8h708PDQXXfd1YkRuxZb34P5+fm64YYb5Ofnp+joaM2cOVOXLl3qpGhdky19WFdXpwULFiguLk6+vr4aNGiQCgsLOzFa1/LRRx9p3LhxioqKkoeHhzZs2HDVbbZu3aohQ4bIx8dH3//+97Vy5UqHxwnHI5+wHTmE7cgZbEeeYDvygrYjD3Bftn63/OUvf1F8fLx8fX01cOBAtxu/rsaW/ly2bJlGjRqla665Rtdcc41SUlKu2v/uxtb3Z6M33nhDHh4eGj9+vGMDNBhyVvsiN7Mfp+QhZriEN954w+zt7W1esWKF+fPPPzdnZmaag4ODzWVlZc22//Of/2wODAw0nzlzxnIrLS3t5Khdh639V1tbax42bJg5LS3NvG3bNvPx48fNW7duNe/bt6+TI3cdtvbh2bNnrd5/Bw8eNHt5eZn//Oc/d27gLsLW/luzZo3Zx8fHvGbNGvPx48fN7777rjkyMtI8c+bMTo7cddjah7NmzTJHRUWZN27caC4uLja//PLLZl9fX/Onn37ayZG7hk2bNpmffvpp8/r1682SzG+//Xar7Y8dO2b29/c3Z2Vlmb/44gvzSy+9ZPby8jIXFhZ2TsBwCPIJ25FD2I6cwXbkCbYjL7ANeYB7svVz8vHHH5u9vLzMzz33nPmLL74w5+TkmLt3724+cOBAJ0fummztz8mTJ5uXLl1q3rt3r/nLL780/+xnPzMHBQWZT5482cmRuyZb+7PR8ePHzb179zaPGjXKfM8993ROsAZAzmpf5Gb25Yw8hKKGixg+fLj50Ucftdyvr683R0VFmXNzc5tt/+c//9kcFBTUSdG5Plv775VXXjHHxsaaTSZTZ4Xo8mztw+964YUXzD179jRXV1c7KkSXZmv/Pfroo+bbbrvNallWVpZ5xIgRDo3Tldnah5GRkeY//OEPVst+/OMfm++77z6HxmkEbUkiZs2aZR4wYIDVskmTJplTU1MdGBkcjXzCduQQtiNnsB15gu3IC9qPPMB92Po5+elPf2q+6667rJYlJSWZf/7znzs0TqPo6Ph2+fJlc8+ePc2vvvqqo0I0lPb05+XLl80333yzefny5eZp06ZR1LgCOat9kZs5TmflIUw/5QJMJpP27NmjlJQUyzJPT0+lpKRox44dLW5XXV2tmJgYRUdH65577tHnn3/eGeG6nPb03zvvvKPk5GQ9+uijCg8P10033aRnn31W9fX1nRW2S2nve/BKf/rTn/Rf//Vf6tGjh6PCdFnt6b+bb75Ze/bssZzeeOzYMW3atElpaWmdErOraU8f1tbWNpkmx8/PT9u2bXNorF3Fjh07rPpbklJTU9v8mYfrIZ+wHTmE7cgZbEeeYDvyAscjDzC+9nxO+L+3zB7j24ULF1RXV6drr73WUWEaRnv7c8GCBQoLC9ODDz7YGWEaBjmrfZGbOZ89xiOKGi6goqJC9fX1Cg8Pt1oeHh6u0tLSZre54YYbtGLFCv31r3/V6tWr1dDQoJtvvlknT57sjJBdSnv679ixY3rrrbdUX1+vTZs26ZlnntHixYv1m9/8pjNCdjnt6cMr7d69WwcPHtRDDz3kqBBdWnv6b/LkyVqwYIFGjhyp7t27Ky4uTmPGjNFTTz3VGSG7nPb0YWpqqvLy8nTkyBE1NDRo8+bNWr9+vc6cOdMZIRteaWlps/1dVVWlixcvOikqdAT5hO3IIWxHzmA78gTbkRc4HnmA8bXnc9LS/70t399dXUfHN0l68sknFRUV1WRHnTtqT39u27ZNf/rTn7Rs2bLOCNFQyFnti9zM+eyRh1DUMKjk5GRNnTpViYmJuuWWW7R+/XqFhobqf/7nf5wdmiE0NDQoLCxMf/zjHzV06FBNmjRJTz/9tAoKCpwdmiH96U9/0sCBAzV8+HBnh2IYW7du1bPPPquXX35Zn376qdavX6+NGzdq4cKFzg7NMJYsWaK+ffsqPj5e3t7emjFjhjIyMuTpydAGtBX5hO3IITqGnKFtyBNsR14AwJkWLVqkN954Q2+//XaTs8ZwdefPn9eUKVO0bNkyhYSEODucLoGc1b7IzVxPN2cHACkkJEReXl4qKyuzWl5WVqaIiIg2PUb37t01ePBgHT161BEhurT29F9kZKS6d+8uLy8vy7L+/furtLRUJpNJ3t7eDo3Z1XTkPVhTU6M33nhDCxYscGSILq09/ffMM89oypQpliNVBw4cqJqaGk2fPl1PP/202/0Ab08fhoaGasOGDbp06ZLOnj2rqKgozZ49W7GxsZ0RsuFFREQ029+BgYHy8/NzUlToCPIJ25FD2I6cwXbkCbYjL3A88gDja8/npKX/e1vzhK6sI+Pb888/r0WLFmnLli1KSEhwZJiGYWt/FhcX68SJExo3bpxlWUNDgySpW7duOnz4sOLi4hwbtAsjZ7UvcjPns0ceQo+7AG9vbw0dOlRFRUWWZQ0NDSoqKlJycnKbHqO+vl4HDhxQZGSko8J0We3pvxEjRujo0aOWQVKS/vnPfyoyMtItv9g78h78y1/+otraWt1///2ODtNltaf/Lly40GTQa0w2vr2uknvpyHvQ19dXvXv31uXLl7Vu3Trdc889jg63S0hOTrbqb0navHlzm8cduB7yCduRQ9iOnMF25Am2Iy9wPPIA42vP54T/e8va+73z3HPPaeHChSosLNSwYcM6I1RDsLU/4+PjdeDAAe3bt89yu/vuu3Xrrbdq3759io6O7szwXQ45q32RmzmfXcYjmy9hDod44403zD4+PuaVK1eav/jiC/P06dPNwcHB5tLSUrPZbDZPmTLFPHv2bEv7+fPnm999911zcXGxec+ePeb/+q//Mvv6+po///xzZ70Ep7K1/0pKSsw9e/Y0z5gxw3z48GHz3//+d3NYWJj5N7/5jbNegtPZ2oeNRo4caZ40aVJnh+tybO2/uXPnmnv27Gl+/fXXzceOHTO/99575ri4OPNPf/pTZ70Ep7O1D3fu3Glet26dubi42PzRRx+Zb7vtNvP1119v/ve//+2kV+Bc58+fN+/du9e8d+9esyRzXl6eee/eveavvvrKbDabzbNnzzZPmTLF0v7YsWNmf39/8xNPPGH+8ssvzUuXLjV7eXmZCwsLnfUSYAfkE7Yjh7AdOYPtyBNsR15gG/IA92Tr5+Tjjz82d+vWzfz888+bv/zyS/PcuXPN3bt3Nx84cMBZL8Gl2NqfixYtMnt7e5vfeust85kzZyy38+fPO+sluJT25guNpk2bZr7nnns6KVrXR85qX+Rm9uWMPISihgt56aWXzNddd53Z29vbPHz4cPPOnTst62655RbztGnTLPd/9atfWdqGh4eb09LSzJ9++qkTonYdtvSf2Ww2b9++3ZyUlGT28fExx8bGmn/729+aL1++3MlRuxZb+/DQoUNmSeb33nuvkyN1Tbb0X11dnXnevHnmuLg4s6+vrzk6Otr8i1/8wm1+eLfElj7cunWruX///mYfHx9zr169zFOmTDGfOnXKCVG7hg8++MAsqcmtsc+mTZtmvuWWW5psk5iYaPb29jbHxsaa//znP3d63LA/8gnbkUPYjpzBduQJtiMvaDvyAPdl6/fxm2++ae7Xr5/Z29vbPGDAAPPGjRs7OWLXZkt/xsTENPu5mzt3bucH7qJsfX9eiaJGU+Ss9kVuZj/OyEM8zGbOkQEAAAAAAAAAAK6Pa2oAAAAAAAAAAABDoKgBAAAAAAAAAAAMgaIGAAAAAAAAAAAwBIoaAAAAAAAAAADAEChqAAAAAAAAAAAAQ6CoAQAAAAAAAAAADIGiBgAAAAAAAAAAMASKGgAAAAAAAAAAwBAoagAAAABwWX369FF+fr6zw2gXI8cOAAAAuCqKGgAAAAAAAAAAwBAoagAwBJPJ5OwQAAAAAAAAADgZRQ0ALmnMmDGaMWOGfvWrXykkJESpqamaN2+errvuOvn4+CgqKkq//OUvLe379Omj3/zmN5o6daoCAgIUExOjd955R+Xl5brnnnsUEBCghIQEffLJJ058VQAAuKe33npLAwcOlJ+fn3r16qWUlBTV1NRozJgx+tWvfmXVdvz48frZz35mtez8+fNKT09Xjx491Lt3by1dutSyzmw2t5ojrFq1SsOGDVPPnj0VERGhyZMn65tvvrGs37p1qzw8PPTuu+9q8ODB8vPz02233aZvvvlG//u//6v+/fsrMDBQkydP1oULFyzbNeYqM2bMUFBQkEJCQvTMM8/IbDa32A/nzp3TQw89pNDQUAUGBuq2227TZ5991s5eBQAAANwTRQ0ALuvVV1+Vt7e3Pv74Y91xxx164YUX9D//8z86cuSINmzYoIEDB1q1f+GFFzRixAjt3btXd911l6ZMmaKpU6fq/vvv16effqq4uDhNnTq11Z0NAADAvs6cOaP09HQ98MAD+vLLL7V161b9+Mc/tmk8/v3vf69BgwZp7969mj17th577DFt3rxZkrRu3bpWc4S6ujotXLhQn332mTZs2KATJ040KZpI0rx58/SHP/xB27dv19dff62f/vSnys/P12uvvaaNGzfqvffe00svvWS1zauvvqpu3bpp9+7dWrJkifLy8rR8+fIWX8e9995rKZbs2bNHQ4YM0dixY/Wvf/2rzX0BAAAAuLtuzg4AAFrSt29fPffcc5Kk7t27KyIiQikpKerevbuuu+46DR8+3Kp9Wlqafv7zn0uS5syZo1deeUU/+MEPdO+990qSnnzySSUnJ6usrEwRERGd+2IAAHBTZ86c0eXLl/XjH/9YMTExktTkwISrGTFihGbPni1J6tevnz7++GO98MIL+tGPfqSSkpJWc4QHHnjA8ndsbKxefPFF/eAHP1B1dbUCAgIs637zm99oxIgRkqQHH3xQ2dnZKi4uVmxsrCTpJz/5iT744AM9+eSTlm2io6P1wgsvyMPDQzfccIMOHDigF154QZmZmU1ew7Zt27R7925988038vHxkSQ9//zz2rBhg9566y1Nnz7dpj4BAAAA3BVnagBwWUOHDrX8fe+99+rixYuKjY1VZmam3n77bV2+fNmqfUJCguXv8PBwSdY7TRqXXTnlBAAAcKxBgwZp7NixGjhwoO69914tW7ZM//73v216jOTk5Cb3v/zyS0lXzxH27NmjcePG6brrrlPPnj11yy23SJJKSkqsHvO7eYS/v7+loNG47Ls5xA9/+EN5eHhYxXXkyBHV19c3eQ2fffaZqqur1atXLwUEBFhux48fV3FxsU39AQAAALgzihoAXFaPHj0sf0dHR+vw4cN6+eWX5efnp1/84hcaPXq06urqLG26d+9u+btxB0NzyxoaGhwdOgAA+H+8vLy0efNm/e///q9uvPFGvfTSS7rhhht0/PhxeXp6NpmG6sqxvS1ayxFqamqUmpqqwMBArVmzRv/3f/+nt99+W5JkMpmsHue7OcOV9xuXdSSHqK6uVmRkpPbt22d1O3z4sJ544ol2Py4AAADgbph+CoBh+Pn5ady4cRo3bpweffRRxcfH68CBAxoyZIizQwMAAK3w8PDQiBEjNGLECM2ZM0cxMTF6++23FRoaqjNnzlja1dfX6+DBg7r11luttt+5c2eT+/3797fcbylHMJvNOnv2rBYtWqTo6GhJ0ieffGK317Vr164mcfXt21deXl5N2g4ZMkSlpaXq1q2b+vTpY7cYAAAAAHdDUQOAIaxcuVL19fVKSkqSv7+/Vq9eLT8/P8vc3AAAwDXt2rVLRUVFuv322xUWFqZdu3apvLxc/fv3V48ePZSVlaWNGzcqLi5OeXl5OnfuXJPH+Pjjj/Xcc89p/Pjx2rx5s/7yl79o48aNklrPERoaGuTt7a2XXnpJDz/8sA4ePKiFCxfa7bWVlJQoKytLP//5z/Xpp5/qpZde0uLFi5ttm5KSouTkZI0fP17PPfec+vXrp9OnT2vjxo2aMGGChg0bZre4AAAAgK6MogYAQwgODtaiRYuUlZWl+vp6DRw4UH/729/Uq1cvZ4cGAABaERgYqI8++kj5+fmqqqpSTEyMFi9erDvvvFN1dXX67LPPNHXqVHXr1k0zZ85scpaGJP3617/WJ598ovnz5yswMFB5eXlKTU2VdPUcYeXKlXrqqaf04osvasiQIXr++ed199132+W1TZ06VRcvXtTw4cPl5eWlxx57rMULfnt4eGjTpk16+umnlZGRofLyckVERGj06NGW634BAAAAuDoP83cnsQUAAAAAtGrMmDFKTExUfn6+s0MBAAAA3AoXCgcAAAAAAAAAAIZAUQMAAAAAAAAAABgC008BAAAAAAAAAABD4EwNAAAAAAAAAABgCBQ1AAAAAAAAAACAIVDUAAAAAAAAAAAAhkBRAwAAAAAAAAAAGAJFDQAAAAAAAAAAYAgUNQAAAAAAAAAAgCFQ1AAAAAAAAAAAAIZAUQMAAAAAAAAAABgCRQ0AAAAAAAAAAGAI/z9AdGRY32sYbgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1600x700 with 6 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "X_params = ['depth', 'l2_leaf_reg', 'learning_rate',\t'rsm', 'subsample']\n",
+    "_, axes = plt.subplots(2, 3, figsize = (16, 7))\n",
+    "for i, ax in zip(X_params, axes.flatten()):\n",
+    "    sns.scatterplot(\n",
+    "        df_cb_optuna.T.reset_index(0, drop=True).T, x = i, y = 'valid', ax = ax\n",
+    "    )\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c3c3f37-ced9-43a8-9289-7dfe494485d1",
+   "metadata": {},
+   "source": "- depth: 작을수록(=3) 성능 우위. depth 증가 → train_sub 상승, valid 하락 (overfitting 명확)\n\n- learning_rate: 1차 탐색 상한(0.015)에 최적값이 붙어 있음 → 상한을 높여 재탐색 필요\n\n- subsample: 0.5~1.0 범위에서 성능 차이 미미 → 실질적 영향 없음, 탐색 제외 가능"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 207,
+   "id": "865b526e-dffd-42eb-ab2a-99d82d476206",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 0 node(s)\n",
+      "Exp 1/1 (100%) Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb3</th>\n",
+       "      <td>0.955309</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          AUC\n",
+       "        valid\n",
+       "cb3  0.955309"
+      ]
+     },
+     "execution_count": 207,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.set_node(\n",
+    "    'cb3', grp='cb_optuna',\n",
+    "    edges={'X': [(None, X_all)]},\n",
+    "    params={\n",
+    "        \"learning_rate\": 0.02,\n",
+    "        \"depth\": 3,\n",
+    "        \"l2_leaf_reg\": 1.5,\n",
+    "        \"rsm\": 0.67, \n",
+    "        \"subsample\": 0.97,\n",
+    "    }\n",
+    ")\n",
+    "e_aml.exp('cb3')\n",
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    'cb3.*'\n",
+    ")[0][['valid']].stack().rename('AUC').to_frame().unstack()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 209,
+   "id": "23cdc13e-f08b-47aa-a656-f04532a7fc05",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) cb4 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb4</th>\n",
+       "      <td>0.955312</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          AUC\n",
+       "        valid\n",
+       "cb4  0.955312"
+      ]
+     },
+     "execution_count": 209,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.set_node(\n",
+    "    'cb4', grp='cb_optuna',\n",
+    "    edges={'X': [(None, X_all)]},\n",
+    "    params={\n",
+    "        \"learning_rate\": 0.03,\n",
+    "        \"depth\": 3,\n",
+    "        \"l2_leaf_reg\": 1.5,\n",
+    "        \"rsm\": 0.67, \n",
+    "        \"subsample\": 0.97,\n",
+    "    }\n",
+    ")\n",
+    "e_aml.exp('cb4')\n",
+    "e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    'cb4.*'\n",
+    ")[0][['valid']].stack().rename('AUC').to_frame().unstack()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 220,
+   "id": "9f8b3a37-99cb-424e-b4d7-957eeb83a53c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "reinitialize 'cb_rsm_0.75'\n",
+      "Experimenting 1 node(s)\n",
+      "Exp 1/1 (100%) cb_rsm_0.75 1/1 (100%)\n",
+      "Experimentation complete: 1 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.reinitialize('cb_rsm_0.75')\n",
+    "e_aml.exp('cb_rsm_0.75')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 222,
+   "id": "45ab0498-869f-4342-b957-1f7e4405524b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cb_rsm_0.75    3175.0\n",
+       "Name: (evals_result, best_iteration), dtype: float64"
+      ]
+     },
+     "execution_count": 222,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['cb_evals_results'].get_attrs('cb_rsm_0.75')\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation', 'AUC')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "s_best_iteration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 210,
+   "id": "db283bc2-5e79-44ed-8e84-a948d40585d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cb4    3829.0\n",
+       "Name: (evals_result, best_iteration), dtype: float64"
+      ]
+     },
+     "execution_count": 210,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['cb_evals_results'].get_attrs('cb4')\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation', 'AUC')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "s_best_iteration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "id": "eb44dc21-a840-46d2-be8c-093ba699fa54",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"6\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>border_count</th>\n",
+       "      <th>depth</th>\n",
+       "      <th>l2_leaf_reg</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>rsm</th>\n",
+       "      <th>subsample</th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_border_count_511</th>\n",
+       "      <td>511.0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>0.75</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.955354</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_rsm_0.75</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>0.75</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.955354</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_subsample_0.5</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.955334</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>default</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.955331</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_33</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1.479891</td>\n",
+       "      <td>0.013043</td>\n",
+       "      <td>0.668498</td>\n",
+       "      <td>0.962132</td>\n",
+       "      <td>0.955329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_28</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.084098</td>\n",
+       "      <td>0.013898</td>\n",
+       "      <td>0.752706</td>\n",
+       "      <td>0.995564</td>\n",
+       "      <td>0.955329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_learning_rate_0.02</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.020000</td>\n",
+       "      <td>default</td>\n",
+       "      <td>default</td>\n",
+       "      <td>0.955329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_46</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3.007111</td>\n",
+       "      <td>0.013057</td>\n",
+       "      <td>0.868617</td>\n",
+       "      <td>0.908254</td>\n",
+       "      <td>0.955324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_42</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2.729726</td>\n",
+       "      <td>0.012293</td>\n",
+       "      <td>0.871871</td>\n",
+       "      <td>0.935666</td>\n",
+       "      <td>0.955324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna_39</th>\n",
+       "      <td>default</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1.105251</td>\n",
+       "      <td>0.012136</td>\n",
+       "      <td>0.955694</td>\n",
+       "      <td>0.913699</td>\n",
+       "      <td>0.955324</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            params                                            \\\n",
+       "                      border_count depth l2_leaf_reg learning_rate       rsm   \n",
+       "cb_border_count_511          511.0     3     default      0.050000      0.75   \n",
+       "cb_rsm_0.75                default     3     default      0.050000      0.75   \n",
+       "cb_subsample_0.5           default     3     default      0.050000   default   \n",
+       "cb_max_depth_3             default     3     default      0.050000   default   \n",
+       "cb_optuna_33               default     3    1.479891      0.013043  0.668498   \n",
+       "cb_optuna_28               default     3    0.084098      0.013898  0.752706   \n",
+       "cb_learning_rate_0.02      default     3     default      0.020000   default   \n",
+       "cb_optuna_46               default     3    3.007111      0.013057  0.868617   \n",
+       "cb_optuna_42               default     3    2.729726      0.012293  0.871871   \n",
+       "cb_optuna_39               default     3    1.105251      0.012136  0.955694   \n",
+       "\n",
+       "                                      AUC  \n",
+       "                      subsample     valid  \n",
+       "cb_border_count_511     default  0.955354  \n",
+       "cb_rsm_0.75             default  0.955354  \n",
+       "cb_subsample_0.5            0.5  0.955334  \n",
+       "cb_max_depth_3          default  0.955331  \n",
+       "cb_optuna_33           0.962132  0.955329  \n",
+       "cb_optuna_28           0.995564  0.955329  \n",
+       "cb_learning_rate_0.02   default  0.955329  \n",
+       "cb_optuna_46           0.908254  0.955324  \n",
+       "cb_optuna_42           0.935666  0.955324  \n",
+       "cb_optuna_39           0.913699  0.955324  "
+      ]
+     },
+     "execution_count": 224,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_cb =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('cb_.*')\n",
+    ")['CatBoostClassifier'].fillna('default').join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'cb_.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_cb.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46b17596-0c26-4984-ade9-1d9c945e5f4a",
+   "metadata": {},
+   "source": [
+    "- learning_rate의 적정 구간을 잘못 판단하여 재실험(max_depth: 3 으로 고정)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 226,
+   "id": "71e2f0f7-6cac-4f99-ac76-8cdef23e69f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m[I 2026-02-24 09:01:38,945]\u001b[0m Trial 19 finished with value: 0.955332493100815 and parameters: {'learning_rate': 0.028572234664115893, 'rsm': 0.7256641416229763}. Best is trial 4 with value: 0.9553381037602411.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best Score: 0.9553381037602411\n",
+      "Best Params: {'learning_rate': 0.04211731677303143, 'rsm': 0.8138754289554542}\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.set_grp('cb_optuna2', parent='cb', params={'iterations': 10000, 'max_depth': 3})\n",
+    "def objective(trial):\n",
+    "    trial_number = trial.number\n",
+    "    node_name = f'cb_optuna2_{trial_number}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_optuna2',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={\n",
+    "            \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.01, 0.05),\n",
+    "            \"rsm\": trial.suggest_float(\"rsm\", 0.5, 1.0), \n",
+    "        }\n",
+    "    )\n",
+    "    e_aml.exp(node_name)\n",
+    "    e_aml.finalize(node_name)\n",
+    "    clear_output()\n",
+    "    return e_aml.collectors['AUC'].get_metrics_agg(node_name)[0].iloc[0]['valid']\n",
+    "\n",
+    "# Study 생성 및 최적화\n",
+    "study = optuna.create_study(direction=\"maximize\")\n",
+    "study.optimize(objective, n_trials=20)\n",
+    "\n",
+    "print(\"Best Score:\", study.best_value)\n",
+    "print(\"Best Params:\", study.best_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 227,
+   "id": "c93c38ed-7473-4e45-8f29-6a6b608d91e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"2\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "      <th>evals_result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>rsm</th>\n",
+       "      <th>valid</th>\n",
+       "      <th>best_iteration</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_4</th>\n",
+       "      <td>0.042117</td>\n",
+       "      <td>0.813875</td>\n",
+       "      <td>0.955338</td>\n",
+       "      <td>3134.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_2</th>\n",
+       "      <td>0.020167</td>\n",
+       "      <td>0.582808</td>\n",
+       "      <td>0.955336</td>\n",
+       "      <td>7201.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_12</th>\n",
+       "      <td>0.019405</td>\n",
+       "      <td>0.665371</td>\n",
+       "      <td>0.955335</td>\n",
+       "      <td>7164.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_8</th>\n",
+       "      <td>0.039595</td>\n",
+       "      <td>0.957362</td>\n",
+       "      <td>0.955333</td>\n",
+       "      <td>3086.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_19</th>\n",
+       "      <td>0.028572</td>\n",
+       "      <td>0.725664</td>\n",
+       "      <td>0.955332</td>\n",
+       "      <td>4576.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_1</th>\n",
+       "      <td>0.023846</td>\n",
+       "      <td>0.760800</td>\n",
+       "      <td>0.955329</td>\n",
+       "      <td>5349.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_5</th>\n",
+       "      <td>0.041414</td>\n",
+       "      <td>0.771621</td>\n",
+       "      <td>0.955329</td>\n",
+       "      <td>3194.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_7</th>\n",
+       "      <td>0.042234</td>\n",
+       "      <td>0.953057</td>\n",
+       "      <td>0.955328</td>\n",
+       "      <td>2796.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_9</th>\n",
+       "      <td>0.015229</td>\n",
+       "      <td>0.684242</td>\n",
+       "      <td>0.955326</td>\n",
+       "      <td>8515.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_6</th>\n",
+       "      <td>0.032606</td>\n",
+       "      <td>0.809001</td>\n",
+       "      <td>0.955323</td>\n",
+       "      <td>3910.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     params                 AUC   evals_result\n",
+       "              learning_rate       rsm     valid best_iteration\n",
+       "cb_optuna2_4       0.042117  0.813875  0.955338         3134.0\n",
+       "cb_optuna2_2       0.020167  0.582808  0.955336         7201.0\n",
+       "cb_optuna2_12      0.019405  0.665371  0.955335         7164.0\n",
+       "cb_optuna2_8       0.039595  0.957362  0.955333         3086.0\n",
+       "cb_optuna2_19      0.028572  0.725664  0.955332         4576.0\n",
+       "cb_optuna2_1       0.023846  0.760800  0.955329         5349.0\n",
+       "cb_optuna2_5       0.041414  0.771621  0.955329         3194.0\n",
+       "cb_optuna2_7       0.042234  0.953057  0.955328         2796.0\n",
+       "cb_optuna2_9       0.015229  0.684242  0.955326         8515.0\n",
+       "cb_optuna2_6       0.032606  0.809001  0.955323         3910.0"
+      ]
+     },
+     "execution_count": 227,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['cb_evals_results'].get_attrs('cb_optuna2.*')\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation', 'AUC')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "df_cb_optuna2 =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('cb_optuna2.*')\n",
+    ")['CatBoostClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'cb_optuna2.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").join(\n",
+    "    s_best_iteration\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_cb_optuna2.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: CatBoost Optuna2 (lr 재탐색)\n\n| Best 파라미터 | 값 |\n|---|---|\n| learning_rate | 0.042 |\n| rsm | 0.814 |\n| best valid AUC | **0.955338** |\n| best_iteration 평균 | 3,134 |\n\n- lr=0.02~0.04 구간에서도 높은 AUC 유지, lr=0.002~0.008은 큰 차이 없음\n- rsm은 0.6~0.9 범위에서 안정적 — 0.8 수준이 최적\n- best_iteration ≈ 3,000~7,000 (lr에 따라 역비례)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92f67dbd-3985-4d53-a899-b37706f14bcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# XGB는 잊지 말고 evals_results를 붙여서\n",
+    "e_aml.add_collector(\n",
+    "    ModelAttrCollector('xgb_evals_results', Connector(processor=xgb.XGBClassifier), 'evals_result')\n",
+    ")\n",
+    "\n",
+    "# XGB는 GPU를 사용해서\n",
+    "e_aml.set_grp('xgb_optuna', parent='xgb', params={'n_estimators': 10000, 'tree_method': 'hist', 'device': 'cuda'})\n",
+    "def objective(trial):\n",
+    "    trial_number = trial.number\n",
+    "    node_name = f'xgb_optuna_{trial_number}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='xgb_optuna',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={\n",
+    "            \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.01, 0.03),\n",
+    "            \"max_depth\": trial.suggest_int(\"max_depth\", 3, 5),\n",
+    "            \"reg_lambda\": trial.suggest_float(\"reg_lambda\", 1e-3, 10, log=True),\n",
+    "            \"colsample_bytree\": trial.suggest_float(\"colsample_bytree\", 0.5, 1.0), \n",
+    "        }\n",
+    "    )\n",
+    "    e_aml.exp(node_name)\n",
+    "    e_aml.finalize(node_name)\n",
+    "    clear_output()\n",
+    "    return e_aml.collectors['AUC'].get_metrics_agg(node_name)[0].iloc[0]['valid']\n",
+    "\n",
+    "# Study 생성 및 최적화\n",
+    "study = optuna.create_study(direction=\"maximize\")\n",
+    "study.optimize(objective, n_trials=50)\n",
+    "\n",
+    "print(\"Best Score:\", study.best_value)\n",
+    "print(\"Best Params:\", study.best_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## XGBoost Optuna 탐색\n\n탐색 범위: max_depth(3~5), learning_rate(0.01~0.03), reg_lambda(1e-3~10), colsample_bytree(0.5~1.0)\nGPU 가속(tree_method=hist, device=cuda) 사용."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "id": "eb1d181a-6b2f-4043-9017-739006036061",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"4\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "      <th>evals_result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>colsample_bytree</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>max_depth</th>\n",
+       "      <th>reg_lambda</th>\n",
+       "      <th>valid</th>\n",
+       "      <th>best_iteration</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_41</th>\n",
+       "      <td>0.530680</td>\n",
+       "      <td>0.026873</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.014533</td>\n",
+       "      <td>0.955357</td>\n",
+       "      <td>2914.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_31</th>\n",
+       "      <td>0.530258</td>\n",
+       "      <td>0.028310</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.061065</td>\n",
+       "      <td>0.955353</td>\n",
+       "      <td>2980.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_47</th>\n",
+       "      <td>0.532539</td>\n",
+       "      <td>0.023520</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.024241</td>\n",
+       "      <td>0.955353</td>\n",
+       "      <td>3351.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_29</th>\n",
+       "      <td>0.501445</td>\n",
+       "      <td>0.028262</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.196886</td>\n",
+       "      <td>0.955352</td>\n",
+       "      <td>3249.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_40</th>\n",
+       "      <td>0.524260</td>\n",
+       "      <td>0.026754</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.013060</td>\n",
+       "      <td>0.955351</td>\n",
+       "      <td>3344.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_23</th>\n",
+       "      <td>0.500024</td>\n",
+       "      <td>0.025102</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.018343</td>\n",
+       "      <td>0.955347</td>\n",
+       "      <td>3253.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_22</th>\n",
+       "      <td>0.502778</td>\n",
+       "      <td>0.025136</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.048226</td>\n",
+       "      <td>0.955343</td>\n",
+       "      <td>3109.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_37</th>\n",
+       "      <td>0.580552</td>\n",
+       "      <td>0.028378</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.062963</td>\n",
+       "      <td>0.955343</td>\n",
+       "      <td>3099.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_21</th>\n",
+       "      <td>0.501225</td>\n",
+       "      <td>0.024335</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.040823</td>\n",
+       "      <td>0.955341</td>\n",
+       "      <td>3061.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optuna_20</th>\n",
+       "      <td>0.513741</td>\n",
+       "      <td>0.024578</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.041419</td>\n",
+       "      <td>0.955339</td>\n",
+       "      <td>3215.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        params                                          AUC  \\\n",
+       "              colsample_bytree learning_rate max_depth reg_lambda     valid   \n",
+       "xgb_optuna_41         0.530680      0.026873         3   0.014533  0.955357   \n",
+       "xgb_optuna_31         0.530258      0.028310         3   0.061065  0.955353   \n",
+       "xgb_optuna_47         0.532539      0.023520         3   0.024241  0.955353   \n",
+       "xgb_optuna_29         0.501445      0.028262         3   0.196886  0.955352   \n",
+       "xgb_optuna_40         0.524260      0.026754         3   0.013060  0.955351   \n",
+       "xgb_optuna_23         0.500024      0.025102         3   0.018343  0.955347   \n",
+       "xgb_optuna_22         0.502778      0.025136         3   0.048226  0.955343   \n",
+       "xgb_optuna_37         0.580552      0.028378         3   0.062963  0.955343   \n",
+       "xgb_optuna_21         0.501225      0.024335         3   0.040823  0.955341   \n",
+       "xgb_optuna_20         0.513741      0.024578         3   0.041419  0.955339   \n",
+       "\n",
+       "                evals_result  \n",
+       "              best_iteration  \n",
+       "xgb_optuna_41         2914.0  \n",
+       "xgb_optuna_31         2980.0  \n",
+       "xgb_optuna_47         3351.0  \n",
+       "xgb_optuna_29         3249.0  \n",
+       "xgb_optuna_40         3344.0  \n",
+       "xgb_optuna_23         3253.0  \n",
+       "xgb_optuna_22         3109.0  \n",
+       "xgb_optuna_37         3099.0  \n",
+       "xgb_optuna_21         3061.0  \n",
+       "xgb_optuna_20         3215.0  "
+      ]
+     },
+     "execution_count": 219,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['xgb_evals_results'].get_attrs()\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation_0', 'auc')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "df_xgb_optuna =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('xgb_optuna.*')\n",
+    ")['XGBClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'xgb_optuna.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").join(\n",
+    "    s_best_iteration\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_xgb_optuna.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 228,
+   "id": "6d2462af-76a7-45d9-9787-7adb2f4ce871",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjUAAAKyCAYAAACdeVx6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAADrhklEQVR4nOzdeXgUVdr38V+2zkI2pBNIMIQQEBAJBJSIQMSBEcRHEXlcIiMICOPCuOACjCiLo+CGuA4zKOAAijog+oiiEkXZBGXAgAKSyCKrBCUhZOks9f7Bmx6bzp5Ouiv9/VxXLuiq09V3dVV13VWnzjk+hmEYAgAAAAAAAAAA8HC+7g4AAAAAAAAAAACgJqjUAAAAAAAAAAAApkClBgAAAAAAAAAAMAUqNQAAAAAAAAAAgClQqQEAAAAAAAAAAEyBSg0AAAAAAAAAAGAKVGoAAAAAAAAAAABToFIDAAAAAAAAAACYgr+7A/BmZWVlOnLkiMLCwuTj4+PucAAAkCQZhqHTp08rNjZWvr48/+AJyBkAAJ6GfMEzkTMAADxNQ+QMVGq40ZEjRxQXF+fuMAAAqNDPP/+s888/391hQOQMAADPRb7gWcgZAACeypU5A5UabhQWFibp7AYNDw93czQAAJyVm5uruLg4+3kK7kfOAADwNOQLnomcAQDgaRoiZ6BSw43Km4KGh4eTbAAAPA5dFngOcgYAgKciX/As5AwAAE/lypyBji8BAAAAAAAAAIApUKkBAAAAAAAAAABMgUoNAAAAAAAAAABgClRqAAAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBT83R0AXCMn36bsPJtyC4sVHhwgazOLIkIs7g4LAAB4GHIGAAAAAKgdrqM8C5UaTcCRUwWatDxD6/Zm26eldrBq9vAkxUYGuzEyAADgScgZAAAAAKB2uI7yPHQ/ZXI5+Tang0qSvtqbrcnLM5STb3NTZAAAwJOQMwAAAABA7XAd5ZloqWFy2Xk2bT3wmyb8ob2S4yJVVFKmoAA//efgb1qwfp+y82w0hQIAAMrOs9kT8RCLn8b0TXDIHU7lF5MzAAAAAMDv/P466lxf7c1u0HuvdHlVOSo1TC6vqFjzRvSUJcBHzQL9lVdYqrAgf/Vt30K94s/TmaJid4cIAAA8QG5hsUIsfhqf2k4DOkfrl9wi+fj46IejuVqwfp8uS2yhGdd2UWFxGUkzAAAAAEncWM8trPre6ulq5tfV4d/ydeBkvk4VFCsowE/pu3/RnqO5mjH0Irq8EpUapndesEXNAv017YPvtSHzpH163/YtNP3aLgr0pYcxAAAgRQQH6MW0ZC3asE9z1+y1T+/TvoVeuaWHDBl6eHmGQz5BP7EAAACA92IsCSk8KKDK+WHVzK+LQ7/ma9IKx2uzPu1baHSfBE17f6eevaGbV1UsVcQj7ni/8soratu2rYKCgpSSkqItW7ZUWra4uFgzZ85UYmKigoKC1K1bN61evdqhzPTp0+Xj4+Pw16lTJ4cy/fv3dypzxx132OefPHlSgwcPVmxsrAIDAxUXF6cJEyYoNzfXXmbt2rVOy/Dx8dGxY8dc9M1Uz/CRnvxol5LbNNfroy7WqyN6aMFtl6h7m+aa9dEuGT6NFgoAAA2KfKF+mgX6683NB9T9nJwhuU1znThdqAXr9zkkzRL9xAIAzImcAQDqj7EkzgoN8tebt6fYr58m/KG9Qix+ks5W8FhDXVu5kJNv05RzKjQkaUPmSS3csE8dY8KVnecd331V3N5S4+2339bEiRM1b948paSkaO7cuRo0aJD27Nmj6Ohop/JTp07VkiVLNH/+fHXq1EmffPKJhg0bpo0bNyo5OdlerkuXLlqzZo39tb+/86qOGzdOM2fOtL8OCQmx/9/X11dDhw7V3/72N0VFRSkzM1N33323fv31V7355psOy9mzZ4/Cw8PtryuKu6HkF5fqlpR4LdywTy9/nmmfXl57l19c2mixAADQUMgX6u9MUUmlOcO1SbGa/n8/VPi+hu4nFgAAVyJnAADXcOdYEp6iopYqfdq30ItpyXp7y0HNHHqRy7+D7Dyb1p1ToVFuQ+ZJjemT0GBdXpmJ2ys15syZo3Hjxmn06NGSpHnz5mnVqlVasGCBJk+e7FR+8eLFeuSRRzRkyBBJ0p133qk1a9boueee05IlS+zl/P391apVqyo/OyQkpNIyzZs315133ml/HR8fr7vuukvPPPOMU9no6GhFRkZWu64NwpAWbnB+srL89aNXX+iOqAAAcCnyhforKTMqzRke//B7jemb4FDZ8XskzQAAsyBnAADXcNdYEp6ispYqGzJPytfHR8/e0E0tw4Nc/rnVfe9FJWUN0uWV2bi1+ymbzaatW7dq4MCB9mm+vr4aOHCgNm3aVOF7ioqKFBTkuMMEBwdr/fr1DtP27t2r2NhYtWvXTiNGjNDBgwedlrV06VJZrVZddNFFmjJlivLz8yuN9ciRI1qxYoUuv/xyp3ndu3dXTEyM/vjHP2rDhg1VrrOrGZK2HTylCX9o79CVxIQ/tNe2g6dkNGo0AAC4HvmCa5SVGZXmDFsPnlJyXGSl7yVpBgCYATkDALiOO8aSOFdOvk1Zv+Rp28HflHUir1G7vKqqpcq6vdnKKyxpkM+t7nuPDA5weZdXZuTWlhrZ2dkqLS1Vy5YtHaa3bNlSu3fvrvA9gwYN0pw5c5SamqrExESlp6drxYoVKi39bzdLKSkpWrRokTp27KijR49qxowZ6tevn3bu3KmwsDBJ0i233KL4+HjFxsYqIyNDkyZN0p49e7RixQqHz0tLS9P777+vgoICXXPNNXrttdfs82JiYjRv3jxdfPHFKioq0muvvab+/ftr8+bN6tGjh1PsRUVFKioqsr/+fd+ZdVVYXKIX05Ir7ErixbRkFRY3zAEGAEBj8bZ8QXJPzuDnU/FAXA3RTywAAA2BnME1OQMASJI11KLUDlZ9VcGN/ca4RnD3IOXuaqlS1ffet30LxbcIafLdftWEj2EYbnuY/8iRI2rdurU2btyo3r1726c//PDD+vLLL7V582an95w4cULjxo3T//3f/8nHx0eJiYkaOHCgFixYoIKCggo/59SpU4qPj9ecOXM0duzYCst8/vnnGjBggDIzM5WYmGiffuzYMZ06dUo//vijpkyZossvv1yvvvpqpet0+eWXq02bNlq8eLHTvOnTp2vGjBlO03Nychz6y6yNA9ln9NeVO5y6kpDO3qR48rquirc2q9OyAQDeKTc3VxEREfU6P7mSt+ULkntyhr8NvUjTPvjeIXlO7WDVU8OTFNMIFw0AAHPxtHxBImf4PU/aLgDM68ipAk1entHo1wg5+TZNeGtbhS0lUjtY9VJacoPf2M/6JU8D5nxZ6fz0iZcrMTq0QT67ou+9XwerZg3rqvPPC6ninZ6pIXIGt7bUsFqt8vPz0/Hjxx2mHz9+vNJ+KKOiorRy5UoVFhbq5MmTio2N1eTJk9WuXbtKPycyMlIXXHCBMjMr7idaOvvkhSSnhKNVq1Zq1aqVOnXqpPPOO0/9+vXTo48+qpiYmAqX06tXL6dmquWmTJmiiRMn2l/n5uYqLi6u0phqwlZaVuHNCelsH2+20rJ6LR8AAHfztnxBck/OUFJm6KW0ZGXn2XS6sFhhQWebNfMUEADALMgZXJMzAEC52Mhgt1wjeMIg5e5sqeKu791M3FqpYbFY1LNnT6Wnp+u6666TJJWVlSk9PV0TJkyo8r1BQUFq3bq1iouLtXz5ct14442Vls3Ly1NWVpZuvfXWSsts375dkipNJMpjk+TQtLOi5VS2jMDAQAUGBlb63rrIKyqRNdSip4YnKTo8UHmFpQoL8tfx3EJNWp6hM0V0PwUAMDdvyxekhssZJCnE4qc/X95OV3SMliTl20oV4Hd2mLWIEBJlAIB5kTMAgOu54xqhvOunEIufxvRNUHJcpIpKyhQU4Kf/HPxNZ4oafpDyiBCLZg9PqrSlSkN/J+Xfe06+Tdl5Nv2UfUbhwTZZm3HNJrm5UkOSJk6cqFGjRuniiy9Wr169NHfuXJ05c0ajR4+WJI0cOVKtW7fWrFmzJEmbN2/W4cOH1b17dx0+fFjTp09XWVmZHn74YfsyH3zwQV1zzTWKj4/XkSNHNG3aNPn5+SktLU2SlJWVpTfffFNDhgxRixYtlJGRofvvv1+pqalKSkqSJH300Uc6fvy4LrnkEoWGhur777/XQw89pD59+qht27aSpLlz5yohIUFdunRRYWGhXnvtNX3++ef69NNPG+37iwwO0NLbL9XMD793ePqyb/sWWnr7pbL4Vdw/NgAAZkK+UH/hQQEKsfjplVt6KCjAV0+t3u2QO/T7/8l5Y/RPCwBAQyFnAADzK792qWxMwP/tcX6jxOHuFhPuHlfEk7m9UuOmm27SiRMn9Nhjj+nYsWPq3r27Vq9ebR/Y6+DBg/L19bWXLyws1NSpU/XTTz8pNDRUQ4YM0eLFixUZGWkvc+jQIaWlpenkyZOKiopS37599fXXXysqKkrS2ac31qxZY09u4uLiNHz4cE2dOtW+jODgYM2fP1/333+/ioqKFBcXp+uvv16TJ0+2l7HZbHrggQd0+PBhhYSEKCkpSWvWrNEVV1zRwN/afwUG+OnxVTuU3Ka5xvRJcKi1fHr1Lj1+XddGiwUAgIZCvlB/1lCLHv2fC3XidKFKygyN6ZOgESnx9rxhwfp9mrw8o1H6pwUAoKGQMwCAZylvaZBbWKzw4IAatTQov3ZZuGGfUxe6GzJP6rH3dzbadYu7WrPn5NucKjSks91vcd3m5oHCvZ0rBknZcyxXP/9W4HSQ92nfQqP7JCiuebA6tmJwMABAzXniwJ/ezlXb5MfjuZLhoxnntPAszxvueWub/m9C3wYb8A4A0HSQL3gmtgsAT1KflgZ7juVq0Nx1lc5vyIG6PYE7Byp3tSY3UDjqzzCkNzcfqLClxpubD+jhQZ3cHSIAAPAYPnp69a5K84YxfRN0urDh+6cFAAAA0LRV1tLg2wO/6csfT+ji+ObKKyqptPVGvq20yuU39euW3GrWr6mvf3Wo1DA7H+nWS9vqaE6Bw+TYiCD1bNNcYkgNAABgZ+iegRfodGGJcgqK7RUaPxzJ0S0p8fL38VFYUIC7gwQAAABgctl5NqcKjd+PkzFlxQ779Ipab4RXc13SFK9bft9VV7DFTxP+0F4L1u+rsIKnKa5/bVCpYXK+PlJQgK9W7Tjq1I3EhCvay5dKDQAA8P8F+Plqxv/9UGHXU29uPqD7Bl4ga6j39ssKAAAAwDUqamkwpm9CheNkVDROhDXUotQOVn11TsWIdLYSpKldt1TUVVff9i30Ylqy7nlrm0PFRlNc/9ryrb4IPFmAr69e/iKzwkFzXv4iUwG+bGIAAHD2qZ/HVu6sMGdYuGGfLoyNUICfr1cPNgcAAADANSpqaZEcF+l0PVLuq73Zys6z2V9HhFg0e3iSUjtYHcqldrDqqeFJTeq6pbKuutZnntSiDfs0pm+CfVpTXP+6oKWGyRUUl1b6Y7Ah86QKiqvufw4AAHiH7Dyb1lWRM4zpk6CCavqtBQAAAICaqKilRVFJWZXvOXeciNjIYL2UlqzsPJtOFxYrLChA1lDn8TfMrqKuusqtzzypqVdfqIGdopvs+tcFlRomd8ZWKmuoRU8NT1J0eKDyCksVFuSv47mFmrQ8o9pBdQAAgHfIKyrWhD+0V3JcpMMA4eV9tJaUGWrRzKKsX/KUW1hc6YB9AAAAAFCd8pYWk5dn2Cs2Av2r7lGmonEiIkJqf03y+7EpzHBdU92g4IXFperepnmDx2Gm741KDZM7r1mA3hx3qb7d/6ukszWeBcWl+iW3UG+Ou1R+9D4FAAAkRQRb9MORHElnm30XFpfqssQWuvLClrp76X+UaG2mqSt3al3mf58QqmjAPgAAAAC1Z6Ybxq5ybkuL5iENP05GRWNTePp1jScMim62741KDZMLCfDXwV/POE03JP12pkhtzmvW+EEBjcwbEwMAqI2cfJteXPOjpgzpLFtxmXILS9Qy/GzLziWb9mvh6Es0+6PdDhUaUsUD9gEAAACoHbPdMK5IXe+9nNvS4tzWG5LrxomobGwKT7+uaexB0c/dlqGB/nrs/Z2m+t6o1DC5ouJSlRnSqh1HHcbW6NO+hSZc0V5FjKmBJq4pJAYA0NB+PWPT3QM66LH3HQcK79u+hR79ny56/rMf1Sk2XGt2/+L03vIB+zwtiQUAAADMwKw32n/PlfdeGnKcjKrGpvDk65qKuuqSGmZQ8Iq2Zb8OVo26rK02Zp10GsrAU783KjVMrtSQXv4i02mw8PLXM6+9yB1hAY2iKSQGANAofKTHVu50yhfWZ57U4x9+r9F9Eqp8+7kD9gEAAACoGbPeaC/XEPde6jJORk1UNzaFJ1/XNMag6JVty3V7s1VmGBrTN0Evf57p9D5P/N4YccHkCktKnW5QlNuQeVKFJbTUQNNVk8QAACAVFpdVmi+szzyp6PBAFZWUVfr+xujDFQAAAGiKzHyjXTLXvRdPGJuiPiJCLEqMDlX3Ns2VGB3q8oqfqrblhsyTSo6LrHCeJ35vVGqYXH5R1ZUW5zYZApoSsycGANBYqvs9zCssVWRwxYlqQ/ThCgAAAHgLs99oN9O9l/KxKSrCdU3127KiB9089Xuj+ymTiwwJUIjFT2P6Jig5LlJFJWUKCvDTfw7+pgXr91V6gwJoCsyeGABAY6nu9zI8yF+RIQFOg9O5ug/Xug4uCAAAAJhVYw8CXVvV5ehmuvfSmGNTmFF12/Lc+8ie/L1RqWFy0WGBWnDbJXrp870OfZ71ad9CC267RNFhgW6MDmhYnp4YAICnaN7Mor7tW2h9BV1Q9W3fQhEhAWrdPKRB+3B15eCCAAAAgFl48o32muToZrv30hhjU5hVddsyMTpU6RMvN8X35mMYhuHuILxVbm6uIiIilJOTo/Dw8DotIyffpgfe+U6dYsOdWmrsPpqr527o5rE7H+AKR04VVJoYxHCTDKgTV5yf4Fqu2CYHT57RX9/bYa/YCLH46dGrOys5vrkKbKUN2nIiJ9+mCW9tq7D/1tQO1joNLggAcC/yBc/EdgE8V3mLCE+5YVybHL2yey9PD09SsMWP1tgm4o77aA1xbqKlhsmdPGPTiEvjdTSnwGF6bESQerZprpNnbPyQoEmjBh4AaqZNi2Z6+n+7KaegWKcLixURHKD/HDil61/daB+Dq6FaTtRkcEF+twEAANCURYR41r2K2uTold17OWMrdaoYaUqtsZti97lN5T4alRomV2oYCgrw1aodR7Xhd11K9GnfQhOuaK8yGuLAC3haYgAAnqiipuV92rfQi2nJuuetbcq3leqrvdmavDzD5S0nzDS4IAAAAOANapujn3vvJSff5nR9IanBrikaW1PuPrcp3EejUsPk/H189K9N+zWmT4ImX9VJeYWlCgvy1/HcQv1r0349PKiTu0MEAABuVn7BsfXAb7r/jx10RcdoSVK+rVTBAX565ZZk3f3mfys2XN1ywkyDCwIAAABmUZ+WBPXN0Ztya2wzVNg0xVYktUGlhskVlZbq/j921Lf7fz37uqRMBcWl+iW3UPf/saOKSkvdHCEAAHC37Dybth74TfNG9FRUmEW/5hcrp6BYQQF+Wp+Zrd1Hc/XyLcma8P8rNlzdcsJsgwsCAAAAnq6+LQnqm6M35dbYjVlhU5fKiabciqSmqNQwuSA/Px3NLayw+6m21maKCQ9yY3QAAMAT5BYW68+Xt5M1zKK/fbTLKWcY3SdBb359QGP6JujlzzNd3nIiIsSi2cOTKh2QzpueKAIAAADqyxUtCeqbozfl1tiNVWFTl8oJM7QiaQxUaphcmaSXv8h0uDkhyf768aEXuSEqAADgScKDAnRFx2jNOqdCQ/pvzpDcprmS4yIbrOVEUxmQDgAAAHA3V7UkqE+O3pRbYzdGhU1dKyeacrdfteHr7gBQPwXFpU43J8ptyDypgmK6nwIAwNtZQy3y8ZHWVZEzJMdFSlKDtpyICLEoMTpU3ds0V2J0qFck2wAAAICrubIlQV1z9PKWHqkdrA7Tm0Jr7PIKm4q4qsKmJpUTFWnK3X7VBi01TC6/qOpKi+rmAwCApi8ixKLC43lVlikqKVOH6FDFeEkfrAAAAIBZeUrXT021NXZjdJ9b18oJT9n27kalhslFBFe9o1Y3HwAAeIfIkKpzgsjgAEWHBTZSNAAAAADqypO6fooIMX8lRkUausKmrpUTnrTt3Ynup0yuZXig+lXSHKpfB6tahnNzAgAASNFhlecMfdu3UHyLkCZ5MQIAAAA0NU256ydP0pDd59a1iyu2/Vk+hmEY7g7CW+Xm5ioiIkI5OTkKDw+v83KOnCpwGlimXwernh6eRBcSAIBac9X5Ca7jypzh3CbU/TpYNWtYV51/XogrQgUAeAnyBc/EdgG8S06+rcl1/eRNKro+K6+cqO6erpm2fUOcm+h+qgmIjQzWszd0029nbMotLFF4sL+ah1jUMjzI3aEBAAAP0lT7vK2J8qQ/t7BY4cEBsjbzjvUGAABoTORcjaupdv3kLepzfebt255KjSbg6KkCrf3xhKLDAlVUUqa8ohJtO3hK/S+IoqUGAABw0FDJrydfwFbUqjW1g1WzhycpllwJAADAJci5HHlyfgzP4e2VE3VFpYbJ5eTb9PNv+Tq3FzHDMPTzb/kKsfhxYAAAgAblqRewOfk2/XK6SAd/zdfoPgnqFhepBev3Kd9Wqq/2Zmvy8gy9lJZMrgQAAFAP5FzOPDU/BpoKKjVMLie/WKVlhlbtOKoNmSft0/u0b6EJV7RXTn6xV500AABA48rJtzldsEly+wVsRReSfdq30ItpybrnrW32i+zsPBu5EgAAQB2Rcznz1PwYaEp83R0A6qekzNDLX2Q6VGhI0obMk3r5i0yVlDEOPAAAaDjZeTanC7Zy5Rewja2yC8kNmSe1cMM+jembYJ92urC4scMDAABoEsi5KuaJ+THQ1FCpYXIFJaVOFRrlNmSeVEFJaSNHBAAAvEluNReo7riArepCckPmSSXHRdpfhwUFNFJUAAAATQs5V8U8MT8GmhoqNUwu31Z1pUV18wEAAOojvJoLVHdcwFZ3IVlUUibpbL/G1lCa/gMAANQFOVfFPDE/BpoaxtQwucjgqn8Iq5sPNAU5+TZl59mUW1is8OAAWZtZ6J8SAKrgyt9Na6hFqR2s+qqCp/TcdQFb3YVkoL+vUjtY9dTwJM4XAAAAdUTOVTF358fcI4E3oFLD5KLDAtWvg7XC5n79OlgVHRbohqiAxlPRoGSpHayaPTxJsZHBbowMADyTq383I0Ismj08SZOXZzhcuLnzAraqC8l+HaxqHxXKAI0AAAD1RM5VMXfmx9wjgbfwMQyDkaTdJDc3VxEREcrJyVF4eHidl3P0VIHW/nhC0WGBKiopU1CAn47nFuqKC6LUih8sNGE5+TZNeGtbhZV6qR2sXpk8Aa7gqvMTXMdV26QhfzfLnwg7XVissKAAWUPd+0TYkVMFlV5IxpAfAW7Bk6NNC/mCZ2K7oLF5W85Vm3NZY+fH3COBp2qIc5NHjKnxyiuvqG3btgoKClJKSoq2bNlSadni4mLNnDlTiYmJCgoKUrdu3bR69WqHMtOnT5ePj4/DX6dOnRzK9O/f36nMHXfcYZ9/8uRJDR48WLGxsQoMDFRcXJwmTJig3Nxch+WsXbtWPXr0UGBgoNq3b69FixbV/wupJUPSRxlHNfaNb3XX0v9ozKJv9PGOoypr9EiAxlXVoGRf7c1Wdp6tkSMC0JDIF+qvIX83I0IsSowOVfc2zZUYHer2C6bYyGC9lJas9ImXa+Vdlyl94uV6KS25SV5cA2Zw5FSBJry1TQPmfKlhr27UgOe+1F/e2qYjpwrcHRqaIHIGoPF4U85V23NZY+fH3COBN3F791Nvv/22Jk6cqHnz5iklJUVz587VoEGDtGfPHkVHRzuVnzp1qpYsWaL58+erU6dO+uSTTzRs2DBt3LhRycnJ9nJdunTRmjVr7K/9/Z1Xddy4cZo5c6b9dUhIiP3/vr6+Gjp0qP72t78pKipKmZmZuvvuu/Xrr7/qzTfflCTt27dPV199te644w4tXbpU6enpuv322xUTE6NBgwa55PupTk6+TY+9v1Pd2kTqtj5t7S01/nPwN017f6eevaGb228qAA2lukHJTlczH4B5kC+4xu9/N0MsfhrTN0HJcZH2/KGsiTXgjQjhKXDAE+Tk25y6wpDO3mCZvDyDJ0fhUuQMQOPzhpzLDOcy7pGgpppC61m3V2rMmTNH48aN0+jRoyVJ8+bN06pVq7RgwQJNnjzZqfzixYv1yCOPaMiQIZKkO++8U2vWrNFzzz2nJUuW2Mv5+/urVatWVX52SEhIpWWaN2+uO++80/46Pj5ed911l5555hn7tHnz5ikhIUHPPfecJKlz585av369nn/++UZLOE6esenmXm20cMM+vfx5pn16n/YtNLpPgk6esZlupwRqqrpBycKqmQ/APMgXXKP8dzPE4qcX05Kd8od+/7+rAPrbBeBKNXlylGsWuAo5A4CGYIZzGfdIUBNNZdwVt3Y/ZbPZtHXrVg0cONA+zdfXVwMHDtSmTZsqfE9RUZGCgoIcpgUHB2v9+vUO0/bu3avY2Fi1a9dOI0aM0MGDB52WtXTpUlmtVl100UWaMmWK8vPzK431yJEjWrFihS6//HL7tE2bNjnELkmDBg2qMvbc3FyHv/oqKTO0cMM+bcg86TB9Q+ZJLdywT6VlTeuJS+D3ygclq0hqB6usoVwcA02Bt+UL5fG7OmeQ/vu7OaZvQoX5w7r//6RZTj5N0wG4Dk+OorGQM7guZwDgyAznMu6RoDrVtTgy03WgW1tqZGdnq7S0VC1btnSY3rJlS+3evbvC9wwaNEhz5sxRamqqEhMTlZ6erhUrVqi0tNReJiUlRYsWLVLHjh119OhRzZgxQ/369dPOnTsVFhYmSbrlllsUHx+v2NhYZWRkaNKkSdqzZ49WrFjh8HlpaWl6//33VVBQoGuuuUavvfaafd6xY8cqjD03N1cFBQUKDnas3Zo1a5ZmzJhR+y+qCmVlhrYdPKUJf2jv0H3Efw7+pgXrqdRA0xYRYtFTw5O09scTig4LtO//x3MLdcUFUW5/SgKAa3hbviA1TM4gnf3dnHV9V53KL9aFMeEa27edPWfIt539bjzlSbOaagpNp4GmjidH0VjIGYCGQb5ljnNZRIhFs4cnVTpwu7dtM3fw9GPFDC2Oasrt3U/V1gsvvKBx48apU6dO8vHxUWJiokaPHq0FCxbYy1x11VX2/yclJSklJUXx8fF65513NHbsWEnS+PHj7WW6du2qmJgYDRgwQFlZWUpMTLTPe/755zVt2jT9+OOPmjJliiZOnKhXX321TrGXv79cbm6u4uLi6rSscoXFJRV2H9GnfQu9mJaswuLSKt4NmJ8h6aOMo1qX6XjCvvyCKPcFBcDtzJwvSA2TM0hnmxpPXrHDIZEtzxnueWubvWLDE540q4mm0nQaaOrKnxz9qoKLaJ4chbuRMwBVI986yyznsvKB27PzbDpdWKywoABZQz3rxnpTZYZjxQwtjmrKrd1PWa1W+fn56fjx4w7Tjx8/Xmk/lFFRUVq5cqXOnDmjAwcOaPfu3QoNDVW7du0q/ZzIyEhdcMEFyszMrLRMSkqKJDmVadWqlTp16qRrr71W//jHP/T3v/9dR48etc+rKPbw8PAKn6AIDAxUeHi4w199NQ8J1JubDyi5TXO9PupivTqihxbcdomS2zTXm5sPqDk/WmjC7M3mMs3fbA5A5bwtX5AaJmeorKlxeZeVY/om2Kd5wpNm1alP0+mcfJuyfsnTtoO/KetEHucLoIGVPzl6bpcYPDkKVyNncE3OAJQrz7e2HvhNE/7Q3n7f6bY+CfryxxNelUOZ6VwWEWJRYnSourdprsToUI+KrakyS7dOZmhxVFNubalhsVjUs2dPpaen67rrrpMklZWVKT09XRMmTKjyvUFBQWrdurWKi4u1fPly3XjjjZWWzcvLU1ZWlm699dZKy2zfvl2SFBMTU2mZsrIySWf7rJSk3r1766OPPnIo89lnn6l3795Vxu5KxWVluvXStjqaU+AwPTYiSD3bNFfx/48ZaIqaUrM5AJUjX3CN7Dyb/YK0oi4rx/Q5W6nhSU+aVaWu5wAzPEEFNEU8OYrGQM4AuFZ5/lhZDyG927Xwqt9xzmWozMkzNnWLi9Rtl7V1us7ypPtTZmlxVBNu735q4sSJGjVqlC6++GL16tVLc+fO1ZkzZzR69GhJ0siRI9W6dWvNmjVLkrR582YdPnxY3bt31+HDhzV9+nSVlZXp4Ycfti/zwQcf1DXXXKP4+HgdOXJE06ZNk5+fn9LS0iRJWVlZevPNNzVkyBC1aNFCGRkZuv/++5WamqqkpCRJ0kcffaTjx4/rkksuUWhoqL7//ns99NBD6tOnj9q2bStJuuOOO/Tyyy/r4Ycf1pgxY/T555/rnXfe0apVqxrt+zMkBQX4atWOow6DffZp30ITrmjfaHEA7tCUms0BqBr5Qv3lFRVX2WVlSZnhkU+aVaYu54DqnqB6KS3ZFOsOmFVECDd+0PDIGQDXyS0s1pi+CVq4YZ/DPSfpbGvfR9/fqZe9LH/iXIaKGJK2Hfytwuuse97a5jH3p5rSuCtur9S46aabdOLECT322GM6duyYunfvrtWrV9sHxzp48KB8ff/bS1ZhYaGmTp2qn376SaGhoRoyZIgWL16syMhIe5lDhw4pLS1NJ0+eVFRUlPr27auvv/5aUVFn+9i3WCxas2aNPbmJi4vT8OHDNXXqVPsygoODNX/+fN1///0qKipSXFycrr/+ek2ePNleJiEhQatWrdL999+vF154Qeeff75ee+01DRo0qIG/tf/y9/HRy19kVnhykaS/Db2o0WIBGlt4UIBCLH4a0zehwqeOzdRsDkDVyBfqLzLYohfS9yq5TXON6ZPg8Jv55uYDevTqC011U78uTadp4QcATR85A+A64UEBSo6LdLhR+3vryJ/ggRp7sO6cfJumv7+z0nuzY/omeNT9qabS4sjHMAzD3UF4q9zcXEVERCgnJ6fO/V7+cCRHQ15cX+n8j+7pqwtjI+oaIuDRcvJt2nXstF76fK9TS6W//KGDOrcKM92PMuAJXHF+gmu5Yptk/nJa+0/mOz1p16d9C43uk6C2LULUPjrMVSE3uJx8m/7y1rZKm05XVEGz7eBvGvbqxkqXufKuy9S9TXOXxwoATRH5gmdiu8CVcvJt+vbAbxr7xreVliF/gidxR1ezWb/kacCcLyud/+btKeoSG+7V96ca4tzk1oHCUX9nbKVVzs+vZj5gdq98XnFLpVe+qHzQPgDwRmWGKu06YOGGfTLbYy51GayxKQ2MBwAA0NAiQiw6v3nVN4LJn+Ap3DVYd3Xd4gYG+Hp1hUZDcXv3U6ifyOCzTYSeGp6k6PBA5RWWKizIX8dzCzVpeYYigjm5oOnKzrNpXWbF3YjQDBYAHBmGUWHXUwvWn63oKC0zWa2Gqm86fW7T89Agf/2xc7Q+2/WL07LMNjAeAABAY2gVHlTngYUbuxsgeDd3dTVb3YNTkcHm2+fNcOxSqWFy0WGBWja+t6Z94Nh3W9/2LbRsfG9FcXGOJoyBwgGg5vx9fascvM6srTsrG6yxsqbnf7vu7Hhjv6/YMOPAeAAAAI2hrgMLu6MbIHg3d90jsoZa6lzx54nMcuxSqWFyhSVlThUakrQ+86Smf7BTz93YXYyogaaKbkQAoGZy8m2aXkG+8PvB65pS686qmp5PXblTz9zQTZOvKjH1wHgAAACNpbYDC1fXDVBFY58B9eWue0R1rfjzRGY6dqnUMLnfzticblCUW595Ur+dsalleFAjRwU0jqZWGw4ADeVsd30V5wsbMk/q7v7tm9RvZnVNz/MKS5QYHdrIUQEAAJhXZa1jK+KuboDg3dx5j6i2FX+eykzHLpUaJpdbWKIQi5/G9E1QclykUx/ZuYUl7g4RaDBNqTYcABpSVU2xQyx+ahFqUXaeTT9ln/HYPlNrg+4JAQCAJzNDf/X1QS4Gd3D3PaLaVPx5KjMdu1RqmFxEsL9eTEvWwg37KuwjOyKYTYymLTYyWM/c0E2/nbEpt7BE4cH+ah5ioYUSAPxOZU2xQyx+ejEtWX/78AeHlhye2GdqbdA9ITxdU7+ZBQBm0ti/yWbpr74+yMXgLk2lxYS7mOnY5Y63yYUFBejNzbuV3Ka5xvRJcGip8dbmA3r8uq7uDhFoUEdPFWjtjycUHRaoopIy5RWVaNvBU+p/QZRimkhCCAD1ZQ216I+do9UxJtyhZadhGFq6+YBDhUaIxU9JcZHan31Gx3IKFBFiMd0NV7onhCfzhptZAGAWjf2bbKb+6uvDrLkYDx00De5uMWHm/chMxy6VGiZXWFyqW1LiK2ypMbpPggqLS90YHdCwcvJtOvBrvj7MOOIwtkyf9i2UYG2mEIufaU4cANCQIkIsevR/LtSU93Y45Av92ls1qk9bff3Tr8q3ldpbbpybV5jthqu7m54DlfGWm1kAYAbu+E02U3/19WHGXIyHDuAKZt+PzHTsUqlhciVlhhZu2Oc0WHj56+nXdHFHWECjOJVfrJc+31vp/v/kdV096gcXANwlJ9+mR1budPq9XJeZrTIZGtM3QS9/nqkxfRMqzCvMeMOVpufwRN5yMwsAzMAdv8lm6q++vsyUi/HQAVyhqexHZjl2qdQwubIyw+nGQ7kNmSdVWmY0ckRA4zljK6ly/z9jK2nkiADAM1V10b4h86TG9EmQJCXHRTq00Pg9M95wdXfTc+Bc3nQzCwA8nTt+k83UX70rmCUX46EDuEJT2o/McOz6ujsA1E9+NTdt8210P4Wm60w1+zf7PwCcVd1Fe1FJmcO/leGGK1A/3nYzCwA8mTt+k8v7q6+Ip/VX70146ACuwH7UuKjUMLmI4KpPeBHBXBih6YqsZv9m/weAs6q7aC//PQ30rzo15IYrUD/czAIAz+GO3+Ty/urP/VxP7K/em/DQAVyB/ahx0f2UyZlpVHrA1aLDAtWvg7XC5n39OlgVHRbohqiAxpWTb1N2nk25hcUKDw6QtZnnNxNF46suX0iMDlX6xMtVZhhOv6shFj+N6Zugy9q1UE6BTVkn8tjPgDoy0+CLANDUues32Sz91XuTpnBvjetC92sK+5GZ+BiGwaALbpKbm6uIiAjl5OQoPDy8zss5cqqg0pNwTGSwK0IFPBb7P7zZkVMFTgORpXawavbwJMXWY/931fkJruOKbVLT38vflwux+OnFtGSnwcNdsZ8B3qz8xgM3s2Bm5Aueie1Se/wmQzL3vYWGui5E7Zl5P2pIDXFuolLDjVy5QTkJw5ux/8Mb5eTbNOGtbRW2VErtYNVLacl1Pg64GPY8rtomNf29LC9XZhia+X/fa93vKjTK1Xc/AwCYG/mCZ2K7AHVnxnsLDXldiLox437U0Bri3ET3U02EGUalBxoK+z+8UXaercLEVZK+2put7DwbxwWc1PT3srxc1i95FVZoSOxnAAAAaFrMeG+B60LPY8b9yIwYKBwAABPKLSyucv7pauYDNcF+BgAAAHgu8nV4Kyo1AAAwofCggCrnh1UzH6gJ9jMAAADAc5Gvw1tRqQEAgAlZQy1K7WCtcF5qB6usoTR3Rf2xnwEAAACei3wd3opKDQAATCgixKLZw5OcEtjUDlY9NTyJPjzhEuxnAAAAgOciX4e3YqBwAKaXk29Tdp5NuYXFCg8OkLUZgzLBO8RGBuultGRl59l0urBYYUEBsoay/6N2qvsNZT8DAMD7cI0FmAf5OrwRlRoATO3IqQJNWp6hdXuz7dNSO1g1e3iSYiOD3RgZ0DgiQkhWUXc1/Q1lPwMAwHtwjQWYD/k6vA3dTwEwrZx8m1OyLUlf7c3W5OUZysm3uSkyAPB8/IYCAIBzkR8AAMyASg0AppWdZ3NKtst9tTdb2Xkk3ABQGX5DAQDAucgPAABmQKUGANPKLSyucv7pauYDgDfjNxQAAJyL/AAAYAaMqdFEMIgXvFF4UECV88OqmQ8A3iwiOEAT/tBeyXGRKiopU1CAn/5z8DctWL9P+bZSfkMBAPBCXGMB8FbcWzUXKjWaAAbxgreyhlqU2sGqrypoHp3awSprKCcfAKiMxc9X2w7+ppc/z7RP69O+hV5MS9bbWw7yGwoAgBfiGguAN+LeqvnQ/ZTJMYgXvFlEiEWzhycptYPVYXpqB6ueGp5EjToAVCIn36Yp7+3QhsyTDtM3ZJ7Uog37NP3aLvyGAgDghbjGAuBtuLdqTrTUMLmaDOJF0oGmLDYyWC+lJSs7z6bThcUKCwqQNZQmggBQlaryh/WZJ1VYXNbIEQEAAE/BNRYAb8K9VXOiUsPkGMQLOPs0EScYAKg58gcAAFAVrrEAeAuujcyJ7qdMjkG8AABAbZE/AAAAAADXRmZFpYbJlQ/iVREG8QIAABUhfwAAAAAAro3MikoNk2MQLwAAUFvkDwAAAADAtZFZMaZGE8AgXgAAoLbIHwAAAACAayMz8oiWGq+88oratm2roKAgpaSkaMuWLZWWLS4u1syZM5WYmKigoCB169ZNq1evdigzffp0+fj4OPx16tTJoUz//v2dytxxxx32+d99953S0tIUFxen4OBgde7cWS+88ILDMtauXeu0DB8fHx07dswF30rtRIRYlBgdqu5tmisxOpSDDgDQ5JAvuB75AwCgKSJnAADUFtdG5uL2lhpvv/22Jk6cqHnz5iklJUVz587VoEGDtGfPHkVHRzuVnzp1qpYsWaL58+erU6dO+uSTTzRs2DBt3LhRycnJ9nJdunTRmjVr7K/9/Z1Xddy4cZo5c6b9dUhIiP3/W7duVXR0tJYsWaK4uDht3LhR48ePl5+fnyZMmOCwnD179ig8PNz+uqK4AQBA3ZEvAACAmiBnAACg6XN7pcacOXM0btw4jR49WpI0b948rVq1SgsWLNDkyZOdyi9evFiPPPKIhgwZIkm68847tWbNGj333HNasmSJvZy/v79atWpV5WeHhIRUWmbMmDEOr9u1a6dNmzZpxYoVTglHdHS0IiMjq11XAABQN+QLAACgJsgZAABo+tza/ZTNZtPWrVs1cOBA+zRfX18NHDhQmzZtqvA9RUVFCgoKcpgWHBys9evXO0zbu3evYmNj1a5dO40YMUIHDx50WtbSpUtltVp10UUXacqUKcrPz68y3pycHJ133nlO07t3766YmBj98Y9/1IYNG6pcBgAAqB3yBQAAUBPkDAAAeAe3ttTIzs5WaWmpWrZs6TC9ZcuW2r17d4XvGTRokObMmaPU1FQlJiYqPT1dK1asUGlpqb1MSkqKFi1apI4dO+ro0aOaMWOG+vXrp507dyosLEySdMsttyg+Pl6xsbHKyMjQpEmTtGfPHq1YsaLCz924caPefvttrVq1yj4tJiZG8+bN08UXX6yioiK99tpr6t+/vzZv3qwePXo4LaOoqEhFRUX217m5uTX/sgAA8FLeli9I5AwAANQFOQM5AwDASxhudPjwYUOSsXHjRofpDz30kNGrV68K3/PLL78YQ4cONXx9fQ0/Pz/jggsuMO666y4jKCio0s/57bffjPDwcOO1116rtEx6erohycjMzHSat2PHDsNqtRqPP/54teuUmppq/OlPf6pw3rRp0wxJTn85OTnVLhcAgMaSk5PjUecnb8sXDIOcAQDg+TwtXzAMcgZyBgCAJ2qInMGt3U9ZrVb5+fnp+PHjDtOPHz9eaT+UUVFRWrlypc6cOaMDBw5o9+7dCg0NVbt27Sr9nMjISF1wwQXKzMystExKSookOZX54YcfNGDAAI0fP15Tp06tdp169epV6edMmTJFOTk59r+ff/652uUBAODtvC1fkMgZAACoC3IGcgYAgHdwa6WGxWJRz549lZ6ebp9WVlam9PR09e7du8r3BgUFqXXr1iopKdHy5cs1dOjQSsvm5eUpKytLMTExlZbZvn27JDmU+f7773XFFVdo1KhReuKJJ2q0Ttu3b6/0cwIDAxUeHu7wBwAAquZt+YJEzgAAQF2QM5AzAAC8g1vH1JCkiRMnatSoUbr44ovVq1cvzZ07V2fOnNHo0aMlSSNHjlTr1q01a9YsSdLmzZt1+PBhde/eXYcPH9b06dNVVlamhx9+2L7MBx98UNdcc43i4+N15MgRTZs2TX5+fkpLS5MkZWVl6c0339SQIUPUokULZWRk6P7771dqaqqSkpIkSTt37tQf/vAHDRo0SBMnTtSxY8ckSX5+foqKipIkzZ07VwkJCerSpYsKCwv12muv6fPPP9enn37aaN8fAADegHwBAADUBDkDAABNn9srNW666SadOHFCjz32mI4dO6bu3btr9erV9oG9Dh48KF/f/zYoKSws1NSpU/XTTz8pNDRUQ4YM0eLFixUZGWkvc+jQIaWlpenkyZOKiopS37599fXXX9sTBYvFojVr1tiTm7i4OA0fPtyh6ee///1vnThxQkuWLNGSJUvs0+Pj47V//35Jks1m0wMPPKDDhw8rJCRESUlJWrNmja644ooG/MYAAPA+5AsAAKAmyBkAAGj6fAzDMNwdhLfKzc1VRESEcnJyaCIKAKiTnHybsvNsyi0sVnhwgKzNLIoIsdRrmZyfPI+rt0lD7DcAAO9CvuCZ2C4AUDWuhRpfQ5yb3N5SAwAA1M2RUwWatDxD6/Zm26eldrBq9vAkxUYGuzEyeDL2GwAAAADeiGuhpsOtA4UDgCvk5NuU9Uueth38TVkn8pSTb3N3SECDy8m3OSVjkvTV3mxNXp7BcYAKuWq/4XcXAADvRA4AwKy4hm5aaKkBwNSoZYe3ys6zOSVj5b7am63sPBtNaOHEFfsNv7sAAHgncgAAZsY1dNNCSw0ApkUtO7xZbmFxlfNPVzMf3qm++w2/uwAAeCdyAABmxzV000KlBgDTqkktO9BUhQcFVDk/rJr58E713W/43QUAwDuRAwAwO66hmxYqNQCYFrXs8GbWUItSO1grnJfawSprKM1m4ay++w2/uwAAeCdyAABmxzV000KlBgDTopYd3iwixKLZw5OckrLUDlY9NTyJvkBRofruN/zuAgDgncgBAJgd19BNS40GCs/IyKjxApOSkuocDADURnkt+1cVNIOmlh3eIDYyWC+lJSs7z6bThcUKCwqQNdTi1mSMnMHz1We/4XcXAOAq5AzmQg4AoCnwxGto1I2PYRhGdYV8fX3l4+MjwzDk4+NTZdnS0lKXBdfU5ebmKiIiQjk5OQoPD3d3OIApHTlVoMnLMxyS6/Ja9pjIYDdGBphXfc5P5AwNw5NyBn53AQBS/c9N5AwNoyFzBnIAAEBdNMS5qUYtNfbt22f//7Zt2/Tggw/qoYceUu/evSVJmzZt0nPPPaenn37aJUEBQE1Ryw54FnKGpo/fXQCAK5AzmA85AADAU9SoUiM+Pt7+/xtuuEEvvviihgwZYp+WlJSkuLg4Pfroo7ruuutcHiQAVCUihEQa8BTkDN6B310AQH2RM5gTOQAAwBPUeqDwHTt2KCEhwWl6QkKCfvjhB5cEBQAAzI+cAQAA1AQ5AwAAqI1aV2p07txZs2bNks1ms0+z2WyaNWuWOnfu7NLgAACAeZEzAACAmiBnAAAAtVGj7qd+b968ebrmmmt0/vnnKykpSZKUkZEhHx8f/d///Z/LAwQAAOZEzgAAAGqCnAEAANSGj2EYRm3fdObMGS1dulS7d++WdPapiltuuUXNmjVzeYBNWUOM/A4AQH258vxEzuAa5AwAAE/j6nMTOYNrkDMAADxNQ5ybat1SQ5KaNWum8ePHuyQAAADQdJEzAACAmiBnAAAANVWjSo0PPvhAV111lQICAvTBBx9UWfbaa691SWAAAMB8yBkAAEBNkDMAAIC6qlH3U76+vjp27Jiio6Pl61v52OI+Pj4qLS11aYBNGc1CAQCeqD7nJ3KGhkHOAADwNPU9N5EzNAxyBgCAp3Fb91NlZWUV/h8AAOD3yBkAAEBNkDMAAIC6qvxxCAAAAAAAAAAAAA9So5YaL774Yo0XeM8999Q5GAAAYG7kDAAAoCbIGQAAQF3VaEyNhISEmi3Mx0c//fRTvYPyFvR1CQDwRPU5P5EzNAxyBgCAp6nvuYmcoWGQMwAAPI3bxtTYt2+fSz4MAAA0beQMAACgJsgZAABAXTGmBgAAAAAAAAAAMIUatdQ416FDh/TBBx/o4MGDstlsDvPmzJnjksAAAID5kTMAAICaIGcAAAA1VetKjfT0dF177bVq166ddu/erYsuukj79++XYRjq0aNHQ8QIAABMiJwBAADUBDkDAACojVp3PzVlyhQ9+OCD2rFjh4KCgrR8+XL9/PPPuvzyy3XDDTc0RIwAAMCEyBkAAEBNkDMAAIDaqHWlxq5duzRy5EhJkr+/vwoKChQaGqqZM2fqqaeecnmAAADAnMgZAABATZAzAACA2qh1pUazZs3s/VvGxMQoKyvLPi87O9t1kQEAAFMjZwAAADVBzgAAAGqj1mNqXHrppVq/fr06d+6sIUOG6IEHHtCOHTu0YsUKXXrppQ0RIwAAMCFyBgAAUBPkDAAAoDZqXakxZ84c5eXlSZJmzJihvLw8vf322+rQoYPmzJnj8gABAIA5kTMAAICaIGcAAAC1UetKjSeffFJ/+tOfJJ1tIjpv3jyXBwUAAMyPnAEAANQEOQMAAKiNWo+pceLECQ0ePFhxcXF66KGH9N133zVEXAAAwOTIGQAAQE2QMwAAgNqodaXG+++/r6NHj+rRRx/VN998ox49eqhLly568skntX///gYIEQCqlpNvU9Yvedp28DdlnchTTr7N3SEBEDmDJ+L3EgDgicgZAABV4ToG5/IxDMOozwIOHTqkt956SwsWLNDevXtVUlLiqtiavNzcXEVERCgnJ0fh4eHuDgcwpSOnCjRpeYbW7c22T0vtYNXs4UmKjQx2Y2SAeTXU+Ymcoe5csU34vQQAuFJDXs+SM9Qd9xkANDVcx5hfQ5ybat1S4/eKi4v17bffavPmzdq/f79atmzpkqAAoCZy8m1OJzZJ+mpvtiYvz6DmHvAg5Azuxe8lAMAsyBkAAOW4jkFl6lSp8cUXX2jcuHFq2bKlbrvtNoWHh+vDDz/UoUOH6hTEK6+8orZt2yooKEgpKSnasmVLpWWLi4s1c+ZMJSYmKigoSN26ddPq1asdykyfPl0+Pj4Of506dXIo079/f6cyd9xxh33+d999p7S0NMXFxSk4OFidO3fWCy+84BTP2rVr1aNHDwUGBqp9+/ZatGhRnb4DALWXnWdzOrGV+2pvtrLzOLkB7ubKnIF8oe74vQQAeDpyhrPcnTMAgCfhOgaV8a/tG1q3bq1ff/1VgwcP1j//+U9dc801CgwMrHMAb7/9tiZOnKh58+YpJSVFc+fO1aBBg7Rnzx5FR0c7lZ86daqWLFmi+fPnq1OnTvrkk080bNgwbdy4UcnJyfZyXbp00Zo1a+yv/f2dV3XcuHGaOXOm/XVISIj9/1u3blV0dLSWLFmiuLg4bdy4UePHj5efn58mTJggSdq3b5+uvvpq3XHHHVq6dKnS09N1++23KyYmRoMGDarzdwKgZnILi6ucf7qa+QAalitzBvKF+uH3EgDgycgZPCdnAABPwnUMKlPrMTXmz5+vG264QZGRkS4JICUlRZdccolefvllSVJZWZni4uL0l7/8RZMnT3YqHxsbq0ceeUR33323fdrw4cMVHBysJUuWSDr7FMXKlSu1ffv2Sj+3f//+6t69u+bOnVvjWO+++27t2rVLn3/+uSRp0qRJWrVqlXbu3Gkvc/PNN+vUqVNOT3ZUhL4ugfrJ+iVPA+Z8Wen89ImXKzE6tBEjApoGV52fXJkzeHO+INV/m/B7CQBwNVdez5IzeE7OAACehOuYpsEjxtQYN26cyyo0bDabtm7dqoEDB/43IF9fDRw4UJs2barwPUVFRQoKCnKYFhwcrPXr1ztM27t3r2JjY9WuXTuNGDFCBw8edFrW0qVLZbVaddFFF2nKlCnKz8+vMt6cnBydd9559tebNm1yiF2SBg0aVGXsubm5Dn8A6s4aatEfO0drwh/a6/VRF+vVET204LZLNOEP7fXHztGyhlrcHSLg1VyVM3hbvlAevytzBmuoRakdrAqx+Dn9Zs66viu/lwAAtyJnOMsTcoamLiffpqxf8rTt4G/KOpFHf/yAhyu/jqlIagcr1zFerNbdT7lSdna2SktLnQb+atmypXbv3l3hewYNGqQ5c+YoNTVViYmJSk9P14oVK1RaWmovk5KSokWLFqljx446evSoZsyYoX79+mnnzp0KCwuTJN1yyy2Kj49XbGysMjIyNGnSJO3Zs0crVqyo8HM3btyot99+W6tWrbJPO3bsWIWx5+bmqqCgQMHBwQ7zZs2apRkzZtT8CwJQpYgQix79nws15b0devnzTPv0vu1b6MlhXRURwskNaAq8LV+QXJ8zRIRY9NTwJB34NV8vfb7X4TezXwerLr8gShEhVSwAAAATIGdAVY6cKnAacDi1g1WzhycpNtL5uwXgfhEhFs0enqTJyzP01TnH7lPDk7jv48XcWqlRFy+88ILGjRunTp06ycfHR4mJiRo9erQWLFhgL3PVVVfZ/5+UlKSUlBTFx8frnXfe0dixYyVJ48ePt5fp2rWrYmJiNGDAAGVlZSkxMdHhM3fu3KmhQ4dq2rRpuvLKK+sc+5QpUzRx4kT769zcXMXFxdV5eYC3y8m36ZGVO7Uh86TD9PWZJzV15U69lJbMCQ7wUmbOF6SGyRlCLH565fNMp9/MdXuzNXl5Br+ZAACvRM7gHXLybU4VGtLZgYbJgwDPFhsZrJfSkpWdZ9PpwmKFBQXIGmrhmPVyte5+ypWsVqv8/Px0/Phxh+nHjx9Xq1atKnxPVFSUVq5cqTNnzujAgQPavXu3QkND1a5du0o/JzIyUhdccIEyMzMrLZOSkiJJTmV++OEHDRgwQOPHj9fUqVMd5rVq1arC2MPDwyt8giIwMFDh4eEOfwDqLjvP5pSUlvtqb7ay82hKDDQF3pYvSA2TM2Tn2bQuk99MAEDTRc7AfYbKcO0ImFtEiEWJ0aHq3qa5EqNDqdCAeys1LBaLevbsqfT0dPu0srIypaenq3fv3lW+NygoSK1bt1ZJSYmWL1+uoUOHVlo2Ly9PWVlZiomJqbRM+YBfvy/z/fff64orrtCoUaP0xBNPOL2nd+/eDrFL0meffVZt7ABcI7ewuMr5p6uZD8AcyBdcg99MAEBTR86AypAHAUDT4tZKDUmaOHGi5s+frzfeeEO7du3SnXfeqTNnzmj06NGSpJEjR2rKlCn28ps3b9aKFSv0008/ad26dRo8eLDKysr08MMP28s8+OCD+vLLL7V//35t3LhRw4YNk5+fn9LS0iRJWVlZevzxx7V161bt379fH3zwgUaOHKnU1FQlJSVJOtsc9IorrtCVV16piRMn6tixYzp27JhOnDhh/5w77rhDP/30kx5++GHt3r1br776qt555x3df//9jfHVAV4vPCigyvlh1cwHYB7kC/XHbyYAwBuQM6Ai5EEA0LS4fUyNm266SSdOnNBjjz2mY8eOqXv37lq9erV9cKyDBw/K1/e/dS+FhYWaOnWqfvrpJ4WGhmrIkCFavHixIiMj7WUOHTqktLQ0nTx5UlFRUerbt6++/vprRUVFSTr79MaaNWs0d+5cnTlzRnFxcRo+fLhD089///vfOnHihJYsWaIlS5bYp8fHx2v//v2SpISEBK1atUr333+/XnjhBZ1//vl67bXXNGjQoAb8xgCUs4ZalNrB6jBYVLnUDlZZQ2mOCDQV5Av1x28mAMAbkDOgIuRBANC0+BiGYbg7CG+Vm5uriIgI5eTk0O8lUEdHThVo8vIMh+Q0tYNVTw1PUkxkxf3OAqga5yfP46ptwm8mAMBVyBc8E9ulcuRBAOAeDXFucntLDQCoj9jIYL2UlqzsPJtOFxYrLChA1lALg0YBQAX4zQQAAN6KPAgAmg4qNQCYXkQIiSgA1BS/mQAAwFuRBwFA0+D2gcIBAAAAAAAAAABqgkoNAAAAAAAAAABgClRqAAAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBSo1AAAAAAAAAAAAKZApQYAAAAAAAAAADAFKjUAAAAAAAAAAIApUKkBAAAAAAAAAABMgUoNAAAAAAAAAABgClRqAAAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBSo1AAAAAAAAAAAAKZApQYAAAAAAAAAADAFKjUAAAAAAAAAAIApUKkBAAAAAAAAAABMgUoNAAAAAAAAAABgCv7uDgAAANRdTr5N2Xk25RYWKzw4QNZmFkWEWNwdFgAA8DDkDEDTw3ENwFtRqQEAgEkdOVWgScsztG5vtn1aagerZg9PUmxksBsjAwAAnoScAWh6OK4BeDO6nwIAwIRy8m1OFzGS9NXebE1enqGcfJubIgMAAJ6EnAFoejiuAXg7KjUAADCh7Dyb00VMua/2Zis7jwsZAABAzgA0RRzXALwdlRoAAJhQbmFxlfNPVzMfAAB4B3IGoOnhuAbg7ajUAADAhMKDAqqcH1bNfAAA4B3IGYCmh+MagLejUgMAABOyhlqU2sFa4bzUDlZZQy2NHBEAAPBE5AxA08NxDcDbUakBAIAJRYRYNHt4ktPFTGoHq54anqSIEC5kAAAAOQPQFHFcA/B2/u4OAAAA1E1sZLBeSktWdp5NpwuLFRYUIGuohYsYAADggJwBaHo4rgF4Myo1AAAwsYgQLlwAAED1yBmApofjGoC3ovspAAAAAAAAAABgClRqAAAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBSo1AAAAAAAAAAAAKbg9kqNV155RW3btlVQUJBSUlK0ZcuWSssWFxdr5syZSkxMVFBQkLp166bVq1c7lJk+fbp8fHwc/jp16uRQpn///k5l7rjjDocy99xzj3r27KnAwEB1797dKZb9+/c7LcPHx0dff/113b8MAABQKXIGAABQE+QMAAA0bf7u/PC3335bEydO1Lx585SSkqK5c+dq0KBB2rNnj6Kjo53KT506VUuWLNH8+fPVqVMnffLJJxo2bJg2btyo5ORke7kuXbpozZo19tf+/s6rOW7cOM2cOdP+OiQkxKnMmDFjtHnzZmVkZFS6DmvWrFGXLl3sr1u0aFH9igMAgFohZwAAADVBzgAAQNPn1kqNOXPmaNy4cRo9erQkad68eVq1apUWLFigyZMnO5VfvHixHnnkEQ0ZMkSSdOedd2rNmjV67rnntGTJEns5f39/tWrVqsrPDgkJqbLMiy++KEk6ceJElclGixYtqv0sAABQP+QMAACgJsgZAABo+tzW/ZTNZtPWrVs1cODA/wbj66uBAwdq06ZNFb6nqKhIQUFBDtOCg4O1fv16h2l79+5VbGys2rVrpxEjRujgwYNOy1q6dKmsVqsuuugiTZkyRfn5+XVaj2uvvVbR0dHq27evPvjggzotAwAAVI6cAQAA1AQ5AwAA3sFtLTWys7NVWlqqli1bOkxv2bKldu/eXeF7Bg0apDlz5ig1NVWJiYlKT0/XihUrVFpaai+TkpKiRYsWqWPHjjp69KhmzJihfv36aefOnQoLC5Mk3XLLLYqPj1dsbKwyMjI0adIk7dmzRytWrKhx/KGhoXruuefUp08f+fr6avny5bruuuu0cuVKXXvttRW+p6ioSEVFRfbXubm5Nf48AAC8FTkDOQMAADVBzkDOAADwDm7tfqq2XnjhBY0bN06dOnWSj4+PEhMTNXr0aC1YsMBe5qqrrrL/PykpSSkpKYqPj9c777yjsWPHSpLGjx9vL9O1a1fFxMRowIABysrKUmJiYo1isVqtmjhxov31JZdcoiNHjuiZZ56pNNmYNWuWZsyYUat1BgAAtUfOAAAAaoKcAQAA83Fb91NWq1V+fn46fvy4w/Tjx49X2ndkVFSUVq5cqTNnzujAgQPavXu3QkND1a5du0o/JzIyUhdccIEyMzMrLZOSkiJJVZapiZSUlCqXMWXKFOXk5Nj/fv7553p9HgAA3oCcgZwBAICaIGcgZwAAeAe3VWpYLBb17NlT6enp9mllZWVKT09X7969q3xvUFCQWrdurZKSEi1fvlxDhw6ttGxeXp6ysrIUExNTaZnt27dLUpVlamL79u1VLiMwMFDh4eEOfwAAoGrkDOQMAADUBDkDOQMAwDu4tfupiRMnatSoUbr44ovVq1cvzZ07V2fOnNHo0aMlSSNHjlTr1q01a9YsSdLmzZt1+PBhde/eXYcPH9b06dNVVlamhx9+2L7MBx98UNdcc43i4+N15MgRTZs2TX5+fkpLS5MkZWVl6c0339SQIUPUokULZWRk6P7771dqaqqSkpLsy8nMzFReXp6OHTumgoICe0Jy4YUXymKx6I033pDFYlFycrIkacWKFVqwYIFee+21xvjqAADwKuQMAACgJsgZAABo+txaqXHTTTfpxIkTeuyxx3Ts2DF1795dq1evtg/qdfDgQfn6/rcxSWFhoaZOnaqffvpJoaGhGjJkiBYvXqzIyEh7mUOHDiktLU0nT55UVFSU+vbtq6+//lpRUVGSzj65sWbNGntiExcXp+HDh2vq1KkOsd1+++368ssv7a/Lk4p9+/apbdu2kqTHH39cBw4ckL+/vzp16qS3335b//u//9sQXxUAAF6NnAEAANQEOQMAAE2fj2EYhruD8Fa5ubmKiIhQTk4OTUQBAB6D85PnYZsAADwN5ybPxHYBAHiahjg3uW1MDQAAAAAAAAAAgNqgUgMAAAAAAAAAAJgClRoAAAAAAAAAAMAU3DpQOAAAqJ+cfJuy82zKLSxWeHCArM0sigixuDsseDD2GQAAAAAwJ67nzqJSAwAAkzpyqkCTlmdo3d5s+7TUDlbNHp6k2MhgN0YGT8U+AwAAAADmxPXcf9H9FAAAJpSTb3NKZiTpq73Zmrw8Qzn5NjdFBk/FPgMAAAAA5sT1nCMqNQAAMKHsPJtTMlPuq73Zys7zroQG1WOfAQAAAABz4nrOEZUaAACYUG5hcZXzT1czH96HfQYAAAAAzInrOUdUagAAYELhQQFVzg+rZj68D/sMAAAAAJgT13OOqNQAAMCErKEWpXawVjgvtYNV1lBLI0cET8c+AwAAAADmxPWcIyo1AAAwoYgQi2YPT3JKalI7WPXU8CRFhHhXQoPqsc8AAAAAgDlxPefI390BAACAuomNDNZLacnKzrPpdGGxwoICZA21eF0yg5pjnwEAAAAAc+J67r+o1AAAwMQiQrwzgUHdsc8AAAAAgDlxPXcW3U8BAAAAAAAAAABToFIDAAAAAAAAAACYApUaAAAAAAAAAADAFKjUAAAAAAAAAAAApkClBgAAAAAAAAAAMAUqNQAAAAAAAAAAgClQqQEAAAAAAAAAAEyBSg0AAAAAAAAAAGAKVGoAAAAAAAAAAABToFIDAAAAAAAAAACYApUaAAAAAAAAAADAFKjUAAAAAAAAAAAApkClBgAAAAAAAAAAMAUqNQAAAAAAAAAAgClQqQEAAAAAAAAAAEyBSg0AAAAAAAAAAGAKVGoAAAAAAAAAAABToFIDAAAAAAAAAACYApUaAAAAAAAAAADAFKjUAAAAAAAAAAAApkClBgAAAAAAAAAAMAUqNQAAAAAAAAAAgClQqQEAAAAAAAAAAEzB7ZUar7zyitq2baugoCClpKRoy5YtlZYtLi7WzJkzlZiYqKCgIHXr1k2rV692KDN9+nT5+Pg4/HXq1MmhTP/+/Z3K3HHHHQ5l7rnnHvXs2VOBgYHq3r17hfFkZGSoX79+CgoKUlxcnJ5++um6fQkAAKBa5AwAAKAmyBkAAGja/N354W+//bYmTpyoefPmKSUlRXPnztWgQYO0Z88eRUdHO5WfOnWqlixZovnz56tTp0765JNPNGzYMG3cuFHJycn2cl26dNGaNWvsr/39nVdz3Lhxmjlzpv11SEiIU5kxY8Zo8+bNysjIcJqXm5urK6+8UgMHDtS8efO0Y8cOjRkzRpGRkRo/fnytvwsAAFA5cgYAAFAT5AwAADR9bq3UmDNnjsaNG6fRo0dLkubNm6dVq1ZpwYIFmjx5slP5xYsX65FHHtGQIUMkSXfeeafWrFmj5557TkuWLLGX8/f3V6tWrar87JCQkCrLvPjii5KkEydOVJhsLF26VDabTQsWLJDFYlGXLl20fft2zZkzh2QDAAAXI2cAAAA1Qc4AAEDT57bup2w2m7Zu3aqBAwf+NxhfXw0cOFCbNm2q8D1FRUUKCgpymBYcHKz169c7TNu7d69iY2PVrl07jRgxQgcPHnRa1tKlS2W1WnXRRRdpypQpys/Pr1X8mzZtUmpqqiwWi31a+dMfv/32W6Xx5+bmOvwBAICqkTOQMwAAUBPkDOQMAADv4LZKjezsbJWWlqply5YO01u2bKljx45V+J5BgwZpzpw52rt3r8rKyvTZZ59pxYoVOnr0qL1MSkqKFi1apNWrV+vvf/+79u3bp379+un06dP2MrfccouWLFmiL774QlOmTNHixYv1pz/9qVbxHzt2rMLYy+dVZNasWYqIiLD/xcXF1eozAQDwRuQM5AwAANQEOQM5AwDAO7i1+6naeuGFFzRu3Dh16tRJPj4+SkxM1OjRo7VgwQJ7mauuusr+/6SkJKWkpCg+Pl7vvPOOxo4dK0kOzTa7du2qmJgYDRgwQFlZWUpMTGyw+KdMmaKJEyfaX+fm5pJwAADQAMgZAABATZAzAABgPm5rqWG1WuXn56fjx487TD9+/HilfVBGRUVp5cqVOnPmjA4cOKDdu3crNDRU7dq1q/RzIiMjdcEFFygzM7PSMikpKZJUZZlztWrVqsLYy+dVJDAwUOHh4Q5/AACgauQM5AwAANQEOQM5AwDAO7itUsNisahnz55KT0+3TysrK1N6erp69+5d5XuDgoLUunVrlZSUaPny5Ro6dGilZfPy8pSVlaWYmJhKy2zfvl2Sqixzrt69e+urr75ScXGxfdpnn32mjh07qnnz5jVeDgAA9ZGTb1PWL3nadvA3ZZ3IU06+zd0huRw5g2t5wz4DAPBO5AwA4Bm45kBDc2v3UxMnTtSoUaN08cUXq1evXpo7d67OnDmj0aNHS5JGjhyp1q1ba9asWZKkzZs36/Dhw+revbsOHz6s6dOnq6ysTA8//LB9mQ8++KCuueYaxcfH68iRI5o2bZr8/PyUlpYmScrKytKbb76pIUOGqEWLFsrIyND999+v1NRUJSUl2ZeTmZmpvLw8HTt2TAUFBfaE5MILL5TFYtEtt9yiGTNmaOzYsZo0aZJ27typF154Qc8//3wjfXsAAG935FSBJi3P0Lq92fZpqR2smj08SbGRwW6MzPXIGVzDm/YZAIB3ImcAAPfimgONwa2VGjfddJNOnDihxx57TMeOHVP37t21evVq+0BYBw8elK/vfxuTFBYWaurUqfrpp58UGhqqIUOGaPHixYqMjLSXOXTokNLS0nTy5ElFRUWpb9+++vrrrxUVFSXp7JMba9assSc2cXFxGj58uKZOneoQ2+23364vv/zS/jo5OVmStG/fPrVt21YRERH69NNPdffdd6tnz56yWq167LHHHPrRBACgoeTk25wSRUn6am+2Ji/P0EtpyYoIsbgpOtcjZ6g/b9tnAADeiZwBANyHaw40Fh/DMAx3B+GtcnNzFRERoZycHPq9BADUStYveRow58tK56dPvFyJ0aF1WjbnJ8/jim3SkPsMAMD7kC94JrYLAHfimgMVaYhzk9vG1AAAAHWXW1hc5fzT1cyH92GfAQAAANCQuOZAY6FSAwAAEwoPCqhyflg18+F92GcAAAAANCSuOdBYqNQAAMCErKEWpXawVjgvtYNV1lD6KYUj9hkAAAAADYlrDjQWKjUAADChiBCLZg9PckoYUztY9dTwJAZfgxP2GQAAAAANiWsONBZ/dwcAAADqJjYyWC+lJSs7z6bThcUKCwqQNdRCoohKsc8AAAAAaEhcc6AxUKkBAICJRYSQHKJ22GcAAAAANCSuOdDQqNQAAMDEcvJtys6zKbewWOHBAbI2I3mEe7AvAgAAAPBGXAs1Pio1AAAwqSOnCjRpeYbW7c22T0vtYNXs4UmKjQx2Y2TwNuyLAAAAALwR10LuwUDhAACYUE6+zSlxkqSv9mZr8vIM5eTb3BQZvA37IgAAAABvxLWQ+1CpAQCACWXn2ZwSp3Jf7c1Wdh7JExoH+yIAAAAAb8S1kPtQqQEAgAnlFhZXOf90NfMBV2FfBAAAAOCNuBZyHyo1AAAwofCggCrnh1UzH3AV9kUAAAAA3ohrIfehUgMAABOyhlqU2sFa4bzUDlZZQy2NHBG8FfsiAAAAAG/EtZD7UKkBAIAJRYRYNHt4klMCldrBqqeGJykihOQJjYN9EQAAAIA34lrIffzdHQAAAKib2MhgvZSWrOw8m04XFissKEDWUAuJExod+yIAAAAAb8S1kHtQqQEAgIlFhJAswTOwLwIAAADwRlwLNT66nwIAAAAAAAAAAKZApQYAAAAAAAAAADAFKjUAAAAAAAAAAIApUKkBAAAAAAAAAABMgUoNAAAAAAAAAABgCv7uDsCbGYYhScrNzXVzJAAA/Ff5ean8PAX3I2cAAHga8gXPRM4AAPA0DZEzUKnhRqdPn5YkxcXFuTkSAACcnT59WhEREe4OAyJnAAB4LvIFz0LOAADwVK7MGXwMHqtwm7KyMh05ckRhYWHy8fGp9/Jyc3MVFxenn3/+WeHh4S6IsHERv3sRv3sRv3sRvyPDMHT69GnFxsbK15eeKj2BK3MGs+/vnoLvsf74Dl2D79E1+B5rj3zBM9U0Z2gq+3xTWI+msA4S6+FJmsI6SKyHJ6nvOjREzkBLDTfy9fXV+eef7/LlhoeHm/YgkYjf3YjfvYjfvYj/v3ji0rM0RM5g9v3dU/A91h/foWvwPboG32PtkC94ntrmDE1ln28K69EU1kFiPTxJU1gHifXwJPVZB1fnDDxOAQAAAAAAAAAATIFKDQAAAAAAAAAAYApUajQhgYGBmjZtmgIDA90dSp0Qv3sRv3sRv3sRP7wJ+4tr8D3WH9+ha/A9ugbfI7xNU9nnm8J6NIV1kFgPT9IU1kFiPTyJJ64DA4UDAAAAAAAAAABToKUGAAAAAAAAAAAwBSo1AAAAAAAAAACAKVCpAQAAAAAAAAAATIFKDQAAAAAAAAAAYApUanigv//970pKSlJ4eLjCw8PVu3dvffzxx1W+591331WnTp0UFBSkrl276qOPPnKYbxiGHnvsMcXExCg4OFgDBw7U3r17PSL++fPnq1+/fmrevLmaN2+ugQMHasuWLQ5lbrvtNvn4+Dj8DR48uEHir8s6LFq0yCm+oKAghzKevA369+/vFL+Pj4+uvvpqe5nG3gblZs+eLR8fH913331VlvOkY+BcNVkHTzwOytUkfk87Bn6vJvF70jEwffp0p8/p1KlTle/x5P0fnueVV15R27ZtFRQUpJSUFKffGlRu1qxZuuSSSxQWFqbo6Ghdd9112rNnj7vDMr2anuvh7PDhw/rTn/6kFi1aKDg4WF27dtW3337r7rBMo7S0VI8++qgSEhIUHBysxMREPf744zIMw92hAU5qe/6uLj9csWKFrrzySrVo0UI+Pj7avn270zIKCwt19913q0WLFgoNDdXw4cN1/PhxhzIHDx7U1VdfrZCQEEVHR+uhhx5SSUmJR6zDr7/+qr/85S/q2LGjgoOD1aZNG91zzz3KyclxKFfRdcCyZcsqjcsd26Ki65U77rjDoUxttoU71mP//v0Vftc+Pj5699137eVqsz1cuQ7FxcWaNGmSunbtqmbNmik2NlYjR47UkSNHHJbx66+/asSIEQoPD1dkZKTGjh2rvLw8hzIZGRnq16+fgoKCFBcXp6effrrKuBp7Pfbv36+xY8c6nP+mTZsmm83mUKaibfH11197zHpIUtu2bZ1inD17tkOZ2myPxl6HtWvXVnpcfPPNN5Lcvy2ks/cpOnXqpGbNmtnvWW3evNmhTEMcG1Uy4HE++OADY9WqVcaPP/5o7Nmzx/jrX/9qBAQEGDt37qyw/IYNGww/Pz/j6aefNn744Qdj6tSpRkBAgLFjxw57mdmzZxsRERHGypUrje+++8649tprjYSEBKOgoMDt8d9yyy3GK6+8Ymzbts3YtWuXcdtttxkRERHGoUOH7GVGjRplDB482Dh69Kj979dff3V57HVdh4ULFxrh4eEO8R07dsyhjCdvg5MnTzrEvnPnTsPPz89YuHChvUxjbwPDMIwtW7YYbdu2NZKSkox777230nKedgzUZR088TioTfyedgzUNn5POgamTZtmdOnSxeFzTpw4UWl5T97/4XmWLVtmWCwWY8GCBcb3339vjBs3zoiMjDSOHz/u7tBMYdCgQcbChQuNnTt3Gtu3bzeGDBlitGnTxsjLy3N3aKZV099pOPv111+N+Ph447bbbjM2b95s/PTTT8Ynn3xiZGZmujs003jiiSeMFi1aGB9++KGxb98+49133zVCQ0ONF154wd2hAQ5qe/6uSX74r3/9y5gxY4Yxf/58Q5Kxbds2p+XccccdRlxcnJGenm58++23xqWXXmpcdtll9vklJSXGRRddZAwcONDYtm2b8dFHHxlWq9WYMmWKR6zDjh07jOuvv9744IMPjMzMTCM9Pd3o0KGDMXz4cIdykoyFCxc65N+V5cnu2haXX365MW7cOIcYc3Jy7PNrsy3ctR4lJSUO8R89etSYMWOGERoaapw+fdperqbbw9XrcOrUKWPgwIHG22+/bezevdvYtGmT0atXL6Nnz54Oyxk8eLDRrVs34+uvvzbWrVtntG/f3khLS7PPz8nJMVq2bGmMGDHC2Llzp/HWW28ZwcHBxj/+8Y9G2RY1WY+PP/7YuO2224xPPvnEyMrKMt5//30jOjraeOCBB+xl9u3bZ0gy1qxZ47AtbDabx6yHYRhGfHy8MXPmTIcYf5+b12Z7uGMdioqKnI6L22+/3UhISDDKyso8YlsYhmEsXbrU+Oyzz4ysrCxj586dxtixY43w8HDjl19+sZdx9bFRHSo1TKJ58+bGa6+9VuG8G2+80bj66qsdpqWkpBh//vOfDcMwjLKyMqNVq1bGM888Y59/6tQpIzAw0HjrrbcaLujfqSr+c5WUlBhhYWHGG2+8YZ82atQoY+jQoQ0UXc1UtQ4LFy40IiIiKn2v2bbB888/b4SFhTmcCBp7G5w+fdro0KGD8dlnnxmXX355lTc6PPUYqM06nMsTjoPaxO+Jx0B9vn93HgPTpk0zunXrVuPynrr/wzP16tXLuPvuu+2vS0tLjdjYWGPWrFlujMq8fvnlF0OS8eWXX7o7FFOqz+80DGPSpElG37593R2GqV199dXGmDFjHKZdf/31xogRI9wUEVCx2p6/q8sPf6/8Ztm5N6BPnTplBAQEGO+++6592q5duwxJxqZNmwzDMIyPPvrI8PX1dXiY6e9//7sRHh5uFBUVuX0dKvLOO+8YFovFKC4utk+TZLz33nvVvted61HdebI228Kd63Gu7t27O/0O13R7NOQ6lNuyZYshyThw4IBhGIbxww8/GJKMb775xl7m448/Nnx8fIzDhw8bhmEYr776qtG8eXOH733SpElGx44dPWY9KvL0008bCQkJ9te12Y7uXI/4+Hjj+eefr/Q9tdkenrAtbDabERUVZcycOdM+zRO3RU5Ojr2ixTAa5tioDt1PebjS0lItW7ZMZ86cUe/evSsss2nTJg0cONBh2qBBg7Rp0yZJ0r59+3Ts2DGHMhEREUpJSbGXaSg1if9c+fn5Ki4u1nnnnecwfe3atYqOjlbHjh1155136uTJkw0RspOarkNeXp7i4+MVFxenoUOH6vvvv7fPM9s2eP3113XzzTerWbNmDtMbcxvcfffduvrqq5327Yp46jFQm3U4lyccB7WN39OOgfp8/+4+Bvbu3avY2Fi1a9dOI0aM0MGDByst66n7PzyPzWbT1q1bHfYFX19fDRw4kH2hjsq7rzj3txo1U5/faUgffPCBLr74Yt1www2Kjo5WcnKy5s+f7+6wTOWyyy5Tenq6fvzxR0nSd999p/Xr1+uqq65yc2TAf9Xl/F1dflgTW7duVXFxscNyOnXqpDZt2tiXs2nTJnXt2lUtW7Z0+Jzc3FyHawF3rUNFcnJyFB4eLn9/f4fpd999t6xWq3r16qUFCxZU2A2du9dj6dKlslqtuuiiizRlyhTl5+c7fE5NtoUnrEe5rVu3avv27Ro7dqzTvOq2R2OtQ05Ojnx8fBQZGWlfRmRkpC6++GJ7mYEDB8rX19feFc+mTZuUmpoqi8Xi8Dl79uzRb7/95hHrUVmZinLaa6+9VtHR0erbt68++OCDCt/r7vWYPXu2WrRooeTkZD3zzDMO3a7VdHu4ex3KffDBBzp58qRGjx7tNM9TtoXNZtM///lPRUREqFu3bvZluPLYqAn/6ovAHXbs2KHevXursLBQoaGheu+993ThhRdWWPbYsWMOJy5JatmypY4dO2afXz6tsjKuVpv4zzVp0iTFxsY6HFCDBw/W9ddfr4SEBGVlZemvf/2rrrrqKm3atEl+fn5uX4eOHTtqwYIFSkpKUk5Ojp599llddtll+v7773X++eebahts2bJFO3fu1Ouvv+4wvTG3wbJly/Sf//zH3n9gdTzxGKjtOpzL3cdBbeP3tGOgPt+/u4+BlJQULVq0SB07dtTRo0c1Y8YM9evXTzt37lRYWJhTeU/c/+GZsrOzVVpaWuG+sHv3bjdFZV5lZWW677771KdPH1100UXuDsd06nuehPTTTz/p73//uyZOnKi//vWv+uabb3TPPffIYrFo1KhR7g7PFCZPnqzc3Fx16tRJfn5+Ki0t1RNPPKERI0a4OzTAri7n7+ryw5o4duyYLBaL0423c/PMij6nfJ671+Fc2dnZevzxxzV+/HiH6TNnztQf/vAHhYSE6NNPP9Vdd92lvLw83XPPPU7vd9d63HLLLYqPj1dsbKwyMjI0adIk7dmzRytWrKjyc8rnecp6/N7rr7+uzp0767LLLnOYXpPt0RjrUFhYqEmTJiktLU3h4eH2ZURHRzuU8/f313nnnedwXCQkJDh9Tvm85s2bu309zpWZmamXXnpJzz77rH1aaGionnvuOfXp00e+vr5avny5rrvuOq1cuVLXXnutw/vduR733HOPevToofPOO08bN27UlClTdPToUc2ZM8f+OTXZHp6yLV5//XUNGjRI559/vn2ap2yLDz/8UDfffLPy8/MVExOjzz77TFar1b4MVx4bNUGlhofq2LGjtm/frpycHP373//WqFGj9OWXX9a4YsDd6hr/7NmztWzZMq1du9ZhkOGbb77Z/v+uXbsqKSlJiYmJWrt2rQYMGOD2dejdu7dDK4jLLrtMnTt31j/+8Q89/vjjDRJfdeq6DV5//XV17dpVvXr1cpjeWNvg559/1r333qvPPvvMaaBps6jvOrj7OKhL/J50DNT3+3f3MfD7p0OTkpKUkpKi+Ph4vfPOOxU+xQTAPe6++27t3LlT69evd3coptMUzvWeoKysTBdffLGefPJJSVJycrJ27typefPmUalRQ++8846WLl2qN998U126dNH27dt13333KTY2lu8QaGJyc3N19dVX68ILL9T06dMd5j366KP2/ycnJ+vMmTN65plnnCo13On3FTFdu3ZVTEyMBgwYoKysLCUmJroxsropKCjQm2++6fDdl/OE7VFcXKwbb7xRhmHo73//e6N9rqvVZD0OHz6swYMH64YbbtC4cePs061WqyZOnGh/fckll+jIkSN65plnnG6kN7Sq1uP3MSYlJclisejPf/6zZs2apcDAwEaNsyo12RaHDh3SJ598onfeecdhuqdsiyuuuELbt29Xdna25s+frxtvvFGbN292qsxoLHQ/5aEsFovat2+vnj17atasWerWrZteeOGFCsu2atVKx48fd5h2/PhxtWrVyj6/fFplZVytNvGXe/bZZzV79mx9+umnSkpKqrJsu3btZLValZmZ6cqwHdRlHcoFBAQoOTnZHp9ZtsGZM2e0bNmyGt04bahtsHXrVv3yyy/q0aOH/P395e/vry+//FIvvvii/P39VVpa6vQeTzsG6rIO5TzhOKhP/OXceQzUJ35POAbOFRkZqQsuuKDSz/G0/R+ey2q1ys/Pj33BBSZMmKAPP/xQX3zxhcNTVKgZV5xnIMXExDg9rNK5c+cquyyEo4ceekiTJ0/WzTffrK5du+rWW2/V/fffr1mzZrk7NMCuLufv6vLDmmjVqpVsNptOnTpV6XIq+5zyee5eh3KnT5/W4MGDFRYWpvfee08BAQFVlk9JSdGhQ4dUVFTkMN3d63FujJIcrrdqsi0kz1iPf//738rPz9fIkSOrLVvR9mjIdSi/+XzgwAF99tlnDk/Ut2rVSr/88otD+ZKSEv3666+1Pi7cuR7ljhw5oiuuuEKXXXaZ/vnPf1b4eb+XkpJS4XWpu9fj3BhLSkq0f//+Kj+nfJ4nrcPChQvVokWLGlVUuGNbNGvWTO3bt9ell16q119/Xf7+/vYeLlx9bNQElRomUVZW5nRCLde7d2+lp6c7TPvss8/sT00nJCSoVatWDmVyc3O1efPmGo+xUF9VxS9JTz/9tB5//HGtXr3aof+1yhw6dEgnT55UTEyMK8OsUnXr8HulpaXasWOHPT4zbANJevfdd1VUVKQ//elP1S6vobbBgAEDtGPHDm3fvt3+d/HFF2vEiBHavn17hd38eNoxUJd1kDznOKhr/L/nzmOgPvF7wjFwrry8PGVlZVX6OZ62/8NzWSwW9ezZ02FfKCsrU3p6OvtCDRmGoQkTJui9997T559/7tR8GjXjivMMpD59+mjPnj0O03788UfFx8e7KSLzyc/Pl6+v4yWxn5+fysrK3BQR4Kwu5+/q8sOa6NmzpwICAhyWs2fPHh08eNC+nN69e2vHjh0ON7LKb9j9vtLVXesgnc17r7zySlksFn3wwQc1aiG4fft2NW/e3Okpb3euR0UxSrJfI9R0W3jKerz++uu69tprFRUVVW3ZirZHQ61D+c3nvXv3as2aNWrRooXTMk6dOqWtW7fap33++ecqKyuzVzT17t1bX331lYqLix0+p2PHjk7d67hrPaSzLTT69++vnj17auHChU7nw4ps3769wutSd65HRTH6+vraWw/UdHu4ex0Mw9DChQs1cuTIaitey9ezMbdFRX5/n9HVx0aN1Gl4cTSoyZMnG19++aWxb98+IyMjw5g8ebLh4+NjfPrpp4ZhGMatt95qTJ482V5+w4YNhr+/v/Hss88au3btMqZNm2YEBAQYO3bssJeZPXu2ERkZabz//vtGRkaGMXToUCMhIcEoKChwe/yzZ882LBaL8e9//9s4evSo/e/06dOGYRjG6dOnjQcffNDYtGmTsW/fPmPNmjVGjx49jA4dOhiFhYUuj78u6zBjxgzjk08+MbKysoytW7caN998sxEUFGR8//33DuvpqdugXN++fY2bbrrJabo7tsHvXX755ca9995rf+3px0Bd1sETj4PaxO9px0Bt4y/nCcfAAw88YKxdu9bYt2+fsWHDBmPgwIGG1Wo1fvnllwpjN8P+D8+xbNkyIzAw0Fi0aJHxww8/GOPHjzciIyONY8eOuTs0U7jzzjuNiIgIY+3atQ6/1fn5+e4OzfTO/Z1G9bZs2WL4+/sbTzzxhLF3715j6dKlRkhIiLFkyRJ3h2Yao0aNMlq3bm18+OGHxr59+4wVK1YYVqvVePjhh90dGuCguvN3XfLDkydPGtu2bTNWrVplSDKWLVtmbNu2zTh69Ki9zB133GG0adPG+Pzzz41vv/3W6N27t9G7d2/7/JKSEuOiiy4yrrzySmP79u3G6tWrjaioKGPKlCkesQ45OTlGSkqK0bVrVyMzM9Ph3F1SUmIYhmF88MEHxvz5840dO3YYe/fuNV599VUjJCTEeOyxxzxmW2RmZhozZ840vv32W2Pfvn3G+++/b7Rr185ITU2t07Zw13qU27t3r+Hj42N8/PHHTnHVZnu4eh1sNptx7bXXGueff76xfft2h/2lqKjIvpzBgwcbycnJxubNm43169cbHTp0MNLS0uzzT506ZbRs2dK49dZbjZ07dxrLli0zQkJCjH/84x+Nsi1qsh6HDh0y2rdvbwwYMMA4dOiQQ5lyixYtMt58801j165dxq5du4wnnnjC8PX1NRYsWOAx67Fx40bj+eefN7Zv325kZWUZS5YsMaKiooyRI0fWaXu4a58yDMNYs2aNIcnYtWuXU1zu3hZ5eXnGlClTjE2bNhn79+83vv32W2P06NFGYGCgsXPnTvtyXH1sVIdKDQ80ZswYIz4+3rBYLEZUVJQxYMAA+81owzh70Tdq1CiH97zzzjvGBRdcYFgsFqNLly7GqlWrHOaXlZUZjz76qNGyZUsjMDDQGDBggLFnzx6PiD8+Pt6Q5PQ3bdo0wzAMIz8/37jyyiuNqKgoIyAgwIiPjzfGjRvXoDdgarsO9913n9GmTRvDYrEYLVu2NIYMGWL85z//cVimJ28DwzCM3bt3G5IcypVzxzb4vXNvdHj6MVCR6tbBE4+D2sTvacdAbeM3DM85Bm666SYjJibGsFgsRuvWrY2bbrrJyMzMrDJ2T9//4Vleeukl+/Haq1cv4+uvv3Z3SKZR0e+0JGPhwoXuDs30qNSom//7v/8zLrroIiMwMNDo1KmT8c9//tPdIZlKbm6uce+99xpt2rQxgoKCjHbt2hmPPPKI040GwBNUdf6uS364cOHCKq8/DMMwCgoKjLvuusto3ry5ERISYgwbNszpBvX+/fuNq666yggODjasVqvxwAMPGMXFxR6xDl988UWl5+59+/YZhmEYH3/8sdG9e3cjNDTUaNasmdGtWzdj3rx5RmlpaWWbotHX4+DBg0Zqaqpx3nnnGYGBgUb79u2Nhx56yMjJyanztnDHepSbMmWKERcXV+F3XNvt4cp12LdvX6X7yxdffGEvd/LkSSMtLc0IDQ01wsPDjdGjR9sfRiz33XffGX379jUCAwON1q1bG7Nnz64wfnetR2Xb6vfPvi9atMjo3LmzERISYoSHhxu9evUy3n33XY9aj61btxopKSlGRESEERQUZHTu3Nl48sknnR48rM32cMc+ZRiGkZaWZlx22WUVxuTubVFQUGAMGzbMiI2NNSwWixETE2Nce+21xpYtWxyW0RDHRlV8DMMwat++AwAAAAAAAAAAoHExpgYAAAAAAAAAADAFKjUAAAAAAAAAAIApUKkBAAAAAAAAAABMgUoNAAAAAAAAAABgClRqAAAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBSo1AAAAAAAAAAAAKZApQaAJmnRokWKjIxslM+67bbbdN111zXKZwEAgIq1bdtWc+fO9djP8fHx0cqVK10eDwAAZtG/f3/dd9997g5D06dPV/fu3d0dBoB6oFIDAGpo//798vHx0fbt290dCgAAAAAAqIMHH3xQ6enp7g6jRniIEqgYlRoAAAAAGpTNZnN3CAAAoImrab4RGhqqFi1aNHA0VSsuLnbr5wNmR6UGgFrr37+//vKXv+i+++5T8+bN1bJlS82fP19nzpzR6NGjFRYWpvbt2+vjjz+WJJWWlmrs2LFKSEhQcHCwOnbsqBdeeMG+vMLCQnXp0kXjx4+3T8vKylJYWJgWLFhQo5gWLVqkNm3aKCQkRMOGDdPJkyedyrz//vvq0aOHgoKC1K5dO82YMUMlJSX2+T4+Pvr73/+uq666SsHBwWrXrp3+/e9/2+cnJCRIkpKTk+Xj46P+/fs7LP/ZZ59VTEyMWrRoobvvvpskBQDgtfr3768JEybovvvuk9Vq1aBBg7Rz505dddVVCg0NVcuWLXXrrbcqOzvb/p7Tp09rxIgRatasmWJiYvT888/Xq5uKOXPmqGvXrmrWrJni4uJ01113KS8vzz6/vKvKDz/8UB07dlRISIj+93//V/n5+XrjjTfUtm1bNW/eXPfcc49KS0sdln369GmlpaWpWbNmat26tV555RWH+Xv37lVqaqqCgoJ04YUX6rPPPnOKb9KkSbrgggsUEhKidu3a6dFHHyV3AAB4jaKiIj344INq3bq1mjVrppSUFK1du9Y+/+TJk0pLS1Pr1q0VEhKirl276q233nJYRkX5xtq1a+Xj46P09HRdfPHFCgkJ0WWXXaY9e/bY33du91PlrSGquqY/evSorr76agUHByshIUFvvvlmrbqkLL/fcO2116pZs2Z64oknqr1XMn36dL3xxht6//335ePjIx8fH/t39PPPP+vGG29UZGSkzjvvPA0dOlT79++v8fcPmB2VGgDq5I033pDVatWWLVv0l7/8RXfeeaduuOEGXXbZZfrPf/6jK6+8Urfeeqvy8/NVVlam888/X++++65++OEHPfbYY/rrX/+qd955R5IUFBSkpUuX2k/WpaWl+tOf/qQ//vGPGjNmTLWxbN68WWPHjtWECRO0fft2XXHFFfrb3/7mUGbdunUaOXKk7r33Xv3www/6xz/+oUWLFumJJ55wKPfoo49q+PDh+u677zRixAjdfPPN2rVrlyRpy5YtkqQ1a9bo6NGjWrFihf19X3zxhbKysvTFF1/ojTfe0KJFi7Ro0aL6fMUAAJjaG2+8IYvFog0bNmj27Nn6wx/+oOTkZH377bdavXq1jh8/rhtvvNFefuLEidqwYYM++OADffbZZ1q3bp3+85//1PnzfX199eKLL+r777/XG2+8oc8//1wPP/ywQ5n8/Hy9+OKLWrZsmVavXq21a9dq2LBh+uijj/TRRx9p8eLF+sc//uHwkIMkPfPMM+rWrZu2bdumyZMn695777VXXJSVlen666+XxWLR5s2bNW/ePE2aNMkpvrCwMC1atEg//PCDXnjhBc2fP1/PP/98ndcXAAAzmTBhgjZt2qRly5YpIyNDN9xwgwYPHqy9e/dKOvvwY8+ePbVq1Srt3LlT48eP16233mq/Li/3+3xj3rx59umPPPKInnvuOX377bfy9/ev9t5Cddf0I0eO1JEjR7R27VotX75c//znP/XLL7/Uap2nT5+uYcOGaceOHRozZky190oefPBB3XjjjRo8eLCOHj2qo0eP6rLLLlNxcbEGDRqksLAwrVu3Ths2bFBoaKgGDx5M61h4DwMAaunyyy83+vbta39dUlJiNGvWzLj11lvt044ePWpIMjZt2lThMu6++25j+PDhDtOefvppw2q1GhMmTDBiYmKM7OzsGsWTlpZmDBkyxGHaTTfdZERERNhfDxgwwHjyyScdyixevNiIiYmxv5Zk3HHHHQ5lUlJSjDvvvNMwDMPYt2+fIcnYtm2bQ5lRo0YZ8fHxRklJiX3aDTfcYNx00001ih8AgKbm8ssvN5KTk+2vH3/8cePKK690KPPzzz8bkow9e/YYubm5RkBAgPHuu+/a5586dcoICQkx7r333hp9Znx8vPH8889XOv/dd981WrRoYX+9cOFCQ5KRmZlpn/bnP//ZCAkJMU6fPm2fNmjQIOPPf/6zw+cMHjzYYdk33XSTcdVVVxmGYRiffPKJ4e/vbxw+fNg+/+OPPzYkGe+9916l8T3zzDNGz549q11PAADM6vLLLzfuvfde48CBA4afn5/DudIwzl63T5kypdL3X3311cYDDzzgsLzf5xuGYRhffPGFIclYs2aNfdqqVasMSUZBQYFhGIYxbdo0o1u3bvb51V3T79q1y5BkfPPNN/b5e/fuNSRVmXv8niTjvvvuq7bcufdKRo0aZQwdOtShzOLFi42OHTsaZWVl9mlFRUVGcHCw8cknn9QoHsDs/N1UlwLA5JKSkuz/9/PzU4sWLdS1a1f7tJYtW0qS/cmFV155RQsWLNDBgwdVUFAgm83m0NxTkh544AGtXLlSL7/8sj7++OMa93G5a9cuDRs2zGFa7969tXr1avvr7777Ths2bHBomVFaWqrCwkLl5+crJCTE/r5zl1OTgcG7dOkiPz8/++uYmBjt2LGjRvEDANAU9ezZ0/7/7777Tl988YVCQ0OdymVlZamgoEDFxcXq1auXfXpERIQ6duxY589fs2aNZs2apd27dys3N1clJSVO5/2QkBAlJiba39OyZUu1bdvWIc6WLVs6PYlZUb5Q3v3Erl27FBcXp9jY2ErLS9Lbb7+tF198UVlZWcrLy1NJSYnCw8PrvL4AAJjFjh07VFpaqgsuuMBhelFRkf0+QGlpqZ588km98847Onz4sGw2m4qKiuzn8HK/zzd+7/f3LGJiYiSdvT/Rpk2bCstXdU2/Z88e+fv7q0ePHvb57du3V/PmzWu6ypKkiy++2GlaTe6VnOu7775TZmamwsLCHKYXFhYqKyurVjEBZkWlBoA6CQgIcHjt4+PjMM3Hx0fS2S4Yli1bpgcffFDPPfecevfurbCwMD3zzDPavHmzwzJ++eUX/fjjj/Lz89PevXs1ePBgl8Wbl5enGTNm6Prrr3eaFxQUVO/lV/R9lJWV1Xu5AACYVbNmzez/z8vL0zXXXKOnnnrKqVxMTIwyMzNd+tn79+/X//zP/+jOO+/UE088ofPOO0/r16/X2LFjZbPZ7DdEqstnyqe5+py+adMmjRgxQjNmzNCgQYMUERGhZcuW6bnnnnPp5wAA4Iny8vLk5+enrVu3OlQkSLI/WPDMM8/ohRde0Ny5c+1jZN13331O3Sv9Pt/4vcruT1SmMc7/58Za03sl58rLy1PPnj21dOlSp3lRUVEujRnwVFRqAGhwGzZs0GWXXaa77rrLPq2ipwfGjBmjrl27auzYsRo3bpwGDhyozp07V7v8zp07O530v/76a4fXPXr00J49e9S+ffsql/X1119r5MiRDq+Tk5MlSRaLRZKcBgsFAABV69Gjh5YvX662bdvK39/5EqRdu3YKCAjQN998Y3+CMicnRz/++KNSU1Nr/Xlbt25VWVmZnnvuOfn6nh1GsLx/alc4N8/4+uuv7TlL586d9fPPP+vo0aP2J0PPLb9x40bFx8frkUcesU87cOCAy+IDAMCTJScnq7S0VL/88ov69etXYZkNGzZo6NCh+tOf/iTpbIXEjz/+qAsvvLAxQ5UkdezYUSUlJdq2bZu9ZUhmZqZ+++23ei23JvdKLBaL0z2IHj166O2331Z0dDStPOG1GCgcQIPr0KGDvv32W33yySf68ccf9eijj+qbb75xKPPKK69o06ZNeuONNzRixAhdd911GjFiRI0Gubrnnnu0evVqPfvss9q7d69efvllh66nJOmxxx7Tv/71L82YMUPff/+9du3apWXLlmnq1KkO5d59910tWLBAP/74o6ZNm6YtW7ZowoQJkqTo6GgFBwfbBzfNycmp5zcDAIB3uPvuu/Xrr78qLS1N33zzjbKysvTJJ59o9OjRKi0tVVhYmEaNGqWHHnpIX3zxhb7//nuNHTtWvr6+9qcra6N9+/YqLi7WSy+9pJ9++kmLFy92GDy0vjZs2KCnn35aP/74o1555RW9++67uvfeeyVJAwcO1AUXXKBRo0bpu+++07p16xwqL6SzudHBgwe1bNkyZWVl6cUXX9R7773nsvgAAPBkF1xwgUaMGKGRI0dqxYoV2rdvn7Zs2aJZs2Zp1apVks6eKz/77DNt3LhRu3bt0p///GcdP37cLfF26tRJAwcO1Pjx47VlyxZt27ZN48ePV3BwcJ3ylHI1uVfStm1bZWRkaM+ePcrOzlZxcbFGjBghq9WqoUOHat26ddq3b5/Wrl2re+65R4cOHarv6gKmQKUGgAb35z//Wddff71uuukmpaSk6OTJkw5PIuzevVsPPfSQXn31VcXFxUmSXn31VWVnZ+vRRx+tdvmXXnqp5s+frxdeeEHdunXTp59+6lRZMWjQIH344Yf69NNPdckll+jSSy/V888/r/j4eIdyM2bM0LJly5SUlKR//etfeuutt+xPgvj7++vFF1/UP/7xD8XGxmro0KH1/WoAAPAKsbGx2rBhg0pLS3XllVeqa9euuu+++xQZGWlvSTFnzhz17t1b//M//6OBAweqT58+6ty5c526iezWrZvmzJmjp556ShdddJGWLl2qWbNmuWx9HnjgAX377bdKTk7W3/72N82ZM0eDBg2SJPn6+uq9995TQUGBevXqpdtvv91hTC9Juvbaa3X//fdrwoQJ6t69uzZu3FijnAcAgKZi4cKFGjlypB544AF17NhR1113nUOLzalTp6pHjx4aNGiQ+vfvr1atWum6665zW7z/+te/1LJlS6WmpmrYsGEaN26cwsLC6tWddXX3SiRp3Lhx6tixoy6++GJFRUVpw4YNCgkJ0VdffaU2bdro+uuvV+fOnTV27FgVFhbScgNew8cwDMPdQQCAJ/Dx8dF7773n1kQJAACcdebMGbVu3VrPPfecxo4d6+5wAAAA7A4dOqS4uDitWbNGAwYMcHc4gNdhTA0AAAAAbrdt2zbt3r1bvXr1Uk5OjmbOnClJtIwEAABu9/nnnysvL09du3bV0aNH9fDDD6tt27Z1GvsLQP3R/RQAj3fVVVcpNDS0wr8nn3zS3eEBAAAXefbZZ9WtWzcNHDhQZ86c0bp162S1WrVu3bpKc4HQ0FB3hw0AAJq44uJi/fWvf1WXLl00bNgwRUVFae3atQoICNDSpUsrzVG6dOni7tCBJonupwB4vMOHD6ugoKDCeeedd57OO++8Ro4IAAA0poKCAh0+fLjS+e3bt2/EaAAAAP7r9OnTlQ5iHhAQ4DSWJ4D6o1IDAAAAAAAAAACYAt1PAQAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBSo1AAAAAAAAAAAAKZApQYAAAAAAAAAADAFKjUAAAAAAAAAAIApUKkBAAAAAAAAAABMgUoNAAAAAAAAAABgClRqAAAAAAAAAAAAU6BSAwAAAAAAAAAAmAKVGgAAAAAAAAAAwBSo1AAAAAAAAAAAAKZApQYAAAAAAAAAADAFKjUAAAAAAAAAAIApUKkBAABQC1999ZWuueYaxcbGysfHRytXrqz2PWvXrlWPHj0UGBio9u3ba9GiRQ0eJwAAcC9yBgAAGgaVGgAAALVw5swZdevWTa+88kqNyu/bt09XX321rrjiCm3fvl333Xefbr/9dn3yyScNHCkAAHAncgYAABqGj2EYhruDAAAAMCMfHx+99957uu666yotM2nSJK1atUo7d+60T7v55pt16tQprV69uhGiBAAA7kbOAACA6/i7OwBvVlZWpiNHjigsLEw+Pj7uDgcAAEmSYRg6ffq0YmNj5etLo8762rRpkwYOHOgwbdCgQbrvvvsqfU9RUZGKiorsr8vKyvTrr7+qRYsW5AwAAI9AvuB65AwAgKaoIXIGKjXc6MiRI4qLi3N3GAAAVOjnn3/W+eef7+4wTO/YsWNq2bKlw7SWLVsqNzdXBQUFCg4OdnrPrFmzNGPGjMYKEQCAOiNfcB1yBgBAU+bKnIFKDTcKCwuTdHaDhoeHuzkaAADOys3NVVxcnP08hcY3ZcoUTZw40f46JydHbdq0IWcAAHgM8gXPQM4AAPB0DZEzUKnhRuVNQcPDw0k2AAAehy4LXKNVq1Y6fvy4w7Tjx48rPDy8wicuJSkwMFCBgYFO08kZAACehnzBdcgZAABNmStzBjq+BAAAaEC9e/dWenq6w7TPPvtMvXv3dlNEAADAE5EzAABQM1RqAAAA1EJeXp62b9+u7du3S/p/7d19XNX1/f/xJ6CHAyJgHUAw8oJInImQJrOUbLIo9jUrtzm0dGY6u9xkZbDIq1ZYTdPMollWXy/KSufa7EcLysy8aDMdWWmCF5QKiVMQEA7K5/dHX8+iw7XncM6Bx/12O7cb5/15fz6f13kf1uc9Xr7fL+ngwYPavXu3ioqKJH23DcSkSZNs/WfMmKEDBw5o1qxZ2rt3r5577jm98cYbmjlzpivCBwAA7YQ5AwAAzkFSAwAAoBX+9a9/KT4+XvHx8ZKktLQ0xcfHa/bs2ZKkY8eO2f5YIUl9+/bVxo0b9d5772nw4MFauHChXnzxRSUnJ7skfgAA0D6YMwAA4BxehmEYrg6isyovL1dQUJDKysrY6xIA4DZ4PrkfvhMAgLvh2eSe+F4AAO7GGc8mVmoAAAAAAAAAAACPQFIDAAAAAAAAAAB4hC6uDgCeoazKqtIKq8qraxXo11WWbiYF+ZtcHRYAAAAAAAAAoBMhqYFmHT11Rg+ty9dH+0ttbYnRFi0YF6uIYD8XRgYAAAAAAAAA6EzYfgpNKquy2iU0JGnz/lKlr8tXWZXVRZEBAAAAAAAAADobkhpoUmmF1S6hcd7m/aUqrSCpAQAAAAAAAABoH2w/hSaVV9fK3+Sj31zbT9f1D5UkVVnPqauPtz7af1yVNbUujhAAAAAAAAAA0FmQ1OhAnFHMO8ivq5ZNuFLmrt56ImevPi44YTs28jKLbo7rdaFhAwAAAAAAAADQIm6x/dSyZcvUp08fmc1mJSQk6JNPPmm0b21trebPn6+oqCiZzWYNHjxYOTk59frMnTtXXl5e9V4xMTH1+owaNcquz4wZM2zHT5w4oRtuuEERERHy9fVVZGSk7r33XpWXl9v6bNq0ye4aXl5eKi4udtDItNzRU2d072u7NHrRh7rlua0avfBD3ffaLh09dabV1yqrsqrw2wrtKjqps3WG/EzeWv7RgXoJDUn6qKBUj/x1D3U1AAAAAAAAAADtwuUrNdauXau0tDRlZ2crISFBixcvVnJysvbt26fQ0FC7/pmZmVq1apWWL1+umJgYvfvuu7rlllu0detWxcfH2/oNHDhQubm5tvdduth/1GnTpmn+/Pm29/7+/rafvb29NXbsWP3xj39USEiICgoKdM899+g///mP1qxZU+86+/btU2BgoO19Q3E7U3PFvJemxrd4xcbRU2fsrjXyMosmX9NH2w/8R1XWc/X6f/R/dTUudEUIAAAAAAAAAADNcXlSY9GiRZo2bZqmTJkiScrOztbGjRu1YsUKpaen2/VfuXKlHn74YaWkpEiS7rrrLuXm5mrhwoVatWqVrV+XLl3Us2fPJu/t7+/faJ8ePXrorrvusr3v3bu37r77bj311FN2fUNDQxUcHNzsZ3WWlhTzbknSobHkyEcFpaqToTtG9NWz7xfYnXe6mroaAAAAAAAAAADnc+n2U1arVTt37lRSUpKtzdvbW0lJSdq2bVuD59TU1MhsNtdr8/Pz05YtW+q17d+/XxEREerXr58mTpyooqIiu2utXr1aFotFV1xxhTIyMlRVVdVorEePHtX69et17bXX2h2Li4tTeHi4fvrTn+rjjz9u8jM7Q0VNre79yWV6afJQPTfxSq349VW69yeXyd/kI6nlSYemkiMfF5xQfGRwg8e6m7u2KW4AAAAAAAAAAFrDpSs1SktLde7cOYWFhdVrDwsL0969exs8Jzk5WYsWLVJiYqKioqKUl5en9evX69y5/26LlJCQoFdeeUX9+/fXsWPHNG/ePI0cOVJ79uxR9+7dJUkTJkxQ7969FRERofz8fD300EPat2+f1q9fX+9+qamp+utf/6ozZ85ozJgxevHFF23HwsPDlZ2draFDh6qmpkYvvviiRo0apR07dujKK6+0i72mpkY1NTW299+vz3EhgvxM2lV0st4qimsuu1jPpMbr/td2tTjpUN5M8qPmbJ1dW2K0RZYAtp4CAAAAAAAAADify7efaq0lS5Zo2rRpiomJkZeXl6KiojRlyhStWLHC1ufGG2+0/RwbG6uEhAT17t1bb7zxhqZOnSpJmj59uq3PoEGDFB4ertGjR6uwsFBRUVG2Y08//bTmzJmjr776ShkZGUpLS9Nzzz0nSerfv7/69+9v63v11VersLBQTz/9tFauXGkXe1ZWlubNm+e4wdB3W0Y9smGPXRHv8+8f+Z8ftTjpENhM8iPIr/7xkdEWPTEulnoaAAAAAAAAAIB24dLtpywWi3x8fFRSUlKvvaSkpNFaFyEhIdqwYYMqKyt1+PBh7d27VwEBAerXr1+j9wkODtbll1+uggL7ehDnJSQkSJJdn549eyomJkY33XSTXnjhBT3//PM6duxYo9cZNmxYo/fJyMhQWVmZ7fX11183ep2WKq2w6qOCxreMuvLS4BYnHSwBJiVGWxo8lhht0aU9/PTO/SP01ozhem9mop5NjVd4sF+bYwcAAAAAAAAAoDVculLDZDJpyJAhysvL08033yxJqqurU15enu69994mzzWbzerVq5dqa2u1bt06/fKXv2y0b0VFhQoLC3X77bc32mf37t2SvttSqjF1dd9tv/T9LaQauk5j1/D19ZWvr2+j57bF97eM8jf56I4RfRUfGayas3Uyd/WRt5dXi68V5G/SgnGxSl+Xr83fq62R+H8rMtw1gVFWZVVphVXl1bUK9OsqSzcTq0cAAAAAAAAAoANy+fZTaWlpmjx5soYOHaphw4Zp8eLFqqys1JQpUyRJkyZNUq9evZSVlSVJ2rFjh44cOaK4uDgdOXJEc+fOVV1dnWbNmmW75gMPPKAxY8aod+/eOnr0qObMmSMfHx+lpqZKkgoLC7VmzRqlpKTo4osvVn5+vmbOnKnExETFxsZKkt555x2VlJToqquuUkBAgD7//HM9+OCDuuaaa9SnTx9J0uLFi9W3b18NHDhQ1dXVevHFF/X+++/rH//4R7uN3/kto/xNPnomNV4vf3ywXm2N81tERbQwIRER7KelqfEqrbDqdHWtupu7yhLgvkmCo6fO6KF1+fUKnCdGW7SgFZ8ZAAAAAAAAAOAZXJ7UGD9+vI4fP67Zs2eruLhYcXFxysnJsRUPLyoqkrf3f3fJqq6uVmZmpg4cOKCAgAClpKRo5cqVCg4OtvX55ptvlJqaqhMnTigkJEQjRozQ9u3bFRISIum7FSK5ubm2BEpkZKTGjRunzMxM2zX8/Py0fPlyzZw5UzU1NYqMjNStt96q9PR0Wx+r1arf//73OnLkiPz9/RUbG6vc3Fxdd911Th61/zq/ZdSQPj30bXm17rimryYm9Ja5q48+LTqpFVsOKn1dvpamxrc4MRHk775JjO8rq7LaJTQkafP+0lZ/ZgAAAAAAAACA+/MyDMNwdRCdVXl5uYKCglRWVqbAwMA2X+fYqTOqrDmrOX/7vF7B8Gsuu1hTrumr+1/bpb/dO0JRoQGOCNttFH5bodGLPmz0eF7atR3uMwNAe3DU8wmOw3cCAHA3PJvcE98LAMDdOOPZ5PKVGrhw/iYfzXrr3/USGpJs7+8Y0Ven/6/2RkeqP/H9eiINOd3McQAAAAAAAACAZyGp0QGUVlj10Q8SGud9XHBCd1zTV4F+XRutP/HEuFj5m3w8Ltlxvp5IY7o3cxwAAAAAAAAA4FlIanQAza1YkKRuvl30wJv/tqs/8a/DJ3X4P1Va9n6BPirwrGLb5+uJbP7BZ5K+i98S4N5JGQAAAAAAAABA63g33wXurrkVC5f08FNF9Vm7hIb03dZUS9/fXy+hIf232HZZldWhsTpSkL9JC8bFKjHaUq/9/OoTd19pAgAAAAAAAABoHVZqdADNrVjoGWjWgdLKBs+NjwzWs+8XNHhs8/5SlVZY3To5EBHsp6Wp8SqtsOp0da26m7vKEuD+W2cBAAAAAAAAAFqPpEYHcH7FQvq6/HqJje+vWAg0N7ziouZsXZPXbm2x7cYKkTuzQHmQP0kMAAAAAAAAAOgMSGp0EM2tWGhsNYdvl6Z3IGtNse3GCpH/8eYrNP/vXyj3y2/rtbuyZoczkywAAAAAAAAAAOegpkYHEuRvUlRogPpaukmSDpRWqvB4hcqqrI3Wn/j2dI1G/qDtvNYU2y6rstolNKTvtrD6w18+U0x4oF27q2p2HD11Rve+tkujF32oW57bqtELP9R9r+3S0VNn2j0WAAAAAAAAAEDLsVKjg2lstcT5VRENrea49vIQu62rfjogVHNvGqjSCqsOlFY2u5qhtMLaYCFySdpScEJTrulr1+6Kmh1NJV/S1+VraWo8KzYAAAAAAAAAwE2R1OhAWvoH+x/+0T7IX/WSHYF+XWXy8Vb6+s8aTY78UHkztTcaq93R2podF6qp5IsnFEYHAAAAAAAAgM6M7ac6kJb8wb4x57euiru0hy7uZlLGXz5rNDnS0JZRgc3U3misdkdranY4QnPJl/ZOsgAAAAAAAAAAWo6kRgfiqD/YtyU5cr4QeUNGXHaxdn19yq69NTU7HKW55Et7J1kAAAAAAAAAAC1HUqMDucjfpJcmD9VzE6/Uil9fpXt/cpn8TT624y39g31bkiONFSJPjLbo8VsGad+xcrv2J8bFtvtWT00lX1yRZAEAAAAAAAAAtBw1NTqIo6fOKHPDHn1U8N8VFtdcdrGeSY3X/a/t0tDePVr8B/u2rmZorBB5kL9Jf/rF4Abb29v55MsPC6O7KskCAAAAAAAAAGg5khodgK1AeEH9LaM+LjghSXrkf36kUZeHtPgP9udXM2xuYAuqH65mKKuyqrTCqvL/KzBu6fZdbY4faqhAuas0lXwBAAAAAAAAALgvkhodQFM1MD4uOKG5YwYqPNivxddr6WqGo6fOfJdM+UGfBeNiFdGK+7mCOyVZAAAAAAAAAAAtQ1KjA2iuBkZlzdlWX7O51Qy21SE/SKZs3l+q9HX5Wpoa75SkQUMrQ0hOAAAAAAAAAEDnQFKjA2hrDYzmNLWaoanVIZv3l6q0wtqqZENLkhWevDIEAAAAAAAAAHDhSGp0AK2pgdEaTSUamlsdcrqZ49/XkmRFe60MYSUIAAAAAAAAALgvkhodQEtrYLRGc4kGR60OaWmywtErQxrCShAAAAAAAAAAcG8kNTqI5mpgtEZLEg2OWh3S0mSFI1eGNMRVNUIAAAAAAAAAAC3n7eoA4DhB/iZFhQYo7tIeigoNaPMf4VuaaFgwLlaJ0ZZ6x1u7OqSlyQpn1Q05ryWfGQAAAAAAAADgWqzUgJ2WJhocsTqkpckKZ9UNOc/ZK0EAAAAAAAAAABeOlRqw05pVERe6OuR8sqIh309WOGplSGOcvRIEAAAAAAAAAHDhWKkBO85eFfF9rSly7si6IT/Unp8ZAAAAAAAAANA2JDVgpzWJBkdoTbIiyN8xSYyGrtuenxkAAAAAAAAA0HpsP4UGnU805KVdqw13X628tGu1NDVe4cF+Trmfo4qcX4j2/szOUFZlVeG3FdpVdFKFxytUVkWBcwBwhmXLlqlPnz4ym81KSEjQJ5980mT/xYsXq3///vLz81NkZKRmzpyp6urqdooWAAC4CnMGAAAcj5UaaJSzVkW4M2d85rIqq0orrCqvrlWgX1dZujlnXI+eOqOH1uXrox+sNFkwLlYRHpSYAQB3t3btWqWlpSk7O1sJCQlavHixkpOTtW/fPoWGhtr1X7NmjdLT07VixQpdffXV+uqrr/TrX/9aXl5eWrRokQs+AQAAaA/MGQAAcA6SGoATtVeioazKancfSfrX4ZP68KvjGtq7hypqzjo1qQIAncWiRYs0bdo0TZkyRZKUnZ2tjRs3asWKFUpPT7frv3XrVl1zzTWaMGGCJKlPnz5KTU3Vjh072jVuAADQvpgzAADgHGw/BThJY4mGzftLlb4u36FbQ5VWWO3u42/y0TOp8fp7/lH99OnNuuW5rRq98EPd99ouHT11xmH3BoDOxGq1aufOnUpKSrK1eXt7KykpSdu2bWvwnKuvvlo7d+60bTdx4MABvfPOO0pJSWmXmAEAQPtjzgAAgPOwUgNwkoYSDedt3l+q0gqrw1ZMlFfX2rXdMaKvXv74oD4uOGF37/R1+VqaGs+KDQBopdLSUp07d05hYWH12sPCwrR3794Gz5kwYYJKS0s1YsQIGYahs2fPasaMGfrDH/7Q6H1qampUU1Nje19eXu6YDwAAANoFcwYAAJyHlRqAkzSUaPi+080cb41Ac1e7tvjIYLuExnnnkyoAAOfbtGmTHn/8cT333HP69NNPtX79em3cuFGPPvpoo+dkZWUpKCjI9oqMjGzHiAEAgCswZwAAoGVIagBO0lCi4fu6N3O8NSwBJiVGW+q11Zyta/IcRyZVAKCzsFgs8vHxUUlJSb32kpIS9ezZs8FzHnnkEd1+++268847NWjQIN1yyy16/PHHlZWVpbq6hv9bnZGRobKyMtvr66+/dvhnAQAAzsOcAQAA5yGpAbRCWZVVhd9WaFfRSRUer2iyLkZDiYbzEqMtsgQ4buunIH+TFoyLrXc/3y5N/8/bkUkVAOgsTCaThgwZory8PFtbXV2d8vLyNHz48AbPqaqqkrd3/f8m+/j4SJIMw2jwHF9fXwUGBtZ7AQAAz8GcAQAA56GmBtBCR0+dsSv8nRht0YJxsYoI9rPrfz7RkL4uX5t/cM4T42IdXs8iIthPS1PjVVph1enqWvXw/y6psrmBuh6OTqoAQGeSlpamyZMna+jQoRo2bJgWL16syspKTZkyRZI0adIk9erVS1lZWZKkMWPGaNGiRYqPj1dCQoIKCgr0yCOPaMyYMbY/VAAAgI6HOQMAAM5BUgNogbIqq11CQ2q+6PYPEw3dzV1lCTA5rUB3kH/9a7dnUgUAOovx48fr+PHjmj17toqLixUXF6ecnBxbIdCioqJ6/8oyMzNTXl5eyszM1JEjRxQSEqIxY8bosccec9VHAAAA7YA5AwAAzuFlNLaGsR0tW7ZMTz31lIqLizV48GAtXbpUw4YNa7BvbW2tsrKy9Oqrr+rIkSPq37+/nnjiCd1www22PnPnztW8efPqnde/f3/t3bvX9n7UqFH68MMP6/X5zW9+o+zsbEnSiRMnNHHiROXn5+vEiRMKDQ3V2LFj9fjjj9dbzrlp0yalpaXp888/V2RkpDIzM/XrX/+6RZ+7vLxcQUFBKisrY4movksclFZYVV5dq0C/rrJ0c94f/1ur8NsKjV70YaPH89KuVVRoQDtG1HLnx7U9kioAOgaeT+6H7wQA4G54NrknvhcAgLtxxrPJ5Ss11q5dq7S0NGVnZyshIUGLFy9WcnKy9u3bp9DQULv+mZmZWrVqlZYvX66YmBi9++67uuWWW7R161bFx8fb+g0cOFC5ubm291262H/UadOmaf78+bb3/v7+tp+9vb01duxY/fGPf1RISIgKCgp0zz336D//+Y/WrFkjSTp48KB+9rOfacaMGVq9erXy8vJ05513Kjw8XMnJyQ4ZH3fnqEREa7d2am/lzRTVduei2z9cvQEAAAAAAAAAnsrlSY1FixZp2rRptj0ls7OztXHjRq1YsULp6el2/VeuXKmHH35YKSkpkqS77rpLubm5WrhwoVatWmXr16VLF/Xs2bPJe/v7+zfap0ePHrrrrrts73v37q27775bTz31lK0tOztbffv21cKFCyVJAwYM0JYtW/T00093iqSGoxIRbd3aqT0FNlNUm6LbAAAAAAAAAOB83s13cR6r1aqdO3cqKSnJ1ubt7a2kpCRt27atwXNqampkNpvrtfn5+WnLli312vbv36+IiAj169dPEydOVFFRkd21Vq9eLYvFoiuuuEIZGRmqqqpqNNajR49q/fr1uvbaa21t27Ztqxe7JCUnJzcZe3l5eb2Xp2ouEVFWZW3xtUorrHbX+f71Sitafi1nsQR8V3S7IRTdBgAAAAAAAID24dKkRmlpqc6dO2crknVeWFiYiouLGzwnOTlZixYt0v79+1VXV6f33ntP69ev17Fjx2x9EhIS9MorrygnJ0fPP/+8Dh48qJEjR+r06dO2PhMmTNCqVav0wQcfKCMjQytXrtRtt91md7/U1FT5+/urV69eCgwM1Isvvmg7Vlxc3GDs5eXlOnPmjN21srKyFBQUZHtFRka2bKDckCMTEe25tVNZlVWF31ZoV9FJFR6vaHHyJcjfpAXjYu0SGx2h6HZbxwQAAAAAAAAA2pvLt59qrSVLlmjatGmKiYmRl5eXoqKiNGXKFK1YscLW58Ybb7T9HBsbq4SEBPXu3VtvvPGGpk6dKkmaPn26rc+gQYMUHh6u0aNHq7CwUFFRUbZjTz/9tObMmaOvvvpKGRkZSktL03PPPdem2M+ff155ebnHJjYcmYhor62dLnS7rIhgPy1Nje9QRbfdvZYJAAAAAAAAAHyfS1dqWCwW+fj4qKSkpF57SUlJo7UuQkJCtGHDBlVWVurw4cPau3evAgIC1K9fv0bvExwcrMsvv1wFBQWN9klISJAkuz49e/ZUTEyMbrrpJr3wwgt6/vnnbatCevbs2WDsgYGB8vOz/4Owr6+vAgMD6708lSMTEe2xtZOjtssK8jcpKjRAcZf2UFRogEcnNBy5hVhb7s3qEAAAAAAAAACt5dKkhslk0pAhQ5SXl2drq6urU15enoYPH97kuWazWb169dLZs2e1bt06jR07ttG+FRUVKiwsVHh4eKN9du/eLUlN9qmrq5P0XW0MSRo+fHi92CXpvffeazb2jsCRiYj22NrJE+p2tDdXjcnRU2d072u7NHrRh7rlua0avfBD3ffaLh09Zb9lGwAAAAAAAAB8n8u3n0pLS9PkyZM1dOhQDRs2TIsXL1ZlZaWmTJkiSZo0aZJ69eqlrKwsSdKOHTt05MgRxcXF6ciRI5o7d67q6uo0a9Ys2zUfeOABjRkzRr1799bRo0c1Z84c+fj4KDU1VZJUWFioNWvWKCUlRRdffLHy8/M1c+ZMJSYmKjY2VpL0zjvvqKSkRFdddZUCAgL0+eef68EHH9Q111yjPn36SJJmzJihZ599VrNmzdIdd9yh999/X2+88YY2btzYjiPoGucTEenr8rX5B1sXtSUR0djWTpJU+G2FyqtrFejXVZZubdvuqT3rdngKV4xJc6tDlqbGe/TqFwAAAAAAAADO5fKkxvjx43X8+HHNnj1bxcXFiouLU05Ojq0Ad1FRkby9/7ugpLq6WpmZmTpw4IACAgKUkpKilStXKjg42Nbnm2++UWpqqk6cOKGQkBCNGDFC27dvV0hIiKTvVojk5ubaEiiRkZEaN26cMjMzbdfw8/PT8uXLNXPmTNXU1CgyMlK33nqr0tPTbX369u2rjRs3aubMmVqyZIkuueQSvfjii0pOTnbyqLkHRycigvzr93NkvYf2qtvhSVwxJi1ZHUJSAwAAAAAAAEBjvAzDMFwdRGdVXl6uoKAglZWVeXR9je9zVCKirMqqe1/b1eAfwBOjLa3+F/1lVVbd99queqtKLuR6HYErxmRX0Und8tzWRo9vuPtqxV3aw6H3BNB6HfH55On4TgAA7oZnk3viewEAuBtnPJtcWlMDHYsjC087ut5De9Tt8DSuGBNWzAAAAAAAAAC4EC7ffgodhyO3FnJGvYfGtstyl4RGWZVVpRXWC64f0hrtPSbnC8w3tjqkNQXmOwpXfO8AAAAAAACApyKpAYdxZCLCWf+i/4d1O9yFI+uHtFZ7jomjC8x7Old+7wAAAAAAAIAnIqkBh3FkIqIz/Yv+5rbt6mj1Ptx9xUx76WzfOwAAAAAAAOAI1NSAw5xPRDSktYmIzlQDw9H1QzxBkL9JUaEBiru0h6JCAzrU99lSnfF7BwAAAAAAAC4UKzXgMI7eWshT/0V/a2skOKN+CNwf3zsAAAAAAADQeiQ14FCOTkScr/dwPlFwoLRSgX5Wty2m3JYaCc6qHwL3xvcOAAAAAAAAtB5JDTicowtPtzZR0NqVEo7S1hoJ7Vk/xFVjA3udqW4MAAAAAAAA4CgkNeDWWpsoaMtKCUdpSY2EhhIIjt62qzGuHBvYa6/vHQAAAAAAAOhISGrArbUmUdDWlRKOciE1EpxdP8TVY4OGeWrdGAAAAAAAAMBVSGrArbUmUdDWlRKOcqE1Ehy9bdf3uXps0Dhnfu8AAAAAAABAR+Pt6gCAprQmUXAhKyUc4XyNhIa4ukaCq8cGAAAAAAAAAByBpAbcWmsSBRe6UuJCna+R8MN43aFGgqvHBgAAAAAAAAAcge2n4NZaU0z5fAJkcwPbLLXXSgl3rZHgDmMDAAAAAAAAABeKpEYHUlZlVWmFVeXVtQr06ypLN9f/Md0RWpooaE0CxJncsUaCu4wNAAAAAAAAAFwIkhodxNFTZ/TQuvx6xaAToy1aMC5WEcF+LozMMVqaKHDXlRLugLEBAAAAAAAA4OlIanQAZVVWu4SGJG3eX6r0dflamhrfqf5w7Y4rJdwFYwMAAAAAAADAk1EovAMorbDaJTTO27y/VKUV1naOCAAAAAAAAAAAxyOp0QGUV9c2efx0M8cBAAAAAAAAAPAEJDU6gEBz1yaPd2/mOAAAAAAAAAAAnoCkRgdgCTApMdrS4LHEaIssAdRQAAAAAAAAAAB4PpIaHUCQv0kLxsXaJTYSoy16YlwshaE7sLIqqwq/rdCuopMqPF6hsirqpwAAAAAAAADouLq4OgA4RkSwn5amxqu0wqrT1bXqbu4qS4CJhEYHdvTUGT20Lr9ekfjEaIsWjItVRLCfCyMDAAAAAAAAAOdgpUYHEuRvUlRogOIu7aGo0AASGh1YWZXVLqEhSZv3lyp9XT4rNgAAAAAAAAB0SCQ1AA9UWmG1S2ict3l/qUorSGoAAAAAAAAA6HhIagAeqLy6tsnjp5s5DgAAAAAAAACeiJoagAcKNHdt8nj3Zo4D8AxlVVaVVlhVXl2rQL+usnSjVhIAAAAAAOjcSGoAHsgSYFJitEWbG9iCKjHaIksAf/QEPN3RU2fsauckRlu0YFysIoL9XBgZAAAAAACA67D9FOCBgvxNWjAuVonRlnrtidEWPTEuln/JDXi4siqrXUJD+q5mTvq6fJVVUTcHAAAAAAB0TqzUADxURLCflqbGq7TCqtPVtepu7ipLAFvTAB1BaYXVLqFx3ub9pSqtsPK/dQAAAAAA0CmR1AA8WJA/SQygIyqvrm3y+OlmjgMAAAAAAHRUbD8FAICbCTR3bfJ492aOAwAAAAAAdFQkNQAAcDOWAJNdzZzzEqMtsgSwQgsAAAAAAHROJDUAAHAzQf4mLRgXa5fYSIy26IlxsWw7BwAAAAAAOi1qagAA4IYigv20NDVepRVWna6uVXdzV1kCqKMDAAAAAAA6N7dYqbFs2TL16dNHZrNZCQkJ+uSTTxrtW1tbq/nz5ysqKkpms1mDBw9WTk5OvT5z586Vl5dXvVdMTEy9PqNGjbLrM2PGDNvxf//730pNTVVkZKT8/Pw0YMAALVmypN41Nm3aZHcNLy8vFRcXO2BUAACdXZC/SVGhAYq7tIeiQgNIaLiR1sxdJOnUqVO65557FB4eLl9fX11++eV655132ilaAADgKswZAABwPJev1Fi7dq3S0tKUnZ2thIQELV68WMnJydq3b59CQ0Pt+mdmZmrVqlVavny5YmJi9O677+qWW27R1q1bFR8fb+s3cOBA5ebm2t536WL/UadNm6b58+fb3vv7+9t+3rlzp0JDQ7Vq1SpFRkZq69atmj59unx8fHTvvffWu86+ffsUGBhoe99Q3AAAoGNo7dzFarXqpz/9qUJDQ/XWW2+pV69eOnz4sIKDg9s/eAAA0G6YMwAA4BxehmEYrgwgISFBV111lZ599llJUl1dnSIjI3XfffcpPT3drn9ERIQefvhh3XPPPba2cePGyc/PT6tWrZL03UqNDRs2aPfu3Y3ed9SoUYqLi9PixYtbHOs999yjL7/8Uu+//76k71ZqXHfddTp58mSbJhnl5eUKCgpSWVlZvaQIAACuxPOpaa2du2RnZ+upp57S3r171bVr1zbdk+8EAOBueDY1jzkDAADOeTa5dPspq9WqnTt3Kikpydbm7e2tpKQkbdu2rcFzampqZDab67X5+flpy5Yt9dr279+viIgI9evXTxMnTlRRUZHdtVavXi2LxaIrrrhCGRkZqqqqajLesrIyXXTRRXbtcXFxCg8P109/+lN9/PHHTV4DAAB4rrbMXd5++20NHz5c99xzj8LCwnTFFVfo8ccf17lz59orbAAA0M6YMwAA4Dwu3X6qtLRU586dU1hYWL32sLAw7d27t8FzkpOTtWjRIiUmJioqKkp5eXlav359vYd8QkKCXnnlFfXv31/Hjh3TvHnzNHLkSO3Zs0fdu3eXJE2YMEG9e/dWRESE8vPz9dBDD2nfvn1av359g/fdunWr1q5dq40bN9rawsPDlZ2draFDh6qmpkYvvviiRo0apR07dujKK6+0u0ZNTY1qamps78vLy1s+WAAAwOXaMnc5cOCA3n//fU2cOFHvvPOOCgoKdPfdd6u2tlZz5sxp8BzmDAAAeDbmDAAAOI/La2q01pIlSzRt2jTFxMTIy8tLUVFRmjJlilasWGHrc+ONN9p+jo2NVUJCgnr37q033nhDU6dOlSRNnz7d1mfQoEEKDw/X6NGjVVhYqKioqHr33LNnj8aOHas5c+bo+uuvt7X3799f/fv3t72/+uqrVVhYqKefflorV660iz0rK0vz5s278EEAAAAeo66uTqGhofrzn/8sHx8fDRkyREeOHNFTTz3V6B8omDMAAND5MGcAAKBlXLr9lMVikY+Pj0pKSuq1l5SUqGfPng2eExISog0bNqiyslKHDx/W3r17FRAQoH79+jV6n+DgYF1++eUqKChotE9CQoIk2fX54osvNHr0aE2fPl2ZmZnNfqZhw4Y1ep+MjAyVlZXZXl9//XWz1wMAAO6jLXOX8PBwXX755fLx8bG1DRgwQMXFxbJarQ2ew5wBAADPxpwBAADncWlSw2QyaciQIcrLy7O11dXVKS8vT8OHD2/yXLPZrF69euns2bNat26dxo4d22jfiooKFRYWKjw8vNE+54uKf7/P559/ruuuu06TJ0/WY4891qLPtHv37kbv4+vrq8DAwHovAADgOdoyd7nmmmtUUFCguro6W9tXX32l8PBwmUymBs9hzgAAgGdjzgAAgPO4NKkhSWlpaVq+fLleffVVffnll7rrrrtUWVmpKVOmSJImTZqkjIwMW/8dO3Zo/fr1OnDggD766CPdcMMNqqur06xZs2x9HnjgAX344Yc6dOiQtm7dqltuuUU+Pj5KTU2VJBUWFurRRx/Vzp07dejQIb399tuaNGmSEhMTFRsbK+m7Laeuu+46XX/99UpLS1NxcbGKi4t1/Phx230WL16sv/71ryooKNCePXv0u9/9Tu+//77uueee9hg6AADgAq2du9x11136z3/+o9/+9rf66quvtHHjRj3++OPMFwAA6OCYMwAA4Bwur6kxfvx4HT9+XLNnz1ZxcbHi4uKUk5NjK6ZVVFQkb+//5l6qq6uVmZmpAwcOKCAgQCkpKVq5cqWCg4Ntfb755hulpqbqxIkTCgkJ0YgRI7R9+3aFhIRI+u5fTOTm5mrx4sWqrKxUZGSkxo0bV297qbfeekvHjx/XqlWrtGrVKlt77969dejQIUmS1WrV73//ex05ckT+/v6KjY1Vbm6urrvuOieOGAAAcKXWzl0iIyP17rvvaubMmYqNjVWvXr3029/+Vg899JCrPgIAAGgHzBkAAHAOL8MwDFcH0VmVl5crKChIZWVlLBEFALgNnk/uh+8EAOBueDa5J74XAIC7ccazyeUrNYDGlFVZVVphVXl1rQL9usrSzaQg/4b3EQUAAAAAAAAAdHwkNeCWjp46o4fW5euj/aW2tsRoixaMi1VEsJ8LI0NnQEINAAAAAAAAcE8kNeB2yqqsdgkNSdq8v1Tp6/K1NDWePzDDaUioAQAAAAAAAO7Lu/kuQPsqrbDaJTTO27y/VKUV1naOCJ1Fcwm1sip+9wAAAAAAAABXIqkBt1NeXdvk8dPNHAfaioQaAAAAAAAA4N5IasDtBJq7Nnm8ezPHgbYioQYAAAAAAAC4N5IacDuWAJMSoy0NHkuMtsgSQD0NOAcJNQAAAAAAAMC9kdSA2wnyN2nBuFi7xEZitEVPjIulSDichoQaAAAAAAAA4N66tKRTfn5+iy8YGxvb5mCA8yKC/bQ0NV6lFVadrq5Vd3NXWQJMJDTgVOcTaunr8rX5e7U1SKgBAAAAAAAA7qFFSY24uDh5eXnJMAx5eXk12ffcuXMOCQwI8ieJgfZHQg0AAAAAAABwXy1Kahw8eND2865du/TAAw/owQcf1PDhwyVJ27Zt08KFC/Xkk086J0oAaEck1AAAAAAAAAD31KKkRu/evW0//+IXv9AzzzyjlJQUW1tsbKwiIyP1yCOP6Oabb3Z4kAAAAAAAAAAAAK0uFP7ZZ5+pb9++du19+/bVF1984ZCgAAAAAAAAAAAAfqjVSY0BAwYoKytLVqvV1ma1WpWVlaUBAwY4NDgAAAAAAAAAAIDzWrT91PdlZ2drzJgxuuSSSxQbGytJys/Pl5eXl/72t785PEAAAAAAAAAAAACpDUmNYcOG6cCBA1q9erX27t0rSRo/frwmTJigbt26OTxAAAAAAAAAAAAAqQ1JDUnq1q2bpk+f7uhYAAAAAAAAAAAAGtWipMbbb7+tG2+8UV27dtXbb7/dZN+bbrrJIYEBAAAAAAAAAAB8X4uSGjfffLOKi4sVGhqqm2++udF+Xl5eOnfunKNiAwAAAAAAAAAAsGlRUqOurq7BnwEAAAAAAAAAANqLt6sDAAAAAAAAAAAAaIkWrdR45plnWnzB+++/v83BAAAAAAAAAAAANKZFSY2nn366RRfz8vIiqQEAAAAAAAAAAJyiRUmNgwcPOjsOAAAAAAAAAACAJlFTAwAAAAAAAAAAeIQWrdT4oW+++UZvv/22ioqKZLVa6x1btGiRQwIDAAAAAAAAAAD4vlYnNfLy8nTTTTepX79+2rt3r6644godOnRIhmHoyiuvdEaMAAAAAAAAAAAArd9+KiMjQw888IA+++wzmc1mrVu3Tl9//bWuvfZa/eIXv3BGjAAAAAAAAAAAAK1Panz55ZeaNGmSJKlLly46c+aMAgICNH/+fD3xxBMODxAAAAAAAAAAAEBqQ1KjW7dutjoa4eHhKiwstB0rLS11XGQAAAAAAAAAAADf0+qaGj/+8Y+1ZcsWDRgwQCkpKfr973+vzz77TOvXr9ePf/xjZ8QIAAAAAAAAAADQ+qTGokWLVFFRIUmaN2+eKioqtHbtWkVHR2vRokUODxAAAAAAAAAAAEBqQ1Lj8ccf12233Sbpu62osrOzHR4UAAAAAAAAAADAD7W6psbx48d1ww03KDIyUg8++KD+/e9/OyMuAICHKquyqvDbCu0qOqnC4xUqq7K6OiQAAAAAAAB0EK1eqfHXv/5VJ0+e1Jtvvqk1a9Zo0aJFiomJ0cSJEzVhwgT16dPHCWECADzB0VNn9NC6fH20v9TWlhht0YJxsYoI9nNhZAAAAAAAAOgIWr1SQ5J69Oih6dOna9OmTTp8+LB+/etfa+XKlbrsssscHR8AwEOUVVntEhqStHl/qdLX5bNiAwAAAAAAABesTUmN82pra/Wvf/1LO3bs0KFDhxQWFtam6yxbtkx9+vSR2WxWQkKCPvnkkybvOX/+fEVFRclsNmvw4MHKycmp12fu3Lny8vKq94qJianXZ9SoUXZ9ZsyYYTv+73//W6mpqYqMjJSfn58GDBigJUuW2MWzadMmXXnllfL19dVll12mV155pU1jAACerrTCapfQOG/z/lKVVpDUAAAAAAAAwIVp9fZTkvTBBx9ozZo1Wrdunerq6nTrrbfq73//u37yk5+0+lpr165VWlqasrOzlZCQoMWLFys5OVn79u1TaGioXf/MzEytWrVKy5cvV0xMjN59913dcsst2rp1q+Lj4239Bg4cqNzc3P9+0C72H3XatGmaP3++7b2/v7/t5507dyo0NFSrVq1SZGSktm7dqunTp8vHx0f33nuvJOngwYP62c9+phkzZmj16tXKy8vTnXfeqfDwcCUnJ7d6LADAk5VX1zZ5/HQzxwEAAAAAAIDmtDqp0atXL/3nP//RDTfcoD//+c8aM2aMfH192xzAokWLNG3aNE2ZMkWSlJ2drY0bN2rFihVKT0+3679y5Uo9/PDDSklJkSTdddddys3N1cKFC7Vq1Spbvy5duqhnz55N3tvf37/RPnfccUe99/369dO2bdu0fv16W1IjOztbffv21cKFCyVJAwYM0JYtW/T000+T1ADQ6QSauzZ5vHszxwEAAAAAAIDmtHr7qblz5+rYsWP6y1/+op///OcXlNCwWq3auXOnkpKS/huQt7eSkpK0bdu2Bs+pqamR2Wyu1+bn56ctW7bUa9u/f78iIiLUr18/TZw4UUVFRXbXWr16tSwWi6644gplZGSoqqqqyXjLysp00UUX2d5v27atXuySlJyc3GTs5eXl9V4A0FFYAkxKjLY0eCwx2iJLgKmdIwIAAAAAAEBH0+qkxrRp0xQcHOyQm5eWlurcuXN2tTjCwsJUXFzc4DnJyclatGiR9u/fr7q6Or333ntav369jh07ZuuTkJCgV155RTk5OXr++ed18OBBjRw5UqdPn7b1mTBhglatWqUPPvhAGRkZWrlypW677bZGY926davWrl2r6dOn29qKi4sbjL28vFxnzpyxu0ZWVpaCgoJsr8jIyKYHCAA8SJC/SQvGxdolNhKjLXpyXKwkqfDbCu0qOqnC4xUUDgcAAAAAAECrtammhistWbJE06ZNU0xMjLy8vBQVFaUpU6ZoxYoVtj433nij7efY2FglJCSod+/eeuONNzR16lRJqpecGDRokMLDwzV69GgVFhYqKiqq3j337NmjsWPHas6cObr++uvbHHtGRobS0tJs78vLy0lsAOhQIoL9tDQ1XqUVVp2urlV3c1dZAkyqtJ7Tva/tqldIPDHaogXjYhUR7OfCiAEAAAAAAOBJWr1Sw5EsFot8fHxUUlJSr72kpKTRWhchISHasGGDKisrdfjwYe3du1cBAQHq169fo/cJDg7W5ZdfroKCgkb7JCQkSJJdny+++EKjR4/W9OnTlZmZWe9Yz549G4w9MDBQfn72f6Tz9fVVYGBgvRcAdDRB/iZFhQYo7tIeigoNkCQ9tC6/XkJDkjbvL1X6unxWbAAAAAAAAKDFXJrUMJlMGjJkiPLy8mxtdXV1ysvL0/Dhw5s812w2q1evXjp79qzWrVunsWPHNtq3oqJChYWFCg8Pb7TP7t27Jalen88//1zXXXedJk+erMcee8zunOHDh9eLXZLee++9ZmMHgM6ktMJql9A4b/P+UpVWkNQAAAAAAABAy7g0qSFJaWlpWr58uV599VV9+eWXuuuuu1RZWakpU6ZIkiZNmqSMjAxb/x07dmj9+vU6cOCAPvroI91www2qq6vTrFmzbH0eeOABffjhhzp06JC2bt2qW265RT4+PkpNTZUkFRYW6tFHH9XOnTt16NAhvf3225o0aZISExMVG/vdvu979uzRddddp+uvv15paWkqLi5WcXGxjh8/brvPjBkzdODAAc2aNUt79+7Vc889pzfeeEMzZ85sj6EDAI9QXl3b5PHTzRwHAAAAAAAAznN5TY3x48fr+PHjmj17toqLixUXF6ecnBxbAe6ioiJ5e/8391JdXa3MzEwdOHBAAQEBSklJ0cqVK+sVL//mm2+UmpqqEydOKCQkRCNGjND27dsVEhIi6bsVIrm5uVq8eLEqKysVGRmpcePG1dte6q233tLx48e1atUqrVq1ytbeu3dvHTp0SJLUt29fbdy4UTNnztSSJUt0ySWX6MUXX1RycrITRwwAPEuguWuTx7s3cxwAAAAAAAA4z8swDMPVQXRW5eXlCgoKUllZGfU1AHRYZVVW3ffaLm1uYAuqxGiLlqbGK8jf5ILI0BieT81btmyZnnrqKRUXF2vw4MFaunSphg0b1ux5r7/+ulJTUzV27Fht2LChxffjOwEAuBueTS3DnAEA0Nk549nk8u2nAAAdW5C/SQvGxSox2lKvPTHaoifGxZLQgMdZu3at0tLSNGfOHH366acaPHiwkpOT9e233zZ53qFDh/TAAw9o5MiR7RQpAABwJeYMAAA4Bys1XIh/QQGgMymrsqq0wqrT1bXqbu4qS4CJhIab4vnUtISEBF111VV69tlnJUl1dXWKjIzUfffdp/T09AbPOXfunBITE3XHHXfoo48+0qlTp/hXlwAAj8azqXnMGQAAYKUGAMCDBfmbFBUaoLhLeygqNICEBjyS1WrVzp07lZSUZGvz9vZWUlKStm3b1uh58+fPV2hoqKZOndqi+9TU1Ki8vLzeCwAAeA7mDAAAOA9JDQAAgBYqLS3VuXPnFBYWVq89LCxMxcXFDZ6zZcsWvfTSS1q+fHmL75OVlaWgoCDbKzIy8oLiBgAA7Ys5AwAAzkNSAwAAwElOnz6t22+/XcuXL5fFYmn+hP+TkZGhsrIy2+vrr792YpQAAMDVmDMAANByXVwdAAAAgKewWCzy8fFRSUlJvfaSkhL17NnTrn9hYaEOHTqkMWPG2Nrq6uokSV26dNG+ffsUFRVld56vr698fX0dHD0AAGgvzBkAAHAeVmoAAAC0kMlk0pAhQ5SXl2drq6urU15enoYPH27XPyYmRp999pl2795te91000267rrrtHv3braIAACgg2LOAACA87BSAwAAoBXS0tI0efJkDR06VMOGDdPixYtVWVmpKVOmSJImTZqkXr16KSsrS2azWVdccUW984ODgyXJrh0AAHQszBkAAHAOkhoAAACtMH78eB0/flyzZ89WcXGx4uLilJOTYysEWlRUJG9vFsMCANDZMWcAAMA5vAzDMFwdRGdVXl6uoKAglZWVKTAw0NXhAAAgieeTO+I7AQC4G55N7onvBQDgbpzxbOKfBAAAAAAAAAAAAI9AUgMAAAAAAAAAAHgEkhoAAAAAAAAAAMAjkNQAAAAAAAAAAAAegaQGAAAAAAAAAADwCCQ1AAAAAAAAAACARyCpAQAAAAAAAAAAPAJJDQAAAAAAAAAA4BFIagAAAAAAAAAAAI9AUgMAAAAAAAAAAHiELq4OAADaoqzKqtIKq8qraxXo11WWbiYF+ZtcHRYAAAAAAAAAJyKpAcDjHD11Rg+ty9dH+0ttbYnRFi0YF6uIYD8XRgYAAAAAAADAmdh+CoBHKauy2iU0JGnz/lKlr8tXWZXVRZEBAAAAAAAAcDaSGgA8SmmF1S6hcd7m/aUqrSCpAQAAAAAAAHRUJDUAeJTy6tomj59u5jgAAAAAAAAAz0VSA4BHCTR3bfJ492aOAwAAAAAAAPBcJDUAeBRLgEmJ0ZYGjyVGW2QJMLVzRAAAAAAAAADaC0kNAB4lyN+kBeNi7RIbidEWPTEuVkH+JDUAAAAAAACAjqqLqwMAgNaKCPbT0tR4lVZYdbq6Vt3NXWUJMJHQAAAAAAAAADo4khoAPFKQP0kMAAAAAAAAoLNh+ykAAAAAAAAAAOARSGoAAAAAAAAAAACPQFIDAAAAAAAAAAB4BJIaAAAAAAAAAADAI5DUAAAAAAAAAAAAHoGkBgAAAAAAAAAA8AguT2osW7ZMffr0kdlsVkJCgj755JNG+9bW1mr+/PmKioqS2WzW4MGDlZOTU6/P3Llz5eXlVe8VExNTr8+oUaPs+syYMaNen/vvv19DhgyRr6+v4uLi7GI5dOiQ3TW8vLy0ffv2tg8GAAAAAAAAAABoVBdX3nzt2rVKS0tTdna2EhIStHjxYiUnJ2vfvn0KDQ2165+ZmalVq1Zp+fLliomJ0bvvvqtbbrlFW7duVXx8vK3fwIEDlZuba3vfpYv9x5w2bZrmz59ve+/v72/X54477tCOHTuUn5/f6GfIzc3VwIEDbe8vvvji5j84AAAAAAAAAABoNZcmNRYtWqRp06ZpypQpkqTs7Gxt3LhRK1asUHp6ul3/lStX6uGHH1ZKSook6a677lJubq4WLlyoVatW2fp16dJFPXv2bPLe/v7+TfZ55plnJEnHjx9vMqlx8cUXN3svAAAAAAAAAABw4Vy2/ZTVatXOnTuVlJT032C8vZWUlKRt27Y1eE5NTY3MZnO9Nj8/P23ZsqVe2/79+xUREaF+/fpp4sSJKioqsrvW6tWrZbFYdMUVVygjI0NVVVVt+hw33XSTQkNDNWLECL399ttN9q2pqVF5eXm9FwAAAAAAAAAAaBmXJTVKS0t17tw5hYWF1WsPCwtTcXFxg+ckJydr0aJF2r9/v+rq6vTee+9p/fr1OnbsmK1PQkKCXnnlFeXk5Oj555/XwYMHNXLkSJ0+fdrWZ8KECVq1apU++OADZWRkaOXKlbrttttaFX9AQIAWLlyoN998Uxs3btSIESN08803N5nYyMrKUlBQkO0VGRnZqnsCAAAAAAAAANCZuXT7qdZasmSJpk2bppiYGHl5eSkqKkpTpkzRihUrbH1uvPFG28+xsbFKSEhQ79699cYbb2jq1KmSpOnTp9v6DBo0SOHh4Ro9erQKCwsVFRXVolgsFovS0tJs76+66iodPXpUTz31lG666aYGz8nIyKh3Tnl5OYkNAAAAAAAAAABayGUrNSwWi3x8fFRSUlKvvaSkpNEaFSEhIdqwYYMqKyt1+PBh7d27VwEBAerXr1+j9wkODtbll1+ugoKCRvskJCRIUpN9WiIhIaHJa/j6+iowMLDeCwAAAAAAAAAAtIzLkhomk0lDhgxRXl6era2urk55eXkaPnx4k+eazWb16tVLZ8+e1bp16zR27NhG+1ZUVKiwsFDh4eGN9tm9e7ckNdmnJXbv3n3B1wAAAAAAAAAAAA1z6fZTaWlpmjx5soYOHaphw4Zp8eLFqqys1JQpUyRJkyZNUq9evZSVlSVJ2rFjh44cOaK4uDgdOXJEc+fOVV1dnWbNmmW75gMPPKAxY8aod+/eOnr0qObMmSMfHx+lpqZKkgoLC7VmzRqlpKTo4osvVn5+vmbOnKnExETFxsbarlNQUKCKigoVFxfrzJkztsTHj370I5lMJr366qsymUyKj4+XJK1fv14rVqzQiy++2B5DBwAAAAAAAABAp+PSpMb48eN1/PhxzZ49W8XFxYqLi1NOTo6teHhRUZG8vf+7mKS6ulqZmZk6cOCAAgIClJKSopUrVyo4ONjW55tvvlFqaqpOnDihkJAQjRgxQtu3b1dISIik71aI5Obm2hIokZGRGjdunDIzM+vFduedd+rDDz+0vT+fvDh48KD69OkjSXr00Ud1+PBhdenSRTExMVq7dq1+/vOfO2OoAAAAAAAAAADo9LwMwzBcHURnVV5erqCgIJWVlVFfAwDgNng+uR++EwCAu+HZ5J74XgAA7sYZzyaX1dQAAAAAAAAAAABoDZIaAAAAAAAAAADAI5DUAAAAAAAAAAAAHsGlhcIBAC1XVmVVaYVV5dW1CvTrKks3k4L8Ta4OCwAAAAAAAGg3JDUAwAMcPXVGD63L10f7S21tidEWLRgXq4hgPxdGBgAAAAAAALQftp8CADdXVmW1S2hI0ub9pUpfl6+yKquLIgMAAAAAAADaF0kNAHBzpRVWu4TGeZv3l6q0gqQGAAAAAAAAOgeSGgDg5sqra5s8frqZ4wAAAAAAAEBHQVIDANxcoLlrk8e7N3McgOMtW7ZMffr0kdlsVkJCgj755JNG+y5fvlwjR45Ujx491KNHDyUlJTXZHwAAdBzMGQAAcDySGgDg5iwBJiVGWxo8lhhtkSXA1M4RAZ3b2rVrlZaWpjlz5ujTTz/V4MGDlZycrG+//bbB/ps2bVJqaqo++OADbdu2TZGRkbr++ut15MiRdo4cAAC0J+YMAAA4h5dhGIarg+isysvLFRQUpLKyMgUGBro6HABu7OipM0pfl6/N36utkRht0RPjYhUe7OfCyNAR8XxqWkJCgq666io9++yzkqS6ujpFRkbqvvvuU3p6erPnnzt3Tj169NCzzz6rSZMmteiefCcAAHfDs6l5zBkAAHDOs6mLQ64CAHCqiGA/LU2NV2mFVaera9Xd3FWWAJOC/FmlAbQnq9WqnTt3KiMjw9bm7e2tpKQkbdu2rUXXqKqqUm1trS666KJG+9TU1Kimpsb2vry8vO1BAwCAdsecAQAA52H7KQDwEEH+JkWFBiju0h6KCg0goQG4QGlpqc6dO6ewsLB67WFhYSouLm7RNR566CFFREQoKSmp0T5ZWVkKCgqyvSIjIy8obgAA0L6YMwAA4DwkNQAAANrJggUL9Prrr+svf/mLzGZzo/0yMjJUVlZme3399dftGCUAAHA15gwAADSO7acAAABayGKxyMfHRyUlJfXaS0pK1LNnzybP/dOf/qQFCxYoNzdXsbGxTfb19fWVr6/vBccLAABcgzkDAADOw0oNAACAFjKZTBoyZIjy8vJsbXV1dcrLy9Pw4cMbPe/JJ5/Uo48+qpycHA0dOrQ9QgUAAC7EnAEAAOdhpQYAAEArpKWlafLkyRo6dKiGDRumxYsXq7KyUlOmTJEkTZo0Sb169VJWVpYk6YknntDs2bO1Zs0a9enTx7aPdkBAgAICAlz2OQAAgHMxZwAAwDlIagAAALTC+PHjdfz4cc2ePVvFxcWKi4tTTk6OrRBoUVGRvL3/uxj2+eefl9Vq1c9//vN615kzZ47mzp3bnqEDAIB2xJwBAADn8DIMw3B1EJ1VeXm5goKCVFZWpsDAQFeHAwCAJJ5P7ojvBADgbng2uSe+FwCAu3HGs4maGgAAAAAAAAAAwCOQ1AAAAAAAAAAAAB6BpAYAAAAAAAAAAPAIJDUAAAAAAAAAAIBHIKkBAAAAAAAAAAA8AkkNAAAAAAAAAADgEUhqAAAAAAAAAAAAj0BSAwAAAAAAAAAAeASSGgAAAAAAAAAAwCOQ1AAAAAAAAAAAAB6BpAYAAAAAAAAAAPAIJDUAAAAAAAAAAIBHIKkBAAAAAAAAAAA8AkkNAAAAAAAAAADgEUhqAAAAAAAAAAAAj0BSAwAAAAAAAAAAeASXJzWWLVumPn36yGw2KyEhQZ988kmjfWtrazV//nxFRUXJbDZr8ODBysnJqddn7ty58vLyqveKiYmp12fUqFF2fWbMmFGvz/33368hQ4bI19dXcXFxDcaTn5+vkSNHymw2KzIyUk8++WTbBgEAAAAAAAAAADSriytvvnbtWqWlpSk7O1sJCQlavHixkpOTtW/fPoWGhtr1z8zM1KpVq7R8+XLFxMTo3Xff1S233KKtW7cqPj7e1m/gwIHKzc21ve/Sxf5jTps2TfPnz7e99/f3t+tzxx13aMeOHcrPz7c7Vl5eruuvv15JSUnKzs7WZ599pjvuuEPBwcGaPn16q8cCAAAAAAAAAAA0zaVJjUWLFmnatGmaMmWKJCk7O1sbN27UihUrlJ6ebtd/5cqVevjhh5WSkiJJuuuuu5Sbm6uFCxdq1apVtn5dunRRz549m7y3v79/k32eeeYZSdLx48cbTGqsXr1aVqtVK1askMlk0sCBA7V7924tWrSIpAYAAAAAAAAAAE7gsu2nrFardu7cqaSkpP8G4+2tpKQkbdu2rcFzampqZDab67X5+flpy5Yt9dr279+viIgI9evXTxMnTlRRUZHdtVavXi2LxaIrrrhCGRkZqqqqalX827ZtU2Jiokwmk63t/CqTkydPtupaAAAAAAAAAACgeS5bqVFaWqpz584pLCysXntYWJj27t3b4DnJyclatGiREhMTFRUVpby8PK1fv17nzp2z9UlISNArr7yi/v3769ixY5o3b55GjhypPXv2qHv37pKkCRMmqHfv3oqIiFB+fr4eeugh7du3T+vXr29x/MXFxerbt69d7OeP9ejRw+6cmpoa1dTU2N6Xl5e3+H4AAAAAAAAAAHR2Lt1+qrWWLFmiadOmKSYmRl5eXoqKitKUKVO0YsUKW58bb7zR9nNsbKwSEhLUu3dvvfHGG5o6daok1dseatCgQQoPD9fo0aNVWFioqKgop8WflZWlefPmOe36AAAAAAAAAAB0ZC7bfspiscjHx0clJSX12ktKShqtdRESEqINGzaosrJShw8f1t69exUQEKB+/fo1ep/g4GBdfvnlKigoaLRPQkKCJDXZ54d69uzZYOznjzUkIyNDZWVlttfXX3/d4vsBAAAAAAAAANDZuSypYTKZNGTIEOXl5dna6urqlJeXp+HDhzd5rtlsVq9evXT27FmtW7dOY8eObbRvRUWFCgsLFR4e3mif3bt3S1KTfX5o+PDh2rx5s2pra21t7733nvr379/g1lOS5Ovrq8DAwHovAIBnKKuyqvDbCu0qOqnC4xUqq7K6OiQAAAAAAIBOx6XbT6WlpWny5MkaOnSohg0bpsWLF6uyslJTpkyRJE2aNEm9evVSVlaWJGnHjh06cuSI4uLidOTIEc2dO1d1dXWaNWuW7ZoPPPCAxowZo969e+vo0aOaM2eOfHx8lJqaKkkqLCzUmjVrlJKSoosvvlj5+fmaOXOmEhMTFRsba7tOQUGBKioqVFxcrDNnztgSHz/60Y9kMpk0YcIEzZs3T1OnTtVDDz2kPXv2aMmSJXr66afbafQAAO3l6Kkzemhdvj7aX2prS4y2aMG4WEUE+7kwMgAAAAAAgM7FpUmN8ePH6/jx45o9e7aKi4sVFxennJwcW8HtoqIieXv/dzFJdXW1MjMzdeDAAQUEBCglJUUrV65UcHCwrc8333yj1NRUnThxQiEhIRoxYoS2b9+ukJAQSd+tEMnNzbUlUCIjIzVu3DhlZmbWi+3OO+/Uhx9+aHsfHx8vSTp48KD69OmjoKAg/eMf/9A999yjIUOGyGKxaPbs2fXqdQAAPF9ZldUuoSFJm/eXKn1dvpamxivI3+Si6AAAAAAAADoXL8MwDFcH0VmVl5crKChIZWVlbEUFAG6q8NsKjV70YaPH89KuVVRoQDtG5Hw8n9wP3wkAwN3wbHJPfC8AAHfjjGeTy2pqAADgCcqra5s8frqZ4wAAAAAAAHAckhoAADQh0Ny1yePdmzkOAAAAAAAAxyGpAQBAEywBJiVGWxo8lhhtkSWAehoAAAAAAADthaQGAABNCPI3acG4WLvERmK0RU+Mi6VIOAAAAAAAQDvq4uoAAABwdxHBflqaGq/SCqtOV9equ7mrLAEmEhoAAAAAAADtjKQGAAAtEORPEgMAAAAAAMDVSGoAAODByqqsKq2wqry6VoF+XWXpRvIFAAAAAAB0XCQ1AADwUEdPndFD6/L10f5SW1titEULxsUqItjPhZEBAAAAAAA4B4XCAQDwQGVVVruEhiRt3l+q9HX5KquyuigyAAAAAAAA5yGpAQCAByqtsNolNM7bvL9UpRUkNQAAAAAAQMdDUgMAAA9UXl3b5PHTzRwHAAAAAADwRCQ1AADwQIHmrk0e797McQAAAAAAAE9EUgMAAA9kCTApMdrS4LHEaIssAaZ2jggAAAAAAMD5SGoAAOCBgvxNWjAu1i6xkRht0RPjYhXkT1IDAAAAAAB0PF1cHQAAAGibiGA/LU2NV2mFVaera9Xd3FWWABMJDQAAAAAA0GGR1AAAwIMF+ZPEAAAAAAAAnQfbTwEAAAAAAAAAAI9AUgMAAAAAAAAAAHgEkhoAAACttGzZMvXp00dms1kJCQn65JNPmuz/5ptvKiYmRmazWYMGDdI777zTTpECAABXYs4AAIDjkdQAAABohbVr1yotLU1z5szRp59+qsGDBys5OVnffvttg/23bt2q1NRUTZ06Vbt27dLNN9+sm2++WXv27GnnyAEAQHtizgAAgHN4GYZhuDqIzqq8vFxBQUEqKytTYGCgq8MBAEASz6fmJCQk6KqrrtKzzz4rSaqrq1NkZKTuu+8+paen2/UfP368Kisr9fe//93W9uMf/1hxcXHKzs5u0T35TgAA7oZnU/OYMwAA4JxnEys1AAAAWshqtWrnzp1KSkqytXl7eyspKUnbtm1r8Jxt27bV6y9JycnJjfYHAACejzkDAADO08XVAXRm5xfJlJeXuzgSAAD+6/xzicWc9kpLS3Xu3DmFhYXVaw8LC9PevXsbPKe4uLjB/sXFxY3ep6amRjU1Nbb3ZWVlkpgzAADcB/OFpjFnAADgO86YM5DUcKHTp09LkiIjI10cCQAA9k6fPq2goCBXh9EpZWVlad68eXbtzBkAAO7mxIkTzBdciDkDAMBTOHLOQFLDhSIiIvT111+re/fu8vLyuuDrlZeXKzIyUl9//TV7Z7YSY9d2jF3bMXZtx9i1XUvGzjAMnT59WhEREe0cnfuzWCzy8fFRSUlJvfaSkhL17NmzwXN69uzZqv6SlJGRobS0NNv7U6dOqXfv3ioqKuIPRw7Cf0cci/F0PMbU8RhTxyorK9Oll16qiy66yNWhuCXmDB0D/91wPMbU8RhTx2I8Hc8ZcwaSGi7k7e2tSy65xOHXDQwM5H90bcTYtR1j13aMXdsxdm3X3Njxf4IbZjKZNGTIEOXl5enmm2+W9F3Rz7y8PN17770NnjN8+HDl5eXpd7/7na3tvffe0/Dhwxu9j6+vr3x9fe3ag4KC+J13MP474liMp+Mxpo7HmDqWtzelOhvCnKFj4b8bjseYOh5j6liMp+M5cs5AUgMAAKAV0tLSNHnyZA0dOlTDhg3T4sWLVVlZqSlTpkiSJk2apF69eikrK0uS9Nvf/lbXXnutFi5cqJ/97Gd6/fXX9a9//Ut//vOfXfkxAACAkzFnAADAOUhqAAAAtML48eN1/PhxzZ49W8XFxYqLi1NOTo6tsGdRUVG9f4Fy9dVXa82aNcrMzNQf/vAHRUdHa8OGDbriiitc9REAAEA7YM4AAIBzkNToQHx9fTVnzpwGl56iaYxd2zF2bcfYtR1j13aMnWPce++9jW4dsWnTJru2X/ziF/rFL37R5vvxvTkeY+pYjKfjMaaOx5g6FuPZMswZPBvj6XiMqeMxpo7FeDqeM8bUyzAMw2FXAwAAAAAAAAAAcBIqegEAAAAAAAAAAI9AUgMAAAAAAAAAAHgEkhoAAAAAAAAAAMAjkNTwMMuWLVOfPn1kNpuVkJCgTz75pNG+r7zyiry8vOq9zGZzO0brXlozdpJ06tQp3XPPPQoPD5evr68uv/xyvfPOO+0UrXtpzdiNGjXK7vfOy8tLP/vZz9oxYvfR2t+7xYsXq3///vLz81NkZKRmzpyp6urqdorWvbRm7GprazV//nxFRUXJbDZr8ODBysnJacdo3cPmzZs1ZswYRUREyMvLSxs2bGj2nE2bNunKK6+Ur6+vLrvsMr3yyitOjxMNa+1/L958803FxMTIbDZr0KBBnfYZ1ZTWjOny5cs1cuRI9ejRQz169FBSUlKz30Fn09rf0fNef/11eXl56eabb3ZugB6I+anjMfdyHOYV7os5g2MxX3A85gyOx5zBsZgvOJZL5gwGPMbrr79umEwmY8WKFcbnn39uTJs2zQgODjZKSkoa7P/yyy8bgYGBxrFjx2yv4uLido7aPbR27GpqaoyhQ4caKSkpxpYtW4yDBw8amzZtMnbv3t3Okbtea8fuxIkT9X7n9uzZY/j4+Bgvv/xy+wbuBlo7dqtXrzZ8fX2N1atXGwcPHjTeffddIzw83Jg5c2Y7R+56rR27WbNmGREREcbGjRuNwsJC47nnnjPMZrPx6aeftnPkrvXOO+8YDz/8sLF+/XpDkvGXv/ylyf4HDhww/P39jbS0NOOLL74wli5davj4+Bg5OTntEzBsWvs7//HHHxs+Pj7Gk08+aXzxxRdGZmam0bVrV+Ozzz5r58jdV2vHdMKECcayZcuMXbt2GV9++aXx61//2ggKCjK++eabdo7cPbV2PM87ePCg0atXL2PkyJHG2LFj2ydYD8H81PGYezkW8wr3xJzBsZgvOB5zBsdjzuBYzBcczxVzBpIaHmTYsGHGPffcY3t/7tw5IyIiwsjKymqw/8svv2wEBQW1U3TurbVj9/zzzxv9+vUzrFZre4Xotlo7dj/09NNPG927dzcqKiqcFaLbau3Y3XPPPcZPfvKTem1paWnGNddc49Q43VFrxy48PNx49tln67XdeuutxsSJE50apztryURi1qxZxsCBA+u1jR8/3khOTnZiZGhIa3/nf/nLXxo/+9nP6rUlJCQYv/nNb5wapye50OfX2bNnje7duxuvvvqqs0L0KG0Zz7NnzxpXX3218eKLLxqTJ0/mDxQ/wPzU8Zh7OQ/zCvfBnMGxmC84HnMGx2PO4FjMF5yrveYMbD/lIaxWq3bu3KmkpCRbm7e3t5KSkrRt27ZGz6uoqFDv3r0VGRmpsWPH6vPPP2+PcN1KW8bu7bff1vDhw3XPPfcoLCxMV1xxhR5//HGdO3euvcJ2C239vfu+l156Sb/61a/UrVs3Z4XpltoydldffbV27txpW/Z44MABvfPOO0pJSWmXmN1FW8aupqbGbns9Pz8/bdmyxamxerpt27bVG2dJSk5ObvH/vuEYbfmd57trmiOeX1VVVaqtrdVFF13krDA9RlvHc/78+QoNDdXUqVPbI0yPwvzU8Zh7uR7PJudjzuBYzBccjzmD4zFncCzmC+7BEc+mLo4OCs5RWlqqc+fOKSwsrF57WFiY9u7d2+A5/fv314oVKxQbG6uysjL96U9/0tVXX63PP/9cl1xySXuE7RbaMnYHDhzQ+++/r4kTJ+qdd95RQUGB7r77btXW1mrOnDntEbZbaMvYfd8nn3yiPXv26KWXXnJWiG6rLWM3YcIElZaWasSIETIMQ2fPntWMGTP0hz/8oT1CdhttGbvk5GQtWrRIiYmJioqKUl5entavX8+krRnFxcUNjnN5ebnOnDkjPz8/F0XWubTld76x7664uNhpcXqSC31+SdJDDz2kiIgIu8l2Z9SW8dyyZYteeukl7d69ux0i9DzMTx2PuZfrMa9wPuYMjsV8wfGYMzgecwbHYr7gHhwxZ2ClRgc2fPhwTZo0SXFxcbr22mu1fv16hYSE6IUXXnB1aG6vrq5OoaGh+vOf/6whQ4Zo/Pjxevjhh5Wdne3q0DzKSy+9pEGDBmnYsGGuDsUjbNq0SY8//riee+45ffrpp1q/fr02btyoRx991NWhub0lS5YoOjpaMTExMplMuvfeezVlyhR5e/OYA9B6CxYs0Ouvv66//OUvdqvA0LzTp0/r9ttv1/Lly2WxWFwdTofB/NTxmHsBuBDMFy4ccwbnYM7gWMwX3BMrNTyExWKRj4+PSkpK6rWXlJSoZ8+eLbpG165dFR8fr4KCAmeE6LbaMnbh4eHq2rWrfHx8bG0DBgxQcXGxrFarTCaTU2N2Fxfye1dZWanXX39d8+fPd2aIbqstY/fII4/o9ttv15133ilJGjRokCorKzV9+nQ9/PDDneYP9G0Zu5CQEG3YsEHV1dU6ceKEIiIilJ6ern79+rVHyB6rZ8+eDY5zYGAg/5qyHbXld76x766lc4KO7kKeX3/605+0YMEC5ebmKjY21plheozWjmdhYaEOHTqkMWPG2Nrq6uokSV26dNG+ffsUFRXl3KDdHPNTx2Pu5XrMK5yPOYNjMV9wPOYMjsecwbGYL7gHR8wZGHUPYTKZNGTIEOXl5dna6urqlJeXp+HDh7foGufOndNnn32m8PBwZ4Xpltoydtdcc40KCgpsD1NJ+uqrrxQeHt6p/uN/Ib93b775pmpqanTbbbc5O0y31Jaxq6qqsnsYnp+EfFdrqXO4kN87s9msXr166ezZs1q3bp3Gjh3r7HA92vDhw+uNsyS99957LX6uwDHa8jvPd9e0tv535Mknn9Sjjz6qnJwcDR06tD1C9QitHc+YmBh99tln2r17t+1100036brrrtPu3bsVGRnZnuG7Jeanjsfcy/V4NjkfcwbHYr7geMwZHI85g2MxX3APDnk2ta5+OVzp9ddfN3x9fY1XXnnF+OKLL4zp06cbwcHBRnFxsWEYhnH77bcb6enptv7z5s0z3n33XaOwsNDYuXOn8atf/cowm83G559/7qqP4DKtHbuioiKje/fuxr333mvs27fP+Pvf/26EhoYaf/zjH131EVymtWN33ogRI4zx48e3d7hupbVjN2fOHKN79+7Ga6+9Zhw4cMD4xz/+YURFRRm//OUvXfURXKa1Y7d9+3Zj3bp1RmFhobF582bjJz/5idG3b1/j5MmTLvoErnH69Glj165dxq5duwxJxqJFi4xdu3YZhw8fNgzDMNLT043bb7/d1v/AgQOGv7+/8eCDDxpffvmlsWzZMsPHx8fIyclx1UfotFr7O//xxx8bXbp0Mf70pz8ZX375pTFnzhyja9euxmeffeaqj+B2WjumCxYsMEwmk/HWW28Zx44ds71Onz7tqo/gVto6Hzhv8uTJxtixY9spWs/A/NTxmHs5FvMK98ScwbGYLzgecwbHY87gWMwXHM8VcwaSGh5m6dKlxqWXXmqYTCZj2LBhxvbt223Hrr32WmPy5Mm297/73e9sfcPCwoyUlBTj008/dUHU7qE1Y2cYhrF161YjISHB8PX1Nfr162c89thjxtmzZ9s5avfQ2rHbu3evIcn4xz/+0c6Rup/WjF1tba0xd+5cIyoqyjCbzUZkZKRx9913d7o/zJ/XmrHbtGmTMWDAAMPX19e4+OKLjdtvv904cuSIC6J2rQ8++MCQZPc6P1aTJ082rr32Wrtz4uLiDJPJZPTr1894+eWX2z1ufKe1/6194403jMsvv9wwmUzGwIEDjY0bN7ZzxO6vNWPau3fvBv/3M2fOnPYP3E219nf0+/gDRcOYnzoecy/HYV7hvpgzOBbzBcdjzuB4zBkci/mCY7lizuBlGKyTAQAAAAAAAAAA7o+aGgAAAAAAAAAAwCOQ1AAAAAAAAAAAAB6BpAYAAAAAAAAAAPAIJDUAAAAAAAAAAIBHIKkBAAAAAAAAAAA8AkkNAAAAAAAAAADgEUhqAAAAAAAAAAAAj0BSAwAAAAAAAAAAeASSGgAa9Otf/1o333yzq8NoliPj3LRpk7y8vHTq1CmHXA8AAAAAAACAY5HUAAAHOnTokLy8vLR7925XhwIAAAAAAAB0OCQ1AMAFrFarq0MAAAAAAAAAPA5JDaADq6ur05NPPqnLLrtMvr6+uvTSS/XYY49Jkj777DP95Cc/kZ+fny6++GJNnz5dFRUVjV7rrbfe0qBBg2z9k5KSVFlZKUn65z//qZ/+9KeyWCwKCgrStddeq08//bTe+V5eXnrhhRf0P//zP/L399eAAQO0bds2FRQUaNSoUerWrZuuvvpqFRYW2s6ZO3eu4uLi9MILLygyMlL+/v765S9/qbKysiY/c1ZWlvr27Ss/Pz8NHjxYb731VqvG7eOPP1ZsbKzMZrN+/OMfa8+ePZKkyspKBQYG2l1vw4YN6tatm06fPq2+fftKkuLj4+Xl5aVRo0ZJ+u82WY899pgiIiLUv39/SdLXX3+tX/7ylwoODtZFF12ksWPH6tChQ/Wu/+KLL2rAgAEym82KiYnRc88916rPAwAAAAAAAHQUJDWADiwjI0MLFizQI488oi+++EJr1qxRWFiYKisrlZycrB49euif//yn3nzzTeXm5uree+9t8DrHjh1Tamqq7rjjDn355ZfatGmTbr31VhmGIUk6ffq0Jk+erC1btmj79u2Kjo5WSkqKTp8+Xe86jz76qCZNmqTdu3crJiZGEyZM0G9+8xtlZGToX//6lwzDsIuhoKBAb7zxhv72t78pJydHu3bt0t13393oZ87KytL//u//Kjs7W59//rlmzpyp2267TR9++GGLx+3BBx/UwoUL9c9//lMhISEaM2aMamtr1a1bN/3qV7/Syy+/XK//yy+/rJ///Ofq3r27PvnkE0lSbm6ujh07pvXr19v65eXlad++fXrvvff097//XbW1tUpOTlb37t310Ucf6eOPP1ZAQIBuuOEG20qO1atXa/bs2Xrsscf05Zdf6vHHH9cjjzyiV199tcWfBwAAAAAAAOgwDAAdUnl5ueHr62ssX77c7tif//xno0ePHkZFRYWtbePGjYa3t7dRXFxsGIZhTJ482Rg7dqxhGIaxc+dOQ5Jx6NChFt373LlzRvfu3Y2//e1vtjZJRmZmpu39tm3bDEnGSy+9ZGt77bXXDLPZbHs/Z84cw8fHx/jmm29sbf/v//0/w9vb2zh27JhdnNXV1Ya/v7+xdevWevFMnTrVSE1NbTbuDz74wJBkvP7667a2EydOGH5+fsbatWsNwzCMHTt2GD4+PsbRo0cNwzCMkpISo0uXLsamTZsMwzCMgwcPGpKMXbt21bv25MmTjbCwMKOmpsbWtnLlSqN///5GXV2dra2mpsbw8/Mz3n33XcMwDCMqKspYs2ZNvWs9+uijxvDhw5v9PAAAAAAAAEBHw0oNoIP68ssvVVNTo9GjRzd4bPDgwerWrZut7ZprrlFdXZ327dtn13/w4MEaPXq0Bg0apF/84hdavny5Tp48aTteUlKiadOmKTo6WkFBQQoMDFRFRYWKiorqXSc2Ntb2c1hYmCRp0KBB9dqqq6tVXl5ua7v00kvVq1cv2/vhw4c3GmdBQYGqqqr005/+VAEBAbbX//7v/9bb1qo5w4cPt/180UUXqX///vryyy8lScOGDdPAgQNtKyVWrVql3r17KzExsdnrDho0SCaTyfb+3//+twoKCtS9e3dbrBdddJGqq6tVWFioyspKFRYWaurUqfU+zx//+MdWfR4AAAAAAACgo+ji6gAAOIefn5/DruXj46P33ntPW7du1T/+8Q8tXbpUDz/8sHbs2KG+fftq8uTJOnHihJYsWaLevXvL19dXw4cPtyuG3bVrV9vPXl5ejbbV1dW1Kc7zNUE2btxYLxEiSb6+vm26ZkPuvPNOLVu2TOnp6Xr55Zc1ZcoUW+xN+X4S6Xy8Q4YM0erVq+36hoSE2D7P8uXLlZCQUO+4j4/PBXwCAAAAAAAAwDOxUgPooKKjo+Xn56e8vDy7YwMGDNC///1vW6Fv6bvi2N7e3rYC1j/k5eWla665RvPmzdOuXbtkMpn0l7/8xXbu/fffr5SUFA0cOFC+vr4qLS11yOcoKirS0aNHbe+3b9/eaJw/+tGP5Ovrq6KiIl122WX1XpGRkS2+5/bt220/nzx5Ul999ZUGDBhga7vtttt0+PBhPfPMM/riiy80efJk27HzKzHOnTvX7H2uvPJK7d+/X6GhoXbxBgUFKSwsTBERETpw4IDd8fMFyQEAAAAAAIDOhJUaQAdlNpv10EMPadasWTKZTLrmmmt0/Phxff7555o4caLmzJmjyZMna+7cuTp+/Ljuu+8+3X777bZtob5vx44dysvL0/XXX6/Q0FDt2LFDx48ft/2hPzo6WitXrtTQoUNVXl6uBx980GErRcxmsyZPnqw//elPKi8v1/33369f/vKX6tmzp13f7t2764EHHtDMmTNVV1enESNGqKysTB9//LECAwPrJR+aMn/+fF188cUKCwvTww8/LIvFoptvvtl2vEePHrr11lv14IMP6vrrr9cll1xiOxYaGio/Pz/l5OTokksukdlsVlBQUIP3mThxop566imNHTtW8+fP1yWXXKLDhw9r/fr1mjVrli655BLNmzdP999/v4KCgnTDDTeopqZG//rXv3Ty5EmlpaW1bjABAAAAAAAAD8dKDaADe+SRR/T73/9es2fP1oABAzR+/Hh9++238vf317vvvqv//Oc/uuqqq/Tzn/9co0eP1rPPPtvgdQIDA7V582alpKTo8ssvV2ZmphYuXKgbb7xRkvTSSy/p5MmTuvLKK3X77bfr/vvvV2hoqEM+w2WXXaZbb71VKSkpuv766xUbG6vnnnuu0f6PPvqoHnnkEWVlZWnAgAG64YYbtHHjxlatbFiwYIF++9vfasiQISouLtbf/va3erUwJGnq1KmyWq2644476rV36dJFzzzzjF544QVFRERo7Nixjd7H399fmzdv1qWXXqpbb71VAwYM0NSpU1VdXa3AwEBJ32119eKLL+rll1/WoEGDdO211+qVV15hpQYAAAAAAAA6JS/DMAxXBwEADZk7d642bNig3bt3uzoUOytXrtTMmTN19OhRu4QHAAAAAAAAAOdg+ykAaIWqqiodO3ZMCxYs0G9+8xsSGgAAAAAAAEA7YvspAJ3GjBkzFBAQ0OBrxowZLbrGk08+qZiYGPXs2VMZGRlOjhgAAAAAAADA97H9FIBO49tvv1V5eXmDxwIDAx1WBwQAAAAAAACAc5DUAAAAAAAAAAAAHoHtpwAAAAAAAAAAgEcgqQEAAAAAAAAAADwCSQ0AAAAAAAAAAOARSGoAAAAAAAAAAACPQFIDAAAAAAAAAAB4BJIaAAAAAAAAAADAI5DUAAAAAAAAAAAAHoGkBgAAAAAAAAAA8Aj/H0WjY9kcU44sAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1600x700 with 6 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "X_params = ['max_depth', 'reg_lambda', 'learning_rate',\t'colsample_bytree']\n",
+    "_, axes = plt.subplots(2, 3, figsize = (16, 7))\n",
+    "for i, ax in zip(X_params, axes.flatten()):\n",
+    "    sns.scatterplot(\n",
+    "        df_xgb_optuna.T.reset_index(0, drop=True).T, x = i, y = 'valid', ax = ax\n",
+    "    )\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: XGBoost Optuna scatter\n\n- max_depth: 3이 압도적 — depth 4~5는 AUC 하락\n- colsample_bytree: 0.5~0.55 구간에 최적값 집중 → 하한을 낮춰 재탐색 필요\n- learning_rate: 0.02~0.03 사이가 최적 구간\n- reg_lambda: 0.01~0.1 사이에서 큰 영향 없음"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 229,
+   "id": "dae6a4e3-80f8-44b1-b12b-d6132afd0332",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m[I 2026-02-24 09:24:56,291]\u001b[0m Trial 49 finished with value: 0.9553012803537798 and parameters: {'learning_rate': 0.01625805151783346, 'num_leaves': 29, 'reg_lambda': 0.023221374039833792, 'colsample_bytree': 0.2652499788407333}. Best is trial 25 with value: 0.9553062428752077.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best Score: 0.9553062428752077\n",
+      "Best Params: {'learning_rate': 0.020607186297884036, 'num_leaves': 20, 'reg_lambda': 0.004425590641361036, 'colsample_bytree': 0.26515689156693767}\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.add_collector(\n",
+    "    ModelAttrCollector('lgb_evals_results', Connector(processor=lgb.LGBMClassifier), 'evals_result')\n",
+    ")\n",
+    "\n",
+    "# XGB는 GPU를 사용해서\n",
+    "e_aml.set_grp('lgb_optuna', parent='lgb', params={'n_estimators': 10000})\n",
+    "def objective(trial):\n",
+    "    trial_number = trial.number\n",
+    "    node_name = f'lgb_optuna_{trial_number}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='lgb_optuna',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={\n",
+    "            \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.01, 0.03),\n",
+    "            \"num_leaves\": trial.suggest_int(\"num_leaves\", 7, 31),\n",
+    "            \"reg_lambda\": trial.suggest_float(\"reg_lambda\", 1e-3, 10, log=True),\n",
+    "            \"colsample_bytree\": trial.suggest_float(\"colsample_bytree\", 0.25, 1.0), \n",
+    "        }\n",
+    "    )\n",
+    "    e_aml.exp(node_name)\n",
+    "    e_aml.finalize(node_name)\n",
+    "    clear_output()\n",
+    "    return e_aml.collectors['AUC'].get_metrics_agg(node_name)[0].iloc[0]['valid']\n",
+    "\n",
+    "# Study 생성 및 최적화\n",
+    "study = optuna.create_study(direction=\"maximize\")\n",
+    "study.optimize(objective, n_trials=50)\n",
+    "\n",
+    "print(\"Best Score:\", study.best_value)\n",
+    "print(\"Best Params:\", study.best_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## LightGBM Optuna 탐색\n\n탐색 범위: num_leaves(10~50), learning_rate(0.01~0.05), reg_lambda(1e-3~10), colsample_bytree(0.1~1.0)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 234,
+   "id": "bd03671c-252a-423c-b5e7-41c790edd968",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"4\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "      <th>evals_result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>colsample_bytree</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>num_leaves</th>\n",
+       "      <th>reg_lambda</th>\n",
+       "      <th>valid</th>\n",
+       "      <th>best_iteration</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_25</th>\n",
+       "      <td>0.265157</td>\n",
+       "      <td>0.020607</td>\n",
+       "      <td>20</td>\n",
+       "      <td>0.004426</td>\n",
+       "      <td>0.955306</td>\n",
+       "      <td>2366.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_16</th>\n",
+       "      <td>0.309949</td>\n",
+       "      <td>0.029977</td>\n",
+       "      <td>13</td>\n",
+       "      <td>0.001037</td>\n",
+       "      <td>0.955302</td>\n",
+       "      <td>1904.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_49</th>\n",
+       "      <td>0.265250</td>\n",
+       "      <td>0.016258</td>\n",
+       "      <td>29</td>\n",
+       "      <td>0.023221</td>\n",
+       "      <td>0.955301</td>\n",
+       "      <td>2549.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_10</th>\n",
+       "      <td>0.257306</td>\n",
+       "      <td>0.021063</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.014671</td>\n",
+       "      <td>0.955300</td>\n",
+       "      <td>4645.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_4</th>\n",
+       "      <td>0.381874</td>\n",
+       "      <td>0.010577</td>\n",
+       "      <td>15</td>\n",
+       "      <td>0.001079</td>\n",
+       "      <td>0.955299</td>\n",
+       "      <td>4048.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_26</th>\n",
+       "      <td>0.254640</td>\n",
+       "      <td>0.019921</td>\n",
+       "      <td>22</td>\n",
+       "      <td>0.005080</td>\n",
+       "      <td>0.955298</td>\n",
+       "      <td>2186.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_41</th>\n",
+       "      <td>0.256415</td>\n",
+       "      <td>0.016966</td>\n",
+       "      <td>22</td>\n",
+       "      <td>0.005691</td>\n",
+       "      <td>0.955295</td>\n",
+       "      <td>2545.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_0</th>\n",
+       "      <td>0.321682</td>\n",
+       "      <td>0.027439</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.419266</td>\n",
+       "      <td>0.955294</td>\n",
+       "      <td>2361.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_21</th>\n",
+       "      <td>0.349007</td>\n",
+       "      <td>0.011092</td>\n",
+       "      <td>14</td>\n",
+       "      <td>0.001381</td>\n",
+       "      <td>0.955292</td>\n",
+       "      <td>3818.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_18</th>\n",
+       "      <td>0.312863</td>\n",
+       "      <td>0.029824</td>\n",
+       "      <td>12</td>\n",
+       "      <td>0.007258</td>\n",
+       "      <td>0.955292</td>\n",
+       "      <td>1882.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        params                                           AUC  \\\n",
+       "              colsample_bytree learning_rate num_leaves reg_lambda     valid   \n",
+       "lgb_optuna_25         0.265157      0.020607         20   0.004426  0.955306   \n",
+       "lgb_optuna_16         0.309949      0.029977         13   0.001037  0.955302   \n",
+       "lgb_optuna_49         0.265250      0.016258         29   0.023221  0.955301   \n",
+       "lgb_optuna_10         0.257306      0.021063          7   0.014671  0.955300   \n",
+       "lgb_optuna_4          0.381874      0.010577         15   0.001079  0.955299   \n",
+       "lgb_optuna_26         0.254640      0.019921         22   0.005080  0.955298   \n",
+       "lgb_optuna_41         0.256415      0.016966         22   0.005691  0.955295   \n",
+       "lgb_optuna_0          0.321682      0.027439         10   0.419266  0.955294   \n",
+       "lgb_optuna_21         0.349007      0.011092         14   0.001381  0.955292   \n",
+       "lgb_optuna_18         0.312863      0.029824         12   0.007258  0.955292   \n",
+       "\n",
+       "                evals_result  \n",
+       "              best_iteration  \n",
+       "lgb_optuna_25         2366.0  \n",
+       "lgb_optuna_16         1904.0  \n",
+       "lgb_optuna_49         2549.0  \n",
+       "lgb_optuna_10         4645.0  \n",
+       "lgb_optuna_4          4048.0  \n",
+       "lgb_optuna_26         2186.0  \n",
+       "lgb_optuna_41         2545.0  \n",
+       "lgb_optuna_0          2361.0  \n",
+       "lgb_optuna_21         3818.0  \n",
+       "lgb_optuna_18         1882.0  "
+      ]
+     },
+     "execution_count": 234,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['lgb_evals_results'].get_attrs('lgb_optuna.*')\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('valid_0', 'auc')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "df_lgb_optuna =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('lgb_optuna.*')\n",
+    ")['LGBMClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'lgb_optuna.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").join(\n",
+    "    s_best_iteration\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_lgb_optuna.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: LightGBM Optuna 결과\n\n| Best 파라미터 | 값 |\n|---|---|\n| learning_rate | 0.021 |\n| num_leaves | 20 |\n| reg_lambda | 0.004 |\n| colsample_bytree | 0.265 |\n| best valid AUC | **0.955306** |\n\n- num_leaves=20은 depth=3~4에 상당, 트리 모델 공통으로 얕은 tree가 유리\n- colsample_bytree가 CB rsm과 유사하게 0.25~0.31 저수준에서 최적\n- XGB(0.9554) > LGB(0.9553) 미세 차이 — 최종 파라미터로 확정"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abe2e779-5f65-4e02-ab3e-0ab78399cfed",
+   "metadata": {},
+   "source": [
+    "- XGB의 colsample_bytree의 하한선은 너무 높게 잡은 듯하여, 하한선을 낮추어 실험을 구성 ('max_depth': 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "id": "c08596a8-9e8c-4d02-850e-a12aa139759b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m[I 2026-02-24 09:35:51,432]\u001b[0m Trial 49 finished with value: 0.9553754363816049 and parameters: {'learning_rate': 0.01578776719819734, 'reg_lambda': 0.004487310407416835, 'colsample_bytree': 0.349221344981771}. Best is trial 13 with value: 0.9553767977260723.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best Score: 0.9553767977260723\n",
+      "Best Params: {'learning_rate': 0.01825416966680926, 'reg_lambda': 0.007033391681411446, 'colsample_bytree': 0.35062791656003417}\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.set_grp('xgb_optuna2', parent='xgb', params={'n_estimators': 10000, 'tree_method': 'hist', 'device': 'cuda', 'max_depth': 3})\n",
+    "def objective(trial):\n",
+    "    trial_number = trial.number\n",
+    "    node_name = f'xgb_optun2a_{trial_number}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='xgb_optuna2',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={\n",
+    "            \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.01, 0.03),\n",
+    "            \"reg_lambda\": trial.suggest_float(\"reg_lambda\", 1e-3, 1, log=True),\n",
+    "            \"colsample_bytree\": trial.suggest_float(\"colsample_bytree\", 0.25, 0.75), \n",
+    "        }\n",
+    "    )\n",
+    "    e_aml.exp(node_name)\n",
+    "    e_aml.finalize(node_name)\n",
+    "    clear_output()\n",
+    "    return e_aml.collectors['AUC'].get_metrics_agg(node_name)[0].iloc[0]['valid']\n",
+    "\n",
+    "# Study 생성 및 최적화\n",
+    "study = optuna.create_study(direction=\"maximize\")\n",
+    "study.optimize(objective, n_trials=50)\n",
+    "\n",
+    "print(\"Best Score:\", study.best_value)\n",
+    "print(\"Best Params:\", study.best_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "id": "b56d028e-cd31-4c1e-86d1-9b36b715fd11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"3\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "      <th>evals_result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>colsample_bytree</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>reg_lambda</th>\n",
+       "      <th>valid</th>\n",
+       "      <th>best_iteration</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_13</th>\n",
+       "      <td>0.350628</td>\n",
+       "      <td>0.018254</td>\n",
+       "      <td>0.007033</td>\n",
+       "      <td>0.955377</td>\n",
+       "      <td>5103.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_9</th>\n",
+       "      <td>0.382289</td>\n",
+       "      <td>0.019680</td>\n",
+       "      <td>0.001721</td>\n",
+       "      <td>0.955376</td>\n",
+       "      <td>4572.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_49</th>\n",
+       "      <td>0.349221</td>\n",
+       "      <td>0.015788</td>\n",
+       "      <td>0.004487</td>\n",
+       "      <td>0.955375</td>\n",
+       "      <td>5680.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_45</th>\n",
+       "      <td>0.369971</td>\n",
+       "      <td>0.019972</td>\n",
+       "      <td>0.001740</td>\n",
+       "      <td>0.955375</td>\n",
+       "      <td>4412.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_26</th>\n",
+       "      <td>0.358798</td>\n",
+       "      <td>0.023905</td>\n",
+       "      <td>0.003608</td>\n",
+       "      <td>0.955371</td>\n",
+       "      <td>3459.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_11</th>\n",
+       "      <td>0.406340</td>\n",
+       "      <td>0.020946</td>\n",
+       "      <td>0.007659</td>\n",
+       "      <td>0.955370</td>\n",
+       "      <td>4180.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_42</th>\n",
+       "      <td>0.250061</td>\n",
+       "      <td>0.023700</td>\n",
+       "      <td>0.001069</td>\n",
+       "      <td>0.955370</td>\n",
+       "      <td>5004.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_40</th>\n",
+       "      <td>0.332319</td>\n",
+       "      <td>0.022305</td>\n",
+       "      <td>0.001057</td>\n",
+       "      <td>0.955370</td>\n",
+       "      <td>4013.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_48</th>\n",
+       "      <td>0.412466</td>\n",
+       "      <td>0.020077</td>\n",
+       "      <td>0.001806</td>\n",
+       "      <td>0.955369</td>\n",
+       "      <td>4630.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_12</th>\n",
+       "      <td>0.362170</td>\n",
+       "      <td>0.019553</td>\n",
+       "      <td>0.006012</td>\n",
+       "      <td>0.955366</td>\n",
+       "      <td>4499.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         params                                AUC  \\\n",
+       "               colsample_bytree learning_rate reg_lambda     valid   \n",
+       "xgb_optun2a_13         0.350628      0.018254   0.007033  0.955377   \n",
+       "xgb_optun2a_9          0.382289      0.019680   0.001721  0.955376   \n",
+       "xgb_optun2a_49         0.349221      0.015788   0.004487  0.955375   \n",
+       "xgb_optun2a_45         0.369971      0.019972   0.001740  0.955375   \n",
+       "xgb_optun2a_26         0.358798      0.023905   0.003608  0.955371   \n",
+       "xgb_optun2a_11         0.406340      0.020946   0.007659  0.955370   \n",
+       "xgb_optun2a_42         0.250061      0.023700   0.001069  0.955370   \n",
+       "xgb_optun2a_40         0.332319      0.022305   0.001057  0.955370   \n",
+       "xgb_optun2a_48         0.412466      0.020077   0.001806  0.955369   \n",
+       "xgb_optun2a_12         0.362170      0.019553   0.006012  0.955366   \n",
+       "\n",
+       "                 evals_result  \n",
+       "               best_iteration  \n",
+       "xgb_optun2a_13         5103.0  \n",
+       "xgb_optun2a_9          4572.0  \n",
+       "xgb_optun2a_49         5680.0  \n",
+       "xgb_optun2a_45         4412.0  \n",
+       "xgb_optun2a_26         3459.0  \n",
+       "xgb_optun2a_11         4180.0  \n",
+       "xgb_optun2a_42         5004.0  \n",
+       "xgb_optun2a_40         4013.0  \n",
+       "xgb_optun2a_48         4630.0  \n",
+       "xgb_optun2a_12         4499.0  "
+      ]
+     },
+     "execution_count": 236,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['xgb_evals_results'].get_attrs('xgb_optun2a.*')\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation_0', 'auc')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "df_xgb_optuna =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('xgb_optun2a.*')\n",
+    ")['XGBClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'xgb_optun2a.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").join(\n",
+    "    s_best_iteration\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_xgb_optuna.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: XGBoost Optuna2 (colsample 하한 확대)\n\n| 노드 | colsample_bytree | learning_rate | AUC |\n|------|-----------------|--------------|-----|\n| xgb_optun2a_13 (best) | 0.351 | 0.018 | **0.955377** |\n| xgb_optun2a_9 | 0.382 | 0.020 | 0.955376 |\n\n- colsample 하한을 0.5→0.1로 낮춰도 최적값은 0.35 수준에 수렴\n- XGB 최종 파라미터: max_depth=3, lr≈0.018, reg_lambda≈0.007, colsample≈0.35"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## CatBoost Optuna 재탐색 (high lr 구간)\n\n`cb_optuna2` 결과에서 최적 lr=0.042로 1차 탐색 상한(0.015)을 크게 초과.\n높은 lr 구간(0.03~0.2)에서 rsm과의 조합 재탐색. depth=3, l2_leaf_reg=1.5 고정."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 246,
+   "id": "944ad402-9d98-49f2-8909-9137b532ad62",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m[I 2026-02-24 09:52:01,608]\u001b[0m Trial 19 finished with value: 0.9553203168926013 and parameters: {'learning_rate': 0.07517509655120061, 'rsm': 0.8023958790777355}. Best is trial 11 with value: 0.9553572838062382.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best Score: 0.9553572838062382\n",
+      "Best Params: {'learning_rate': 0.12146937969142849, 'rsm': 0.9784832693721128}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def objective(trial):\n",
+    "    trial_number = trial.number\n",
+    "    node_name = f'cb_optuna3_{trial_number}'\n",
+    "    e_aml.set_node(\n",
+    "        node_name, grp='cb_optuna2',\n",
+    "        edges={'X': [(None, X_all)]},\n",
+    "        params={\n",
+    "            \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.03, 0.2),\n",
+    "            \"rsm\": trial.suggest_float(\"rsm\", 0.25, 1.0), \n",
+    "        }\n",
+    "    )\n",
+    "    e_aml.exp(node_name)\n",
+    "    e_aml.finalize(node_name)\n",
+    "    clear_output()\n",
+    "    return e_aml.collectors['AUC'].get_metrics_agg(node_name)[0].iloc[0]['valid']\n",
+    "\n",
+    "# Study 생성 및 최적화\n",
+    "study = optuna.create_study(direction=\"maximize\")\n",
+    "study.optimize(objective, n_trials=20)\n",
+    "\n",
+    "print(\"Best Score:\", study.best_value)\n",
+    "print(\"Best Params:\", study.best_params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 249,
+   "id": "b9098b16-a42c-470b-863a-af78dc7d152a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"7\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "      <th>evals_result</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>border_count</th>\n",
+       "      <th>depth</th>\n",
+       "      <th>l2_leaf_reg</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>max_depth</th>\n",
+       "      <th>rsm</th>\n",
+       "      <th>subsample</th>\n",
+       "      <th>valid</th>\n",
+       "      <th>best_iteration</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_11</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.121469</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.978483</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955357</td>\n",
+       "      <td>1248.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_rsm_0.75</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.750000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955354</td>\n",
+       "      <td>3175.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_border_count_511</th>\n",
+       "      <td>511.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.750000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955354</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_9</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.102742</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.723387</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955350</td>\n",
+       "      <td>1520.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_7</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.097888</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.989288</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955344</td>\n",
+       "      <td>1319.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_6</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.058160</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.995987</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955344</td>\n",
+       "      <td>2376.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_8</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.156202</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.731636</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955340</td>\n",
+       "      <td>1007.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_12</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.128234</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.790169</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955339</td>\n",
+       "      <td>1211.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_4</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.042117</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.813875</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955338</td>\n",
+       "      <td>3134.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna3_13</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.112958</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.871323</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.955338</td>\n",
+       "      <td>1122.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          params                                            \\\n",
+       "                    border_count depth l2_leaf_reg learning_rate max_depth   \n",
+       "cb_optuna3_11                NaN   NaN         NaN      0.121469       3.0   \n",
+       "cb_rsm_0.75                  NaN   3.0         NaN      0.050000       NaN   \n",
+       "cb_border_count_511        511.0   3.0         NaN      0.050000       NaN   \n",
+       "cb_optuna3_9                 NaN   NaN         NaN      0.102742       3.0   \n",
+       "cb_optuna3_7                 NaN   NaN         NaN      0.097888       3.0   \n",
+       "cb_optuna3_6                 NaN   NaN         NaN      0.058160       3.0   \n",
+       "cb_optuna3_8                 NaN   NaN         NaN      0.156202       3.0   \n",
+       "cb_optuna3_12                NaN   NaN         NaN      0.128234       3.0   \n",
+       "cb_optuna2_4                 NaN   NaN         NaN      0.042117       3.0   \n",
+       "cb_optuna3_13                NaN   NaN         NaN      0.112958       3.0   \n",
+       "\n",
+       "                                              AUC   evals_result  \n",
+       "                          rsm subsample     valid best_iteration  \n",
+       "cb_optuna3_11        0.978483       NaN  0.955357         1248.0  \n",
+       "cb_rsm_0.75          0.750000       NaN  0.955354         3175.0  \n",
+       "cb_border_count_511  0.750000       NaN  0.955354            NaN  \n",
+       "cb_optuna3_9         0.723387       NaN  0.955350         1520.0  \n",
+       "cb_optuna3_7         0.989288       NaN  0.955344         1319.0  \n",
+       "cb_optuna3_6         0.995987       NaN  0.955344         2376.0  \n",
+       "cb_optuna3_8         0.731636       NaN  0.955340         1007.0  \n",
+       "cb_optuna3_12        0.790169       NaN  0.955339         1211.0  \n",
+       "cb_optuna2_4         0.813875       NaN  0.955338         3134.0  \n",
+       "cb_optuna3_13        0.871323       NaN  0.955338         1122.0  "
+      ]
+     },
+     "execution_count": 249,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = e_aml.collectors['cb_evals_results'].get_attrs('cb_.*')\n",
+    "s_best_iteration = pd.Series({\n",
+    "    k: np.mean(\n",
+    "        [[j.unstack().unstack()[('validation', 'AUC')].argmax() for j in i] for i in v]\n",
+    "    )\n",
+    "    for k, v in d.items()\n",
+    "}, name=('evals_result', 'best_iteration'))\n",
+    "df_cb_optuna2 =e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('cb_.*')\n",
+    ")['CatBoostClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "        'cb_.*'\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").join(\n",
+    "    s_best_iteration\n",
+    ").sort_values(('AUC', 'valid'), ascending=False)\n",
+    "df_cb_optuna2.iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03d219c-03d9-4b0a-9c82-f77134238a36",
+   "metadata": {},
+   "source": [
+    "### Experment Result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 271,
+   "id": "18817e22-3349-4e02-988f-bf0f612bae89",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"6\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>categorical_feature</th>\n",
+       "      <th>colsample_bytree</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>n_estimators</th>\n",
+       "      <th>num_leaves</th>\n",
+       "      <th>reg_lambda</th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_25</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.265157</td>\n",
+       "      <td>0.020607</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>0.004426</td>\n",
+       "      <td>0.955306</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_16</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.309949</td>\n",
+       "      <td>0.029977</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>0.001037</td>\n",
+       "      <td>0.955302</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_49</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.265250</td>\n",
+       "      <td>0.016258</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>0.023221</td>\n",
+       "      <td>0.955301</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_10</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.257306</td>\n",
+       "      <td>0.021063</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>0.014671</td>\n",
+       "      <td>0.955300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_4</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.381874</td>\n",
+       "      <td>0.010577</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>15.0</td>\n",
+       "      <td>0.001079</td>\n",
+       "      <td>0.955299</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_26</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.254640</td>\n",
+       "      <td>0.019921</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>22.0</td>\n",
+       "      <td>0.005080</td>\n",
+       "      <td>0.955298</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_41</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.256415</td>\n",
+       "      <td>0.016966</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>22.0</td>\n",
+       "      <td>0.005691</td>\n",
+       "      <td>0.955295</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_0</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.321682</td>\n",
+       "      <td>0.027439</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>0.419266</td>\n",
+       "      <td>0.955294</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_21</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.349007</td>\n",
+       "      <td>0.011092</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>0.001381</td>\n",
+       "      <td>0.955292</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb_optuna_18</th>\n",
+       "      <td>None</td>\n",
+       "      <td>0.312863</td>\n",
+       "      <td>0.029824</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.007258</td>\n",
+       "      <td>0.955292</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           params                                              \\\n",
+       "              categorical_feature colsample_bytree learning_rate n_estimators   \n",
+       "lgb_optuna_25                None         0.265157      0.020607        10000   \n",
+       "lgb_optuna_16                None         0.309949      0.029977        10000   \n",
+       "lgb_optuna_49                None         0.265250      0.016258        10000   \n",
+       "lgb_optuna_10                None         0.257306      0.021063        10000   \n",
+       "lgb_optuna_4                 None         0.381874      0.010577        10000   \n",
+       "lgb_optuna_26                None         0.254640      0.019921        10000   \n",
+       "lgb_optuna_41                None         0.256415      0.016966        10000   \n",
+       "lgb_optuna_0                 None         0.321682      0.027439        10000   \n",
+       "lgb_optuna_21                None         0.349007      0.011092        10000   \n",
+       "lgb_optuna_18                None         0.312863      0.029824        10000   \n",
+       "\n",
+       "                                          AUC  \n",
+       "              num_leaves reg_lambda     valid  \n",
+       "lgb_optuna_25       20.0   0.004426  0.955306  \n",
+       "lgb_optuna_16       13.0   0.001037  0.955302  \n",
+       "lgb_optuna_49       29.0   0.023221  0.955301  \n",
+       "lgb_optuna_10        7.0   0.014671  0.955300  \n",
+       "lgb_optuna_4        15.0   0.001079  0.955299  \n",
+       "lgb_optuna_26       22.0   0.005080  0.955298  \n",
+       "lgb_optuna_41       22.0   0.005691  0.955295  \n",
+       "lgb_optuna_0        10.0   0.419266  0.955294  \n",
+       "lgb_optuna_21       14.0   0.001381  0.955292  \n",
+       "lgb_optuna_18       12.0   0.007258  0.955292  "
+      ]
+     },
+     "execution_count": 271,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('.*')\n",
+    ")['LGBMClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").sort_values(('AUC', 'valid'), ascending=False).iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 245,
+   "id": "5deca7d7-26ef-43d6-b66c-156f8c5b15a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"7\" halign=\"left\">params</th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>colsample_bytree</th>\n",
+       "      <th>device</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>max_depth</th>\n",
+       "      <th>n_estimators</th>\n",
+       "      <th>reg_lambda</th>\n",
+       "      <th>tree_method</th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_13</th>\n",
+       "      <td>0.350628</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.018254</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.007033</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955377</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_9</th>\n",
+       "      <td>0.382289</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.019680</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.001721</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955376</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_49</th>\n",
+       "      <td>0.349221</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.015788</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.004487</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955375</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_45</th>\n",
+       "      <td>0.369971</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.019972</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.001740</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955375</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_26</th>\n",
+       "      <td>0.358798</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.023905</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.003608</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955371</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_11</th>\n",
+       "      <td>0.406340</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.020946</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.007659</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955370</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_42</th>\n",
+       "      <td>0.250061</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.023700</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.001069</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955370</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_40</th>\n",
+       "      <td>0.332319</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.022305</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.001057</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955370</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_48</th>\n",
+       "      <td>0.412466</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.020077</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.001806</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955369</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>xgb_optun2a_12</th>\n",
+       "      <td>0.362170</td>\n",
+       "      <td>cuda</td>\n",
+       "      <td>0.019553</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>0.006012</td>\n",
+       "      <td>hist</td>\n",
+       "      <td>0.955366</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         params                                              \\\n",
+       "               colsample_bytree device learning_rate max_depth n_estimators   \n",
+       "xgb_optun2a_13         0.350628   cuda      0.018254       3.0        10000   \n",
+       "xgb_optun2a_9          0.382289   cuda      0.019680       3.0        10000   \n",
+       "xgb_optun2a_49         0.349221   cuda      0.015788       3.0        10000   \n",
+       "xgb_optun2a_45         0.369971   cuda      0.019972       3.0        10000   \n",
+       "xgb_optun2a_26         0.358798   cuda      0.023905       3.0        10000   \n",
+       "xgb_optun2a_11         0.406340   cuda      0.020946       3.0        10000   \n",
+       "xgb_optun2a_42         0.250061   cuda      0.023700       3.0        10000   \n",
+       "xgb_optun2a_40         0.332319   cuda      0.022305       3.0        10000   \n",
+       "xgb_optun2a_48         0.412466   cuda      0.020077       3.0        10000   \n",
+       "xgb_optun2a_12         0.362170   cuda      0.019553       3.0        10000   \n",
+       "\n",
+       "                                            AUC  \n",
+       "               reg_lambda tree_method     valid  \n",
+       "xgb_optun2a_13   0.007033        hist  0.955377  \n",
+       "xgb_optun2a_9    0.001721        hist  0.955376  \n",
+       "xgb_optun2a_49   0.004487        hist  0.955375  \n",
+       "xgb_optun2a_45   0.001740        hist  0.955375  \n",
+       "xgb_optun2a_26   0.003608        hist  0.955371  \n",
+       "xgb_optun2a_11   0.007659        hist  0.955370  \n",
+       "xgb_optun2a_42   0.001069        hist  0.955370  \n",
+       "xgb_optun2a_40   0.001057        hist  0.955370  \n",
+       "xgb_optun2a_48   0.001806        hist  0.955369  \n",
+       "xgb_optun2a_12   0.006012        hist  0.955366  "
+      ]
+     },
+     "execution_count": 245,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('.*')\n",
+    ")['XGBClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").sort_values(('AUC', 'valid'), ascending=False).iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 244,
+   "id": "f2a5d078-651a-4057-9fdc-5859a9b2b28a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"10\" halign=\"left\">params</th>\n",
+       "      <th>X</th>\n",
+       "      <th>AUC</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>border_count</th>\n",
+       "      <th>cat_features</th>\n",
+       "      <th>depth</th>\n",
+       "      <th>iterations</th>\n",
+       "      <th>l2_leaf_reg</th>\n",
+       "      <th>learning_rate</th>\n",
+       "      <th>max_depth</th>\n",
+       "      <th>rsm</th>\n",
+       "      <th>subsample</th>\n",
+       "      <th>verbose</th>\n",
+       "      <th>DataSource [Age, BP, Cholesterol, Exercise angina, FBS over 120, Max HR, ST depression, Sex]</th>\n",
+       "      <th>valid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>cb_border_count_511</th>\n",
+       "      <td>511.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.750000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955354</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_rsm_0.75</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.750000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955354</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_4</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.042117</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.813875</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955338</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_2</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.020167</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.582808</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955336</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_12</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.019405</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.665371</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955335</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_subsample_0.5</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955334</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_8</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.039595</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.957362</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_19</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.028572</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.725664</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955332</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_max_depth_3</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.050000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955331</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb_optuna2_1</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.023846</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.760800</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[Chest pain type, EKG results, Number of vesse...</td>\n",
+       "      <td>0.955329</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          params                                            \\\n",
+       "                    border_count cat_features depth iterations l2_leaf_reg   \n",
+       "cb_border_count_511        511.0         None   3.0      10000         NaN   \n",
+       "cb_rsm_0.75                  NaN         None   3.0      10000         NaN   \n",
+       "cb_optuna2_4                 NaN         None   NaN      10000         NaN   \n",
+       "cb_optuna2_2                 NaN         None   NaN      10000         NaN   \n",
+       "cb_optuna2_12                NaN         None   NaN      10000         NaN   \n",
+       "cb_subsample_0.5             NaN         None   3.0      10000         NaN   \n",
+       "cb_optuna2_8                 NaN         None   NaN      10000         NaN   \n",
+       "cb_optuna2_19                NaN         None   NaN      10000         NaN   \n",
+       "cb_max_depth_3               NaN         None   3.0      10000         NaN   \n",
+       "cb_optuna2_1                 NaN         None   NaN      10000         NaN   \n",
+       "\n",
+       "                                                                         \\\n",
+       "                    learning_rate max_depth       rsm subsample verbose   \n",
+       "cb_border_count_511      0.050000       NaN  0.750000       NaN       0   \n",
+       "cb_rsm_0.75              0.050000       NaN  0.750000       NaN       0   \n",
+       "cb_optuna2_4             0.042117       3.0  0.813875       NaN       0   \n",
+       "cb_optuna2_2             0.020167       3.0  0.582808       NaN       0   \n",
+       "cb_optuna2_12            0.019405       3.0  0.665371       NaN       0   \n",
+       "cb_subsample_0.5         0.050000       NaN       NaN       0.5       0   \n",
+       "cb_optuna2_8             0.039595       3.0  0.957362       NaN       0   \n",
+       "cb_optuna2_19            0.028572       3.0  0.725664       NaN       0   \n",
+       "cb_max_depth_3           0.050000       NaN       NaN       NaN       0   \n",
+       "cb_optuna2_1             0.023846       3.0  0.760800       NaN       0   \n",
+       "\n",
+       "                                                                                                               X  \\\n",
+       "                    DataSource [Age, BP, Cholesterol, Exercise angina, FBS over 120, Max HR, ST depression, Sex]   \n",
+       "cb_border_count_511  [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_rsm_0.75          [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_optuna2_4         [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_optuna2_2         [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_optuna2_12        [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_subsample_0.5     [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_optuna2_8         [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_optuna2_19        [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_max_depth_3       [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "cb_optuna2_1         [Chest pain type, EKG results, Number of vesse...                                             \n",
+       "\n",
+       "                          AUC  \n",
+       "                        valid  \n",
+       "cb_border_count_511  0.955354  \n",
+       "cb_rsm_0.75          0.955354  \n",
+       "cb_optuna2_4         0.955338  \n",
+       "cb_optuna2_2         0.955336  \n",
+       "cb_optuna2_12        0.955335  \n",
+       "cb_subsample_0.5     0.955334  \n",
+       "cb_optuna2_8         0.955333  \n",
+       "cb_optuna2_19        0.955332  \n",
+       "cb_max_depth_3       0.955331  \n",
+       "cb_optuna2_1         0.955329  "
+      ]
+     },
+     "execution_count": 244,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_aml.pipeline.compare_nodes(\n",
+    "    e_aml.pipeline.get_node_names('.*')\n",
+    ")['CatBoostClassifier'].join(\n",
+    "    e_aml.collectors['AUC'].get_metrics_agg(\n",
+    "    )[0][['valid']].stack().rename('AUC').to_frame().unstack()\n",
+    ").sort_values(('AUC', 'valid'), ascending=False).iloc[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 250,
+   "id": "402eed12-6364-49d6-84f8-c0d925cb0b5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finalize 'lbl'\n",
+      "Finalize 'ohe'\n",
+      "Finalize 'std'\n",
+      "Finalize 'n2c'\n",
+      "Finalize 'lgb1'\n",
+      "Finalize 'lr1'\n",
+      "Finalize 'cb1'\n",
+      "Finalize 'xgb1'\n",
+      "Finalize 'cont_inter'\n",
+      "Finalize 'freq_st'\n",
+      "Finalize 'cat_pair'\n",
+      "Finalize 'xgb_all_fe'\n",
+      "Finalize 'xgb_cat'\n",
+      "Finalize 'xgb_cont'\n",
+      "Finalize 'xgb_freq'\n",
+      "Finalize 'lgb_cat'\n",
+      "Finalize 'lgb_all_fe'\n",
+      "Finalize 'cb2'\n",
+      "Finalize 'ohe_pair'\n",
+      "Finalize 'lr2'\n",
+      "Finalize 'std_cont_inter'\n",
+      "Finalize 'lr3'\n",
+      "Finalize 'te_pair'\n",
+      "Finalize 'lr4'\n",
+      "Finalize 'lr5'\n",
+      "Finalize 'lr6'\n",
+      "Finalize 'cb_optuna_33'\n",
+      "Finalize 'cb3'\n",
+      "Finalize 'cb4'\n",
+      "Finalize 'cb_rsm_0.75'\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_aml.close_exp()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6121565d-6952-4ba2-8e8e-2a4ee26414c4",
+   "metadata": {},
+   "source": [
+    "# Modeling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**모델 구성 기준:**\n- HP 튜닝 결과를 반영한 최종 파라미터로 xgb1, lgb1, cb1 재구성\n- StratifiedKFold(5) 적용 — target 불균형(55:45) 대응\n- StackingCollector 추가 → OOF 예측값 수집, stacking 실험용\n- lr2(선형)도 앙상블 다양성을 위해 포함 (FE 분석에서 best LR 모델)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ec30dc65-d58c-4fac-a4b7-0a6efde361fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded: 10 node(s), 6 group(s), 5 fold(s)\n",
+      "Building 0 node(s)\n",
+      "Build 5/5 (100%)> Node 0\n",
+      "Build complete: 0 node(s)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'result': 'skip',\n",
+       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f7f1a8c5cd0>,\n",
+       " 'affected_nodes': []}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.model_selection import StratifiedKFold\n",
+    "if os.path.exists('exp/modeling'):\n",
+    "    e_modeling = Experimenter.load('exp/modeling', df_train)\n",
+    "    if e_modeling.status == 'closed':\n",
+    "        e_modeling.reopen_exp()\n",
+    "else:\n",
+    "    e_modeling = Experimenter.create(\n",
+    "        df_train, 'exp/modeling', title='모델링을 ML 실험',\n",
+    "        sp=StratifiedKFold(n_splits=5, random_state=1, shuffle=True),\n",
+    "        splitter_params={'y': target}\n",
+    "    )\n",
+    "Markdown(\n",
+    "    e_modeling.desc_spec()\n",
+    ")\n",
+    "\n",
+    "e_modeling.set_grp('pre', role='stage', method='transform')\n",
+    "e_modeling.set_node(\n",
+    "    'lbl', grp='pre', processor=LabelEncoder,\n",
+    "    edges={'y': [(None, target)]}\n",
+    ")\n",
+    "e_modeling.build()\n",
+    "e_modeling.set_grp(\n",
+    "    'clf', role='head', method='predict_proba',\n",
+    "    edges={'y': [('lbl', None)]}\n",
+    ")\n",
+    "# XGBoost\n",
+    "e_modeling.set_grp('xgb', parent='clf', processor=xgb.XGBClassifier,\n",
+    "    adapter=XGBoostAdapter(eval_mode='valid'),\n",
+    "    params={\n",
+    "        'tree_method': 'hist', 'device': 'cuda',\n",
+    "        'enable_categorical': True,\n",
+    "        'verbosity': 0,\n",
+    "        'random_state': 1,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# LightGBM\n",
+    "e_modeling.set_grp('lgb', parent='clf', processor=lgb.LGBMClassifier,\n",
+    "    adapter=LightGBMAdapter(eval_mode='valid'),\n",
+    "    params={\n",
+    "        'verbose': -1,\n",
+    "        'random_state': 1,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# CatBoost\n",
+    "e_modeling.set_grp('cb', parent='clf', processor=cb.CatBoostClassifier,\n",
+    "    adapter=CatBoostAdapter(eval_mode='valid'),\n",
+    "    params={\n",
+    "        'verbose': 0,\n",
+    "        'random_state': 1,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# LogisticRegression (coef 분석용)\n",
+    "e_modeling.set_grp('lr', parent='clf', processor=LogisticRegression,\n",
+    "    params={\n",
+    "        'max_iter': 1000,\n",
+    "        'random_state': 1,\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6ffd5a00-6996-4e9e-9233-304615e1bffc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'result': 'skip',\n",
+       " 'affected_nodes': [],\n",
+       " 'old_obj': <mllabs._pipeline.PipelineNode at 0x7f7f1a8c5310>,\n",
+       " 'obj': <mllabs._pipeline.PipelineNode at 0x7f7f1a8c5310>}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from mllabs.collector import StackingCollector\n",
+    "e_modeling.add_collector(\n",
+    "    MetricCollector(\n",
+    "        'AUC',\n",
+    "        Connector(edges={'y': [('lbl', None)]}),\n",
+    "        slice(-1, None),\n",
+    "        roc_auc_score,\n",
+    "        include_train = True\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "e_modeling.add_collector(\n",
+    "    StackingCollector(\n",
+    "        'stacking', Connector(edges={'y': [('lbl', None)]}),\n",
+    "        slice(-1, None), method='mean', experimenter = e_modeling\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "e_modeling.set_node(\n",
+    "    'ohe', grp='pre', processor=OneHotEncoder,\n",
+    "    edges={'X': [(None, X_nom + X_ord)]},\n",
+    "    params={'sparse_output': False}\n",
+    ")\n",
+    "\n",
+    "e_modeling.set_node(\n",
+    "    'std', grp='pre', processor=StandardScaler,\n",
+    "    edges={'X': [(None, X_cont)]}\n",
+    ")\n",
+    "\n",
+    "e_modeling.set_node(\n",
+    "    'cat_pair', grp='pre', processor=CatPairCombiner,\n",
+    "    edges={'X': [(None, X_nom + X_bin)]},\n",
+    "    params={\n",
+    "        'pairs': [\n",
+    "            ('Thallium', 'Chest pain type'),\n",
+    "            ('Chest pain type', 'Exercise angina'),\n",
+    "            ('Thallium', 'Exercise angina'),\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "e_modeling.set_node(\n",
+    "    'cont_inter', grp='pre', processor=PolynomialFeatures,\n",
+    "    edges={'X': [(None, ['Age', 'Cholesterol', 'Max HR'])]},\n",
+    "    params={'degree': 2, 'include_bias': False, 'interaction_only': True}\n",
+    ")\n",
+    "e_modeling.set_node('ohe_pair', processor = OneHotEncoder, grp='pre', edges={'X': [('cat_pair', None)]}, params={'sparse_output': False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "5bf66e43-91ec-4ed0-9067-40ddff46427f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 0 node(s)\n",
+      "Exp 5/5 (100%)> Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_modeling.set_node(\n",
+    "    'xgb1', grp='xgb', edges={'X': [(None, X_all)]}, \n",
+    "    params = {'colsample_bytree': 0.35, 'learning_rate': 0.018254, 'max_depth': 3,  'reg_lambda': 0.007033, 'n_estimators': 5100}\n",
+    ")\n",
+    "e_modeling.set_node(\n",
+    "    'cb1', grp='cb', edges={'X': [(None, X_all)]},\n",
+    "    params = {'max_depth': 3, 'learning_rate': 0.042117, 'rsm': 0.75, 'n_estimators': 3200}\n",
+    ")\n",
+    "e_modeling.set_node(\n",
+    "    'lgb1', grp='lgb', edges={'X': [(None, X_all)]},\n",
+    "    params = {'colsample_bytree': 0.265157, 'learning_rate': 0.020607, 'num_leaves': 20, 'reg_lambda': 0.004426, 'n_estimators': 2400}\n",
+    ")\n",
+    "e_modeling.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2a9e1853-61c1-442b-a33f-f571e8196a3d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Building 0 node(s)\n",
+      "Build 5/5 (100%)> Node 0\n",
+      "Build complete: 0 node(s)\n",
+      "Experimenting 0 node(s)\n",
+      "Exp 5/5 (100%)> Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_modeling.set_node(\n",
+    "    'lr2', grp='lr', edges = {'X': [('std', None), (None, X_bin), ('ohe', ohe_drop_first), ('ohe_pair', ohe_drop_first)]}, \n",
+    ")\n",
+    "e_modeling.build()\n",
+    "e_modeling.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "79704e43-17a4-4ff2-8d97-d2d9ac376431",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>xgb1</th>\n",
+       "      <td>0.955628</td>\n",
+       "      <td>0.956272</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lgb1</th>\n",
+       "      <td>0.955590</td>\n",
+       "      <td>0.956647</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb1</th>\n",
+       "      <td>0.955554</td>\n",
+       "      <td>0.956179</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.952929</td>\n",
+       "      <td>0.952947</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         valid  train_sub\n",
+       "xgb1  0.955628   0.956272\n",
+       "lgb1  0.955590   0.956647\n",
+       "cb1   0.955554   0.956179\n",
+       "lr2   0.952929   0.952947"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_modeling.collectors['AUC'].get_metrics_agg()[0].sort_values('valid', ascending = False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: 최종 모델 성능\n\n| 모델 | valid AUC |\n|------|----------|\n| xgb1 (HP 튜닝 적용) | **0.955628** |\n| lgb1 (HP 튜닝 적용) | 0.955590 |\n| cb1 (HP 튜닝 적용) | 0.955554 |\n| lr2 | 0.952929 |\n\n- HP 튜닝 후 모든 트리 모델이 e_aml 대비 소폭 상승 (0.9549→0.9556)\n- xgb1이 근소하게 1위, 세 트리 모델이 거의 동급\n- lr2는 다양성 목적으로 stacking에 포함 (단독 성능은 하위)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6af3b0d0-f3ff-4fb1-a50f-252571ab4716",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<mllabs._trainer.Trainer at 0x7f7f1a94fb30>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_modeling.add_trainer('trainer')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3d00924-f2d2-454f-baf8-c4f715a10062",
+   "metadata": {},
+   "source": [
+    "# Stacking"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "`StackingCollector`가 CV 과정에서 각 fold의 out-of-fold 예측값을 수집.\nvalid fold 예측값을 train index에 맞춰 재조합하면 leakage 없는 stacking 피처 생성.\n이를 새 Experimenter(`e_stacking`)의 입력으로 활용하여 앙상블 조합 탐색."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "68f7ad7c-e85e-4bd8-935c-6e013b8801be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>xgb1__Heart Disease_1</th>\n",
+       "      <th>lgb1__Heart Disease_1</th>\n",
+       "      <th>lr2__Heart Disease_1</th>\n",
+       "      <th>cb1__Heart Disease_1</th>\n",
+       "      <th>Heart Disease</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.997452</td>\n",
+       "      <td>0.997422</td>\n",
+       "      <td>0.997146</td>\n",
+       "      <td>0.997866</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.009248</td>\n",
+       "      <td>0.009643</td>\n",
+       "      <td>0.015919</td>\n",
+       "      <td>0.008130</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.009843</td>\n",
+       "      <td>0.010390</td>\n",
+       "      <td>0.017949</td>\n",
+       "      <td>0.009044</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.049203</td>\n",
+       "      <td>0.057194</td>\n",
+       "      <td>0.051042</td>\n",
+       "      <td>0.049295</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.997664</td>\n",
+       "      <td>0.997301</td>\n",
+       "      <td>0.997770</td>\n",
+       "      <td>0.998165</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    xgb1__Heart Disease_1  lgb1__Heart Disease_1  lr2__Heart Disease_1  \\\n",
+       "id                                                                       \n",
+       "0                0.997452               0.997422              0.997146   \n",
+       "1                0.009248               0.009643              0.015919   \n",
+       "2                0.009843               0.010390              0.017949   \n",
+       "3                0.049203               0.057194              0.051042   \n",
+       "4                0.997664               0.997301              0.997770   \n",
+       "\n",
+       "    cb1__Heart Disease_1  Heart Disease  \n",
+       "id                                       \n",
+       "0               0.997866              1  \n",
+       "1               0.008130              0  \n",
+       "2               0.009044              0  \n",
+       "3               0.049295              0  \n",
+       "4               0.998165              1  "
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_stacking = e_modeling.collectors['stacking'].get_dataset().sort_index()\n",
+    "df_stacking.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "3e05f315-7e2b-4a0c-919a-26a34a08ddaa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded: 4 node(s), 2 group(s), 5 fold(s)\n",
+      "Building 0 node(s)\n",
+      "Build 5/5 (100%)> Node 0\n",
+      "Build complete: 0 node(s)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'result': 'skip',\n",
+       " 'grp': <mllabs._pipeline.PipelineGroup at 0x7f7f19d17ef0>,\n",
+       " 'affected_nodes': []}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "if os.path.exists('exp/stacking'):\n",
+    "    e_stacking = Experimenter.load('exp/stacking', df_stacking)\n",
+    "    if e_stacking.status == 'closed':\n",
+    "        e_stacking.reopen_exp()\n",
+    "else:\n",
+    "    e_stacking = Experimenter.create(\n",
+    "        df_stacking, 'exp/stacking', title='Stacking을 ML 실험',\n",
+    "        sp=StratifiedKFold(n_splits=5, random_state=1, shuffle=True),\n",
+    "        splitter_params={'y': target}\n",
+    "    )\n",
+    "\n",
+    "e_stacking.add_collector(\n",
+    "    MetricCollector(\n",
+    "        'AUC',\n",
+    "        Connector(edges={'y': [(None, target)]}),\n",
+    "        slice(-1, None),\n",
+    "        roc_auc_score,\n",
+    "        include_train = True\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "e_stacking.set_grp('pre', role='stage', method='transform')\n",
+    "e_stacking.build()\n",
+    "e_stacking.set_grp(\n",
+    "    'clf', role='head', method='predict_proba',\n",
+    "    edges={'y': [(None, target)]}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "8d2115ef-7c15-4f21-9806-5c272fdd2ef7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['xgb1__Heart Disease_1',\n",
+       " 'lgb1__Heart Disease_1',\n",
+       " 'lr2__Heart Disease_1',\n",
+       " 'cb1__Heart Disease_1']"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_stk = [i for i in df_stacking.columns if i != target]\n",
+    "X_stk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9ce05925-d1d1-4a5c-8f4d-d5a070a369d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 0 node(s)\n",
+      "Exp 5/5 (100%)> Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_stacking.set_node('lr', processor=LogisticRegression, grp='clf', edges={'X': [(None, X_stk)]})\n",
+    "e_stacking.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "366a70b3-7fbb-4e76-8878-60f70fe0b73d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 0 node(s)\n",
+      "Exp 5/5 (100%)> Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_stacking.set_node('lr2', processor=LogisticRegression, grp='clf', edges={'X': [(None, ['xgb1__Heart Disease_1','lgb1__Heart Disease_1'])]})\n",
+    "e_stacking.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "19a75d24-d0dc-416a-b300-e949498328c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lr</th>\n",
+       "      <td>0.955622</td>\n",
+       "      <td>0.955618</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.955630</td>\n",
+       "      <td>0.955626</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr3</th>\n",
+       "      <td>0.955626</td>\n",
+       "      <td>0.955622</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr4</th>\n",
+       "      <td>0.955620</td>\n",
+       "      <td>0.955617</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        valid  train_sub\n",
+       "lr   0.955622   0.955618\n",
+       "lr2  0.955630   0.955626\n",
+       "lr3  0.955626   0.955622\n",
+       "lr4  0.955620   0.955617"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_stacking.collectors['AUC'].get_metrics_agg()[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "4d90914d-552d-443b-8de5-ac58e915aaad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 0 node(s)\n",
+      "Exp 5/5 (100%)> Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_stacking.set_node('lr3', processor=LogisticRegression, grp='clf', edges={'X': [(None, ['xgb1__Heart Disease_1','lgb1__Heart Disease_1','cb1__Heart Disease_1'])]})\n",
+    "e_stacking.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "50115772-4cf3-4902-844a-a77b2fbe983a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lr</th>\n",
+       "      <td>0.955622</td>\n",
+       "      <td>0.955618</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.955630</td>\n",
+       "      <td>0.955626</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr3</th>\n",
+       "      <td>0.955626</td>\n",
+       "      <td>0.955622</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr4</th>\n",
+       "      <td>0.955620</td>\n",
+       "      <td>0.955617</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        valid  train_sub\n",
+       "lr   0.955622   0.955618\n",
+       "lr2  0.955630   0.955626\n",
+       "lr3  0.955626   0.955622\n",
+       "lr4  0.955620   0.955617"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_stacking.collectors['AUC'].get_metrics_agg()[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "461367ea-0d8d-4914-bf9e-8da389f797ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experimenting 0 node(s)\n",
+      "Exp 5/5 (100%)> Node 0\n",
+      "Experimentation complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_stacking.set_node('lr4', processor=LogisticRegression, grp='clf', edges={'X': [(None, ['xgb1__Heart Disease_1','lgb1__Heart Disease_1','lr2__Heart Disease_1'])]})\n",
+    "e_stacking.exp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "baadc4bb-61e6-46d5-ba40-a9a9af895f10",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>valid</th>\n",
+       "      <th>train_sub</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>lr2</th>\n",
+       "      <td>0.955630</td>\n",
+       "      <td>0.955626</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr3</th>\n",
+       "      <td>0.955626</td>\n",
+       "      <td>0.955622</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr</th>\n",
+       "      <td>0.955622</td>\n",
+       "      <td>0.955618</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>lr4</th>\n",
+       "      <td>0.955620</td>\n",
+       "      <td>0.955617</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        valid  train_sub\n",
+       "lr2  0.955630   0.955626\n",
+       "lr3  0.955626   0.955622\n",
+       "lr   0.955622   0.955618\n",
+       "lr4  0.955620   0.955617"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e_stacking.collectors['AUC'].get_metrics_agg()[0].sort_values('valid', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 분석: Stacking 앙상블 결론\n\n| 조합 | valid AUC |\n|------|----------|\n| lr2 (xgb+lgb) | **0.955630** |\n| lr3 (xgb+lgb+cb) | 0.955626 |\n| lr (전체 4모델) | 0.955622 |\n| lr4 (xgb+lgb+lr2) | 0.955620 |\n\n- xgb+lgb 조합(lr2)이 cb, lr2 추가 시보다 미세하게 우위\n- cb1은 이미 유사한 패턴을 학습해 다양성 기여가 낮음\n- lr2(선형 모델)는 트리와 이미 다른 패턴이지만 스태킹 레벨에서 노이즈로 작용\n- 스태킹 자체 개선폭(0.9556→0.9556)이 미미 — 단일 최고 모델과 사실상 동급"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "95c58589-3fbb-4456-8efa-60dc0550b41f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lr2 1/1 (100%) Split 1/1 (100%)\n",
+      "Train complete: 1 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_stacking.add_trainer('trainer')\n",
+    "e_stacking.trainers['trainer'].select_head(['lr2'])\n",
+    "e_stacking.trainers['trainer'].train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "ca1004d4-9a3a-460b-9e44-cb44a42c0059",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train 0\n",
+      "Train complete: 0 node(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_modeling.add_trainer('trainer')\n",
+    "e_modeling.trainers['trainer'].select_head(['xgb1', 'lgb1'])\n",
+    "e_modeling.trainers['trainer'].train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "37d135b4-5d57-4bb4-9503-3001cac11a2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>xgb1__Heart Disease_1</th>\n",
+       "      <th>lgb1__Heart Disease_1</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>630000</th>\n",
+       "      <td>0.949196</td>\n",
+       "      <td>0.937161</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>630001</th>\n",
+       "      <td>0.009064</td>\n",
+       "      <td>0.009210</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>630002</th>\n",
+       "      <td>0.989547</td>\n",
+       "      <td>0.989905</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>630003</th>\n",
+       "      <td>0.004408</td>\n",
+       "      <td>0.004102</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>630004</th>\n",
+       "      <td>0.197181</td>\n",
+       "      <td>0.186887</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>899995</th>\n",
+       "      <td>0.152214</td>\n",
+       "      <td>0.150060</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>899996</th>\n",
+       "      <td>0.687932</td>\n",
+       "      <td>0.673724</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>899997</th>\n",
+       "      <td>0.047882</td>\n",
+       "      <td>0.048240</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>899998</th>\n",
+       "      <td>0.190882</td>\n",
+       "      <td>0.180921</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>899999</th>\n",
+       "      <td>0.027061</td>\n",
+       "      <td>0.028756</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>270000 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        xgb1__Heart Disease_1  lgb1__Heart Disease_1\n",
+       "id                                                  \n",
+       "630000               0.949196               0.937161\n",
+       "630001               0.009064               0.009210\n",
+       "630002               0.989547               0.989905\n",
+       "630003               0.004408               0.004102\n",
+       "630004               0.197181               0.186887\n",
+       "...                       ...                    ...\n",
+       "899995               0.152214               0.150060\n",
+       "899996               0.687932               0.673724\n",
+       "899997               0.047882               0.048240\n",
+       "899998               0.190882               0.180921\n",
+       "899999               0.027061               0.028756\n",
+       "\n",
+       "[270000 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next(e_modeling.trainers['trainer'].process(df_test, slice(-1, None))).data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Inference 파이프라인\n\n`e_modeling.trainers['trainer'].process(df_test)`로 test 데이터에 xgb1, lgb1 예측값 생성 →\n`e_stacking.trainers['trainer'].process(...)`로 stacking lr2 통과 → 최종 확률값 산출.\n두 Trainer가 체이닝되어 end-to-end inference를 구성."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "fe24f133-4728-4575-ab5d-0c77fdb1e283",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_result = next(e_stacking.trainers['trainer'].process(\n",
+    "    next(e_modeling.trainers['trainer'].process(df_test, slice(-1, None))).data, slice(-1, None)\n",
+    ")).data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "916111a7-35e0-456c-a6d0-06366dcdd289",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_result.iloc[:, -1].rename(target).to_csv('data/submission0.csv')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8216b3a5-f5f0-4517-a652-ea557538e3c4",
+   "id": "d0be9cea-0e99-4251-840e-2618bcf09d90",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# !kaggle competitions submit -c playground-series-s6e2 -f data/submission0.csv -m \"Test\""
+   ]
   }
  ],
  "metadata": {

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -427,6 +427,7 @@ class Experimenter():
             node_obj.start_build()
         
         n_splits = self.get_n_splits()
+        self.logger.clear_progress()
         self.logger.start_progress("Build", n_splits)
         for i in range(n_splits):
             self.logger.update_progress(i)
@@ -476,7 +477,7 @@ class Experimenter():
             node = self.pipeline.get_node(i)
             grp = self.pipeline.get_grp(node.grp)
             if grp.role == 'head' and i in node_names:
-                if i not in self.node_objs or self.node_objs[i].status != 'built':
+                if i not in self.node_objs or self.node_objs[i].status not in ['built', 'finalized']:
                     target_nodes.append(i)
 
         self.logger.info(f"Experimenting {len(target_nodes)} node(s)")
@@ -507,6 +508,7 @@ class Experimenter():
 
         # experiment loop
         n_splits = self.get_n_splits()
+        self.logger.clear_progress()
         self.logger.start_progress("Exp", n_splits)
         for i in range(n_splits):
             self.logger.update_progress(i)

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -438,7 +438,7 @@ class Pipeline:
         attrs = grp.get_attrs(self.grps)
         new_edges = attrs['edges']
         affected_nodes = self._get_all_nodes_in_grp(grp)
-
+        self.grps[name] = grp
         if len(new_edges) > 0 or len(affected_nodes) > 0:
             for node_name in affected_nodes:
                 if node_name not in self.nodes:
@@ -459,9 +459,9 @@ class Pipeline:
                 has_cycle, cycle_edges = self._check_cycle(node_name, final_edges)
                 if has_cycle:
                     cycle_info = ", ".join([f"'{e}'" for e in cycle_edges])
+                    self.grps[name] = old_grp
                     raise ValueError(f"Cannot update group '{name}': node '{node_name}' would create cycle through edge(s) {cycle_info}")
 
-        self.grps[name] = grp
         return {
             "result": "update", "affected_nodes": affected_nodes, "old_grp": old_grp, "grp": grp
         }

--- a/mllabs/collector/_metric.py
+++ b/mllabs/collector/_metric.py
@@ -116,8 +116,8 @@ class MetricCollector(Collector):
             else:
                 df_agg_std = None
             if outer_fold:
-                df_agg_mean = df_agg_mean.stack(level=0, future_stack=True).groupby(level=0).mean()
                 if include_std:
-                    df_agg_std = df_agg_std.stack(level=0, future_stack=True).groupby(level=0).mean()
+                    df_agg_std = df_agg_mean.stack(level=0, future_stack=True).groupby(level=0).std()
+                df_agg_mean = df_agg_mean.stack(level=0, future_stack=True).groupby(level=0).mean()
             return df_agg_mean, df_agg_std
         return df


### PR DESCRIPTION
Closes #40

## Summary
- Complete `examples/kaggle_s6e2/Heart.ipynb` end-to-end notebook
  - HP tuning: depth/lr/rsm/subsample/border_count sweeps + Optuna (CB/XGB/LGB)
  - Modeling: final model with tuned params + StackingCollector OOF
  - Stacking: ensemble via e_stacking + Trainer/Inferencer chaining → submission
  - 31 analysis markdown cells added throughout

## Bug fixes (found during notebook authoring)

- **`_experimenter.py`**: add `clear_progress()` before `start_progress()` in `build()`/`exp()` to prevent duplicate progress bar on rerun; exclude `'finalized'` nodes from `exp()` target list
- **`_pipeline.py`**: `set_grp` replace mode rolls back to `old_grp` on cycle detection, preventing corrupt pipeline state
- **`_trainer.py`**: `_get_process_data` returns `None` when `'X'` key absent in edges (X-less nodes); `process()` skips `None` output correctly
- **`collector/_metric.py`**: `get_metrics_agg` std computation runs only when both `outer_fold` and `include_std` are set