### PR TITLE
docs: write user guide (Adapters & Processors)

### DIFF
--- a/docs/guide/adapters-processors.md
+++ b/docs/guide/adapters-processors.md
@@ -1,3 +1,0 @@
-# Adapters & Processors
-
-*Coming soon.*

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -1,0 +1,125 @@
+# Adapters
+
+Adapters bridge the gap between ml-labs' unified interface and each ML framework's specific `fit()` parameter conventions (e.g., `eval_set`, `validation_data`, callbacks).
+
+## Adapter Interface
+
+All adapters extend `ModelAdapter` and may implement three members:
+
+### get_params(params, logger)
+
+Adjusts or filters constructor parameters before the model is instantiated. The default implementation returns `params` unchanged.
+
+LightGBM example — strips `early_stopping` and `eval_metric` from constructor params (they belong in `fit()`):
+
+```python
+def get_params(self, params, logger=None):
+    return {k: v for k, v in params.items() if k not in ['early_stopping', 'eval_metric']}
+```
+
+### get_fit_params(data_dict, params, logger)
+
+Builds the keyword arguments passed to `model.fit()`. Receives a `data_dict` with `(train, train_v)` tuples per key.
+
+Behaviour is controlled by two constructor parameters shared by all adapters:
+
+| Parameter | Values | Effect |
+|-----------|--------|--------|
+| `eval_mode` | `'none'`/`None` | No eval set |
+| | `'valid'` | Pass inner-validation fold only |
+| | `'both'` | Pass both train and inner-validation fold |
+| `verbose` | `0` | Silent |
+| | `0 < v < 1` | Progress every `v*100`% of estimators |
+| | `v >= 1` | Every `v` iterations (framework-native) |
+
+### result_objs
+
+A class-level dict of extractable model attributes used by `ModelAttrCollector`:
+
+```python
+result_objs = {
+    'feature_importances': (get_importance_fn, True),   # (callable, mergeable)
+    'trees':               (get_trees_fn,       False),
+}
+```
+
+`mergeable=True` means the result is a `pd.Series` or `pd.DataFrame` that can be aggregated across folds by `get_attrs_agg()`.
+
+---
+
+## Built-in Adapters
+
+Adapters are registered by model class name and resolved automatically via `get_adapter()`. The default `eval_mode='both'`, `verbose=0.1`.
+
+### DefaultAdapter
+
+Used for any model not in the registry. Passes no extra fit parameters — suitable for standard sklearn transformers and estimators.
+
+### sklearn Adapters
+
+| Adapter | Models | result_objs |
+|---------|--------|-------------|
+| `LMAdapter` | `LinearRegression`, `LogisticRegression` | `coef` |
+| `PCAAdapter` | `PCA` | `explained_variance`, `explained_variance_ratio`, `components` |
+| `LDAAdapter` | `LinearDiscriminantAnalysis` | `coef`, `intercept`, `scalings`, `explained_variance_ratio` |
+| `DecisionTreeAdapter` | `DecisionTreeClassifier/Regressor` | `feature_importances`✓, `tree`✗, `plot_tree`✗ |
+
+✓ mergeable, ✗ not mergeable
+
+### LightGBMAdapter
+
+Passes `eval_set` to `fit()`. Supports `early_stopping` and `eval_metric` as node `params` (they are moved from constructor to `fit()`):
+
+```python
+exp.set_node('lgbm', grp='lgbm_grp', params={
+    'n_estimators': 1000,
+    'early_stopping': early_stopping(50, verbose=False),
+    'eval_metric': 'auc',
+})
+```
+
+`result_objs`: `feature_importances`✓, `evals_result`✓, `trees`✗
+
+### XGBoostAdapter
+
+Passes `eval_set` to `fit()`. Progress callback is added via `get_params()`.
+
+`result_objs`: `feature_importances`✓, `evals_result`✓, `trees`✗
+
+### CatBoostAdapter
+
+Passes `eval_set` to `fit()`. `verbose=0<v<1` falls back to silent (CatBoost callback API is complex).
+
+`result_objs`: `feature_importances_pvc`✓, `feature_importances_interaction`✓, `evals_result`✓, `trees`✗
+
+### KerasAdapter
+
+Uses `validation_data=(X_val, y_val)` instead of `eval_set`. Both `'valid'` and `'both'` eval modes behave identically (Keras only accepts a single validation set).
+
+`result_objs`: none
+
+---
+
+## Custom Adapter
+
+```python
+from mllabs.adapter import ModelAdapter, register_adapter
+
+class MyAdapter(ModelAdapter):
+    def get_fit_params(self, data_dict, params=None, logger=None):
+        train_X, train_v_X = data_dict['X']
+        train_y, train_v_y = data_dict['y']
+        return {
+            'eval_set': [(train_v_X.values, train_v_y.values)],
+        }
+
+register_adapter('MyModel', MyAdapter(eval_mode='valid', verbose=0))
+```
+
+After registration, `MyAdapter` is resolved automatically whenever a node uses `MyModel` as its processor.
+
+To use an adapter on a specific node or group without registering it globally:
+
+```python
+exp.set_node('my_node', grp='my_grp', adapter=MyAdapter())
+```

