### PR TITLE
docs: write serving guide (Inferencer)

### DIFF
--- a/docs/serving/inferencer.md
+++ b/docs/serving/inferencer.md
@@ -1,3 +1,88 @@
 # Serving Guide (Inferencer)
 
-*Coming soon.*
+`Inferencer` packages the fitted processors from a cross-validation `Trainer` into a single, self-contained object for deployment. It has no dependency on `Experimenter` or `Trainer` at serve time.
+
+## Exporting from Trainer
+
+After `train()` completes, call `to_inferencer()` to extract the fitted processors:
+
+```python
+trainer.select_head(['lgbm_v1'])
+trainer.train()
+
+inferencer = trainer.to_inferencer(
+    v=None,   # optionally filter output columns (same as Trainer.process v)
+)
+```
+
+`to_inferencer()` copies the processors out of the Trainer. The resulting `Inferencer` is independent — you can discard the Trainer afterwards.
+
+## Saving and Loading
+
+The entire `Inferencer` — pipeline structure, all split processors, and configuration — is serialized into a single file.
+
+**Save:**
+
+```python
+inferencer.save('./model/inferencer')
+# Writes: ./model/inferencer/__inferencer.pkl
+```
+
+**Load:**
+
+```python
+from mllabs import Inferencer
+
+inferencer = Inferencer.load('./model/inferencer')
+```
+
+No training dependencies (Experimenter, Trainer, Collectors) are required to load or run an Inferencer.
+
+## Running Inference
+
+```python
+predictions = inferencer.process(test_df, agg='mean')
+```
+
+`process()` applies each split's processors to the input data in sequence (Stage transforms → Head prediction), then aggregates across splits.
+
+Input can be any pandas/polars/numpy object that the pipeline was trained on.
+
+## Aggregation Strategies
+
+| `agg` | Behaviour | Use when |
+|-------|-----------|----------|
+| `'mean'` (default) | Element-wise mean across splits | Regression, probability outputs |
+| `'mode'` | Element-wise mode across splits | Classification with hard labels |
+| `callable` | `agg(results)` where `results` is a list of per-split DataFrames | Custom ensembling logic |
+| `None` | Returns a list of per-split results | Debugging, manual aggregation |
+
+When `n_splits == 1`, aggregation is skipped and the single split result is returned directly regardless of `agg`.
+
+**Custom aggregation example:**
+
+```python
+import numpy as np
+
+def weighted_mean(results):
+    # weight later splits more heavily
+    weights = np.linspace(1, 2, len(results))
+    stacked = np.stack([r.values for r in results], axis=0)
+    return (stacked * weights[:, None, None]).sum(axis=0) / weights.sum()
+
+predictions = inferencer.process(test_df, agg=weighted_mean)
+```
+
+## Dependency Requirements
+
+At serve time, only the following are needed:
+
+- `ml-labs` (core package)
+- The framework libraries used by the trained processors (e.g., `lightgbm`, `xgboost`)
+- **Not** needed: `scikit-learn` splitters, Collectors, Trainer, or any training-only dependencies
+
+This means a serving environment can install a minimal subset:
+
+```bash
+pip install ml-labs lightgbm
+```


### PR DESCRIPTION
## Summary

- Exporting from Trainer via `to_inferencer()`
- Single-file save/load (`__inferencer.pkl`)
- `process(data, agg)` with aggregation strategies (mean, mode, callable, None)
- Minimal dependency requirements for serving environments

Closes #38