### PR TITLE
docs: write API reference (docstrings + mkdocstrings)

### DIFF
--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -1,0 +1,41 @@
+# Adapters
+
+::: mllabs.adapter.ModelAdapter
+    options:
+      members:
+        - get_params
+        - get_fit_params
+
+::: mllabs.adapter.LightGBMAdapter
+    options:
+      members:
+        - get_params
+        - get_fit_params
+
+::: mllabs.adapter.XGBoostAdapter
+    options:
+      members:
+        - get_params
+        - get_fit_params
+
+::: mllabs.adapter.CatBoostAdapter
+    options:
+      members:
+        - get_fit_params
+
+::: mllabs.adapter.KerasAdapter
+    options:
+      members:
+        - get_fit_params
+
+::: mllabs.adapter.LMAdapter
+
+::: mllabs.adapter.PCAAdapter
+
+::: mllabs.adapter.LDAAdapter
+
+::: mllabs.adapter.DecisionTreeAdapter
+
+::: mllabs.adapter.get_adapter
+
+::: mllabs.adapter.register_adapter

--- a/docs/reference/collectors.md
+++ b/docs/reference/collectors.md
@@ -1,0 +1,41 @@
+# Collectors
+
+::: mllabs.collector.Collector
+    options:
+      members:
+        - has
+        - has_node
+        - reset_nodes
+        - save
+        - load
+
+::: mllabs.collector.MetricCollector
+    options:
+      members:
+        - get_metric
+        - get_metrics
+        - get_metrics_agg
+
+::: mllabs.collector.StackingCollector
+    options:
+      members:
+        - get_dataset
+
+::: mllabs.collector.ModelAttrCollector
+    options:
+      members:
+        - get_attr
+        - get_attrs
+        - get_attrs_agg
+
+::: mllabs.collector.SHAPCollector
+    options:
+      members:
+        - get_feature_importance
+        - get_feature_importance_agg
+
+::: mllabs.collector.OutputCollector
+    options:
+      members:
+        - get_output
+        - get_outputs

--- a/docs/reference/connector.md
+++ b/docs/reference/connector.md
@@ -1,0 +1,6 @@
+# Connector
+
+::: mllabs.Connector
+    options:
+      members:
+        - match

--- a/docs/reference/experimenter.md
+++ b/docs/reference/experimenter.md
@@ -1,0 +1,43 @@
+# Experimenter
+
+::: mllabs._experimenter.Experimenter
+    options:
+      members:
+        - create
+        - load
+        - set_grp
+        - set_node
+        - rename_grp
+        - remove_grp
+        - remove_node
+        - build
+        - exp
+        - reset_nodes
+        - show_error_nodes
+        - finalize
+        - reinitialize
+        - close_exp
+        - reopen_exp
+        - add_collector
+        - get_collector
+        - remove_collector
+        - collect
+        - add_trainer
+        - get_trainer
+        - remove_trainer
+        - get_node_output
+        - get_node_train_output
+        - get_node_valid_output
+        - get_n_splits
+        - get_n_splits_inner
+        - desc_status
+        - desc_spec
+        - desc_pipeline
+        - desc_node
+
+::: mllabs._experimenter.DataCache
+    options:
+      members:
+        - get_data
+        - put_data
+        - clear_nodes

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -1,0 +1,7 @@
+# Filters
+
+::: mllabs.DataFilter
+
+::: mllabs.RandomFilter
+
+::: mllabs.IndexFilter

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,16 @@
 # API Reference
 
