### PR TITLE
docs: write concepts section

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,34 @@
+# Architecture
+
+ml-labs is composed of four core modules, each with a distinct responsibility.
+
+```
+Pipeline ──────── defines the node graph (structure)
+    │
+Experimenter ──── executes builds and experiments (single dataset)
+    │
+Trainer ────────── trains with cross-validation splits
+    │
+Inferencer ─────── applies trained processors to new data
+```
+
+## Pipeline
+
+`Pipeline` is a directed graph of nodes that describes the ML workflow structure — which processors exist, how they connect, and what parameters they use. It holds no data and performs no computation. It is the blueprint that `Experimenter` and `Trainer` read.
+
+## Experimenter
+
+`Experimenter` takes a `Pipeline` and a dataset, then executes the graph node by node. It manages:
+
+- **Build** (`build()`): runs Stage nodes (transformers)
+- **Experiment** (`exp()`): runs Head nodes (predictors)
+- **Collectors**: pluggable objects that capture metrics, outputs, SHAP values, or stacking data during execution
+- **Cache**: LRU cache (capacity-based) to avoid recomputing Stage outputs
+
+## Trainer
+
+`Trainer` handles cross-validation. It splits data using a `splitter`, then runs each node across all splits. Stage outputs are kept in memory; Head outputs are written to disk per split. The result can be converted to an `Inferencer` via `to_inferencer()`.
+
+## Inferencer
+
+`Inferencer` holds the fitted processors produced by `Trainer`. Given new data, it runs each split's processors and aggregates the results (`mean`, `mode`, or a custom callable).

--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -1,0 +1,55 @@
+# Data Flow
+
+## Overview
+
+Data moves through the pipeline from DataSource → Stage → Head, assembled at each node according to its `edges` definition.
+
+```
+DataSource
+    │
+    ▼
+Stage A  ──►  Stage B
+                 │
+                 ▼
+              Head C
+```
+
+When `Head C` runs, its `edges` are resolved by pulling columns from `DataSource` and/or the outputs of `Stage A`, `Stage B`.
+
+## data_dict Structure
+
+Each node receives a `data_dict` — a dict mapping edge keys to data.
+
+### In Experimenter
+
+```python
+data_dict = {
+    'X': ((X_train, X_train_v), X_valid),
+    'y': ((y_train, y_train_v), y_valid),
+}
+```
+
+- `train`: full training fold data
+- `train_v`: training fold filtered by `output_var` (for inner validation)
+- `valid`: validation fold data
+
+### In Trainer
+
+```python
+data_dict = {
+    'X': (X_train, X_valid),
+    'y': (y_train, y_valid),
+}
+```
+
+No inner fold — data is split once by the `splitter`.
+
+## Cache
+
+`Experimenter` uses an LRU cache (capacity-based, default 4 GB) to store Stage outputs. When a Stage node's output is requested by multiple downstream nodes, it is computed once and reused from cache.
+
+`Trainer` shares the same cache instance with its parent `Experimenter`, using `"train_all"` as the type key to avoid collisions.
+
+## X-less Nodes
+
+If a node's `edges` contains only `'y'` and no `'X'` (e.g. `LabelEncoder`), the `'y'` data is used as the primary input. The processor receives the y array directly, and its output becomes the new y columns.

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -1,0 +1,44 @@
+# Pipeline
+
+A `Pipeline` is a node graph that describes the structure of an ML workflow.
+
+## Roles
+
+Every node has one of three roles:
+
+| Role | Class | Purpose |
+|------|-------|---------|
+| **DataSource** | *(implicit)* | The original input data. Not a real node — represented as `None` in edges. |
+| **Stage** | `TransformProcessor` | Transforms data and passes it downstream. Stays alive to supply data to child nodes. |
+| **Head** | `PredictProcessor` | Consumes transformed data and produces predictions. Terminal node. |
+
+## Nodes and Groups
+
+A **node** is the unit of execution. Each node has:
+
+- `processor`: the class that does the work (e.g. `StandardScaler`, `LGBMClassifier`)
+- `edges`: which upstream nodes supply which variables
+- `method`: method name to call on the processor
+- `adapter`: optional wrapper that translates data and params to framework conventions
+- `params`: constructor parameters for the processor
+
+A **group** (`PipelineGroup`) lets multiple nodes share configuration. Node attributes override group attributes; group attributes override parent group attributes.
+
+## edges
+
+`edges` defines what data a node receives and from where.
+
+```python
+edges = {
+    'X': [(None, ['feature1', 'feature2']),   # from DataSource
+           ('stage1', None)],                  # all columns from stage1
+    'y': [(None, 'target')],
+}
+```
+
+- Keys name variable sets (`'X'`, `'y'`, `'sample_weight'`, …)
+- Each value is a list of `(node_name, var_spec)` pairs
+  - `node_name=None` means DataSource
+  - `var_spec`: `None` (all columns), `str`, `list`, or `callable`
+- Multiple entries for the same key are concatenated column-wise
+- Child nodes inherit and extend parent group edges

--- a/docs/concepts/state-model.md
+++ b/docs/concepts/state-model.md
@@ -1,0 +1,47 @@
+# State Model
+
+## Node States (4-State)
+
+Each node in an `Experimenter` or `Trainer` tracks its own state.
+
+```
+init ──► built ──► finalized
+  ▲
+  │
+error ──► (reset) ──► init
+```
+
+| State | Disk | Memory | Description |
+|-------|------|--------|-------------|
+| **init** | — | — | Defined in Pipeline, not yet executed |
+| **built** | ✓ | Stage: ✓ / Head: ✗ | Execution complete; results are accessible |
+| **finalized** | ✗ | ✗ | Results extracted, resources released (Head only) |
+| **error** | — | error info | Exception occurred; error details are preserved |
+
+**Stage nodes cannot be finalized** — they must remain available to supply data to downstream nodes.
+
+If an upstream Stage is in `error` state, downstream nodes naturally fail without any explicit propagation logic.
+
+## State Transitions
+
+| Method | Transition |
+|--------|------------|
+| `build(nodes)` | `init → built` (Stage) |
+| `exp(nodes)` | `init → built` (Head) |
+| `finalize()` | `built → finalized` (Head only) |
+| `reset_nodes(nodes)` | any → `init` |
+
+## Experiment States (2-State)
+
+At the `Experimenter` level, an experiment session is either **open** or **closed**.
+
+```
+open ──► closed
+```
+
+| State | Stage objects | Collector data |
+|-------|--------------|----------------|
+| **open** | Kept in memory | Kept |
+| **closed** | Released | Kept |
+
+Call `close_exp()` to transition from open to closed. This releases all Stage processor objects while preserving any data collected by Collectors.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,10 @@ nav:
   - Home: index.md
   - Concepts:
     - concepts/index.md
+    - concepts/architecture.md
+    - concepts/pipeline.md
+    - concepts/state-model.md
+    - concepts/data-flow.md
   - User Guide:
     - guide/pipeline-experimenter.md
     - guide/trainer-collectors.md


### PR DESCRIPTION
## Summary

- Add `architecture.md`: module overview and relationships (Pipeline, Experimenter, Trainer, Inferencer)
- Add `pipeline.md`: Node/Group/edges concepts, DataSource/Stage/Head roles
- Add `state-model.md`: Node 4-State, Experiment 2-State, state transition table
- Add `data-flow.md`: data_dict structure (Experimenter vs Trainer), cache, X-less nodes
- Update `mkdocs.yml` nav to include new pages

Closes #34