--- a/docs/guide/processors.md
+++ b/docs/guide/processors.md
@@ -1,0 +1,164 @@
+# Processors
+
+ml-labs provides a set of built-in sklearn-compatible processors for common preprocessing tasks.
+
+## Built-in Processors
+
+### CatConverter
+
+Converts specified columns to a categorical dtype (pandas `category` / polars `Categorical`).
+
+```python
+from mllabs.processor import CatConverter
+
+CatConverter(columns=None)   # None → convert all columns
+CatConverter(columns=['city', 'gender'])
+```
+
+Output columns are the same as input columns with dtype changed. Supports pandas, polars, and numpy inputs.
+
+### CatOOVFilter
+
+Filters out-of-vocabulary (OOV) values in categorical columns. Values not seen during `fit()` (or seen fewer than `min_frequency` times) are replaced with `missing_value`.
+
+```python
+from mllabs.processor import CatOOVFilter
+
+CatOOVFilter(
+    columns=None,                    # None → all columns
+    min_frequency=0,                 # values with count <= this are treated as OOV
+    missing_value=None,              # replacement for OOV/missing values
+    treat_empty_string_as_missing=True,
+)
+```
+
+Fitted attribute: `categories_` — dict of `{column: [allowed_values]}`.
+
+### CatPairCombiner
+
+Combines pairs of categorical columns into new interaction columns by concatenating their string representations.
+
+```python
+from mllabs.processor import CatPairCombiner
+
+CatPairCombiner(
+    pairs=[('city', 'gender'), ('age_bin', 'city')],
+    sep='__',
+    treat_empty_string_as_missing=True,
+    new_col_names=None,   # None → 'city__gender', 'age_bin__city'
+)
+```
+
+Output column names default to `colA{sep}colB`. Either missing value in a pair produces `None` in the output. Supports integer column indices for numpy inputs.
+
+### FrequencyEncoder
+
+Replaces each categorical value with its frequency (proportion or count) observed during `fit()`.
+
+```python
+from mllabs.processor import FrequencyEncoder
+
+FrequencyEncoder(normalize=True)   # True → proportion, False → count
+```
+
+Output column names are `{col}_freq`. Unseen values at transform time receive `0`.
+
+---
+
+## Polars-Optional Processors
+
+Available only when `polars` is installed (`pip install ml-labs[polars]`).
+
+### PolarsLoader
+
+Reads one or more CSV files into a Polars DataFrame with automatically optimized dtypes. Uses `get_type_df` internally to analyze data ranges.
+
+```python
+from mllabs.processor import PolarsLoader
+
+PolarsLoader(
+    predefined_types={'id': pl.Int64},   # override specific column types
+    read_method='read_csv',              # any pl.read_* method name
+)
+
+# fit: accepts a file path (str) or list of file paths
+# transform: returns pl.DataFrame with optimized schema
+```
+
+### ExprProcessor
+
+Applies a dict of Polars expressions to a DataFrame via `with_columns` or `select`.
+
+```python
+from mllabs.processor import ExprProcessor
+import polars as pl
+
+ExprProcessor(
+    dict_expr={
+        'log_income': pl.col('income').log1p(),
+        'age_sq': pl.col('age') ** 2,
+    },
+    with_columns=True,   # True → add/replace columns; False → select only these columns
+)
+```
+
+When `with_columns=True`, output includes all original columns plus the new/replaced ones. When `False`, output contains only the expressions defined in `dict_expr`.
+
+### PandasConverter
+
+Converts a Polars DataFrame to pandas. Useful as the final stage in a Polars-based pipeline.
+
+```python
+from mllabs.processor import PandasConverter
+
+PandasConverter(index_col=None)   # optionally set a column as the DataFrame index
+```
+
+---
+
+## Type Utilities
+
+Utilities for analyzing column types and generating optimal dtype mappings. Useful for preprocessing pipelines that need to minimize memory usage.
+
+```python
+from mllabs.processor import get_type_df, get_type_pl, get_type_pd, merge_type_df
+```
+
+### get_type_df(df)
+
+Analyzes a Polars DataFrame (or LazyFrame) and returns a `pd.DataFrame` with per-column statistics and dtype-fit flags.
+
+```python
+df_type = pl.scan_csv('train.csv').pipe(get_type_df)
+# Columns: min, max, na, count, n_unique, dtype, f32, i32, i16, i8
+# f32/i32/i16/i8: True if numeric values fit within that type's range
+```
+
+### get_type_pl(df_type, ...) / get_type_pd(df_type, ...)
+
+Convert the `df_type` analysis into a type mapping dict for Polars or pandas loading.
+
+```python
+pl_types = get_type_pl(
+    df_type,
+    predefine={'id': pl.Int64},  # always override these
+    f32=True,                    # use Float32 where possible
+    i64=False,                   # use smallest int type that fits
+    cat_max=50,                  # columns with ≤50 unique values → Categorical
+    txt_cols=['description'],    # force these columns to String
+)
+
+pd_types = get_type_pd(df_type, predefine={'id': 'int64'}, cat_max=50)
+```
+
+### merge_type_df(dfs)
+
+Merges `df_type` results from multiple files (e.g., sharded datasets) into a single summary. Takes the global min/max across files to determine safe dtype ranges.
+
+```python
+from glob import glob
+
+df_type = merge_type_df([
+    pl.scan_csv(f).pipe(get_type_df) for f in glob('data/*.csv')
+])
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,8 @@ nav:
   - User Guide:
     - guide/pipeline-experimenter.md
     - guide/trainer-collectors.md
-    - guide/adapters-processors.md
+    - guide/adapters.md
+    - guide/processors.md
   - Serving Guide:
     - serving/inferencer.md
   - API Reference:


### PR DESCRIPTION
## Summary

- `adapters.md`: `ModelAdapter` interface, `eval_mode`/`verbose` options, all built-in adapters (sklearn, LightGBM, XGBoost, CatBoost, Keras), custom adapter + `register_adapter`
- `processors.md`: `CatConverter`, `CatOOVFilter`, `CatPairCombiner`, `FrequencyEncoder`, Polars-optional processors (`PolarsLoader`, `ExprProcessor`, `PandasConverter`), type utilities (`get_type_df`, `get_type_pl`, `get_type_pd`, `merge_type_df`)
- Split `adapters-processors.md` placeholder into two separate pages, updated `mkdocs.yml` nav

Closes #37