-*Coming soon.*
+Auto-generated from source docstrings via [mkdocstrings](https://mkdocstrings.github.io/).
+
+## Modules
+
+| Module | Contents |
+|--------|----------|
+| [Pipeline](pipeline.md) | `Pipeline`, `PipelineGroup`, `PipelineNode` |
+| [Experimenter](experimenter.md) | `Experimenter`, `DataCache` |
+| [Trainer](trainer.md) | `Trainer` |
+| [Inferencer](inferencer.md) | `Inferencer` |
+| [Collectors](collectors.md) | `Collector`, `MetricCollector`, `StackingCollector`, `ModelAttrCollector`, `SHAPCollector`, `OutputCollector` |
+| [Adapters](adapters.md) | `ModelAdapter`, `LightGBMAdapter`, `XGBoostAdapter`, `CatBoostAdapter`, `KerasAdapter`, sklearn adapters |
+| [Connector](connector.md) | `Connector` |
+| [Filters](filters.md) | `DataFilter`, `RandomFilter`, `IndexFilter` |

--- a/docs/reference/inferencer.md
+++ b/docs/reference/inferencer.md
@@ -1,0 +1,8 @@
+# Inferencer
+
+::: mllabs._inferencer.Inferencer
+    options:
+      members:
+        - process
+        - save
+        - load

--- a/docs/reference/pipeline.md
+++ b/docs/reference/pipeline.md
@@ -1,0 +1,32 @@
+# Pipeline
+
+::: mllabs._pipeline.Pipeline
+    options:
+      members:
+        - set_grp
+        - set_node
+        - get_node_names
+        - get_node_attrs
+        - get_node
+        - get_grp
+        - rename_grp
+        - remove_grp
+        - remove_node
+        - copy
+        - copy_stage
+        - copy_nodes
+        - compare_nodes
+        - desc_pipeline
+        - desc_node
+
+::: mllabs._pipeline.PipelineGroup
+    options:
+      members:
+        - get_attrs
+        - diff
+
+::: mllabs._pipeline.PipelineNode
+    options:
+      members:
+        - get_attrs
+        - diff

--- a/docs/reference/trainer.md
+++ b/docs/reference/trainer.md
@@ -1,0 +1,11 @@
+# Trainer
+
+::: mllabs._trainer.Trainer
+    options:
+      members:
+        - select_head
+        - train
+        - process
+        - to_inferencer
+        - reset_nodes
+        - get_n_splits

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,14 @@ nav:
     - serving/inferencer.md
   - API Reference:
     - reference/index.md
+    - reference/pipeline.md
+    - reference/experimenter.md
+    - reference/trainer.md
+    - reference/inferencer.md
+    - reference/collectors.md
+    - reference/adapters.md
+    - reference/connector.md
+    - reference/filters.md
 
 plugins:
   - search

--- a/mllabs/_connector.py
+++ b/mllabs/_connector.py
@@ -2,12 +2,36 @@ import re
 
 
 class Connector:
+    """Selects nodes by matching against name, processor, and/or edges.
+
+    All provided criteria are combined with AND logic. Omitted criteria
+    always match.
+
+    Args:
+        node_query: Node name filter. A ``str`` is treated as a regex pattern;
+            a ``list`` requires exact membership.
+        edges: Edge filter. ``{key: [(node_name, var_spec), ...]}`` — the node's
+            edges must contain all listed entries (contain-based matching).
+        processor: Processor class filter. The node's resolved processor must
+            be exactly this class.
+    """
+
     def __init__(self, node_query=None, edges=None, processor=None):
         self.node_query = node_query
         self.edges = edges
         self.processor = processor
 
     def match(self, node_name, node_attrs):
+        """Return True if the node satisfies all configured criteria.
+
+        Args:
+            node_name (str): Node name to test.
+            node_attrs (dict): Resolved node attributes from
+                ``Pipeline.get_node_attrs()``.
+
+        Returns:
+            bool: True if all criteria match.
+        """
         if self.node_query is not None:
             if isinstance(self.node_query, str):
                 if not re.search(self.node_query, node_name):

--- a/mllabs/adapter/_base.py
+++ b/mllabs/adapter/_base.py
@@ -6,6 +6,18 @@ from abc import ABC, abstractmethod
 
 
 class ModelAdapter(ABC):
+    """Abstract base class for ML framework adapters.
+
+    Adapters translate ml-labs' unified data format into the framework-specific
+    ``fit()`` parameters of each model. Registered by model class name via
+    :func:`~mllabs.adapter.register_adapter`.
+
+    Class Attributes:
+        result_objs (dict): ``{key: (callable, mergeable_bool)}`` mapping of
+            extractable model attributes for use with
+            :class:`~mllabs.collector.ModelAttrCollector`.
+    """
+
     result_objs = {}
     """Abstract base class for model adapters
 

--- a/mllabs/collector/_base.py
+++ b/mllabs/collector/_base.py
@@ -2,6 +2,20 @@ import re
 
 
 class Collector:
+    """Base class for data collectors attached to an Experimenter.
+
+    Subclasses override the lifecycle hooks ``_start``, ``_collect``,
+    ``_end_idx``, and ``_end`` to capture data during :meth:`~mllabs.Experimenter.exp`.
+
+    Args:
+        name (str): Collector name (unique within an Experimenter).
+        connector (Connector): Determines which Head nodes this collector
+            attaches to.
+
+    Attributes:
+        path (Path | None): Set by Experimenter on registration.
+    """
+
     def __init__(self, name, connector):
         self.name = name
         self.connector = connector

--- a/mllabs/collector/_stacking.py
+++ b/mllabs/collector/_stacking.py
@@ -7,6 +7,21 @@ from .._data_wrapper import DataWrapper
 
 
 class StackingCollector(Collector):
+    """Collects out-of-fold (OOF) predictions for stacking.
+
+    Predictions are aggregated across inner folds and saved per outer fold,
+    then assembled into a dataset aligned to the original data index.
+
+    Args:
+        name (str): Collector name.
+        connector (Connector): Node matching criteria. The ``edges`` ``'y'``
+            entry is used to extract the target column.
+        output_var: Column selector for the Head output.
+        experimenter (Experimenter): Used to build the OOF index and target.
+        method (str): Inner-fold aggregation — ``'mean'`` (default), ``'mode'``,
+            or ``'simple'`` (concatenate).
+    """
+
     def __init__(self, name, connector, output_var, experimenter, method='mean'):
         super().__init__(name, connector)
         self.output_var = output_var
@@ -174,6 +189,16 @@ class StackingCollector(Collector):
             return list(self._mem_data.keys())
 
     def get_dataset(self, nodes=None, include_target=True):
+        """Return OOF predictions as a DataFrame aligned to the original index.
+
+        Args:
+            nodes: Node query. ``None`` returns all collected nodes.
+            include_target (bool): Append the target column(s) if available.
+
+        Returns:
+            DataFrame: OOF prediction columns (+ target) indexed to match
+            the original dataset.
+        """
         node_names = self._get_nodes(nodes, self._get_saved_nodes())
 
         node_data = []

--- a/mllabs/filter/_base.py
+++ b/mllabs/filter/_base.py
@@ -2,7 +2,22 @@ import numpy as np
 
 
 class DataFilter:
+    """Base class for data filters used with :class:`~mllabs.collector.SHAPCollector`.
+
+    Subclasses implement :meth:`_select` to return a row index array.
+    The filter is applied to all arrays in the input ``data_dict`` identically.
+    """
+
     def __call__(self, data_dict):
+        """Apply the filter to every array in *data_dict*.
+
+        Args:
+            data_dict (dict): ``{key: DataWrapper}`` mapping.
+
+        Returns:
+            dict: Filtered ``{key: DataWrapper}`` with rows selected by
+            :meth:`_select`.
+        """
         indices = self._select(data_dict)
         return {key: val.iloc(indices) for key, val in data_dict.items()}
 

--- a/mllabs/filter/_index.py
+++ b/mllabs/filter/_index.py
@@ -4,6 +4,12 @@ from ._base import DataFilter
 
 
 class IndexFilter(DataFilter):
+    """Select rows whose index values appear in a provided index array.
+
+    Args:
+        index (array-like): The set of index values to keep.
+    """
+
     def __init__(self, index):
         self.index = index
 

--- a/mllabs/filter/_random.py
+++ b/mllabs/filter/_random.py
@@ -4,6 +4,16 @@ from ._base import DataFilter
 
 
 class RandomFilter(DataFilter):
+    """Randomly subsample rows from a data dict.
+
+    Args:
+        n (int, optional): Absolute number of rows to sample.
+            Mutually exclusive with *frac*.
+        frac (float, optional): Fraction of rows to sample (0–1).
+            Mutually exclusive with *n*.
+        random_state (int, optional): Random seed for reproducibility.
+    """
+
     def __init__(self, n=None, frac=None, random_state=None):
         if n is not None and frac is not None:
             raise ValueError("n and frac are mutually exclusive")


### PR DESCRIPTION
## Summary

- Google-style docstrings added to all public APIs: `Pipeline`, `PipelineGroup`, `PipelineNode`, `Experimenter`, `DataCache`, `Trainer`, `Inferencer`, all Collectors, `ModelAdapter`, `Connector`, `DataFilter`, `RandomFilter`, `IndexFilter`
- mkdocstrings reference pages under `docs/reference/`: pipeline, experimenter, trainer, inferencer, collectors, adapters, connector, filters
- `mkdocs.yml` nav updated with all 8 reference pages

Closes #39