### PR TITLE
refactor: encapsulate collectors/trainers dicts with get/remove methods

### DIFF
--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -155,13 +155,21 @@ class Experimenter():
     def get_n_splits_inner(self):
         return len(self.train_idx_list[0])
 
+    def get_collector(self, name):
+        return self.collectors.get(name)
+
+    def remove_collector(self, name):
+        if name in self.collectors:
+            del self.collectors[name]
+            self._save()
+
     def add_collector(self, collector, exist = 'skip'):
         if collector.name in self.collectors:
             if exist == 'skip':
                 return self.collectors[collector.name]
             elif exist == 'error':
                 raise RuntimeError("")
-        
+
         self._check_open()
         collector.path = self.path / '__collector' / collector.name
         collector.save()
@@ -169,6 +177,14 @@ class Experimenter():
         self.collect(collector)
         self._save()
         return collector
+
+    def get_trainer(self, name):
+        return self.trainers.get(name)
+
+    def remove_trainer(self, name):
+        if name in self.trainers:
+            del self.trainers[name]
+            self._save()
 
     def add_trainer(self, name, data=None, splitter="same", splitter_params=None, exist='skip'):
         if name in self.trainers:

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -535,8 +535,8 @@ class TestCollectorWithExperimenter:
         path = built_exp.path
 
         loaded = Experimenter.load(path, sample_data)
-        assert 'acc' in loaded.collectors
-        loaded_mc = loaded.collectors['acc']
+        assert loaded.get_collector('acc') is not None
+        loaded_mc = loaded.get_collector('acc')
         assert loaded_mc.has('dt')
         result_orig = mc.get_metric('dt')
         result_loaded = loaded_mc.get_metric('dt')

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -278,7 +278,7 @@ class TestCollectorManagement:
                             output_var=None,
                             metric_func=dummy_metric)
         exp.add_collector(mc)
-        assert 'acc' in exp.collectors
+        assert exp.get_collector('acc') is not None
         assert mc.path is not None
 
     def test_add_collector_skip(self, exp):
@@ -453,7 +453,7 @@ class TestStateManagement:
         assert loaded.status == 'open'
         loaded.exp()
 
-        mc2 = list(loaded.collectors.values())[0]
+        mc2 = loaded.get_collector('acc')
         assert mc2.has('dt')
         second_result = mc2.get_metrics_agg(None)[0]
         assert second_result.shape == first_result.shape

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -208,7 +208,7 @@ class TestSaveLoad:
         path = exp.path
 
         loaded_exp = Experimenter.load(path, sample_data)
-        loaded_trainer = loaded_exp.trainers['t1']
+        loaded_trainer = loaded_exp.get_trainer('t1')
         assert loaded_trainer.name == 't1'
         assert set(loaded_trainer.selected_stages) == set(trainer.selected_stages)
         assert set(loaded_trainer.selected_heads) == set(trainer.selected_heads)


### PR DESCRIPTION
Closes #65

## Changes

- Add `get_collector(name)`, `remove_collector(name)` to `Experimenter`
- Add `get_trainer(name)`, `remove_trainer(name)` to `Experimenter`
- Replace direct `collectors`/`trainers` dict access in tests with new methods