### PR TITLE
feat: add desc attribute to PipelineGroup and PipelineNode

### DIFF
--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -21,8 +21,11 @@ A **node** is the unit of execution. Each node has:
 - `method`: method name to call on the processor
 - `adapter`: optional wrapper that translates data and params to framework conventions
 - `params`: constructor parameters for the processor
+- `desc`: optional free-text description (not inherited from group)
 
 A **group** (`PipelineGroup`) lets multiple nodes share configuration. Node attributes override group attributes; group attributes override parent group attributes.
+
+> **Note:** `desc` is the only attribute that is **not** inherited — each group and node holds its own description independently. Changing `desc` alone has no effect on which nodes are considered affected or need rebuilding.
 
 ## edges
 

--- a/docs/guide/pipeline-experimenter.md
+++ b/docs/guide/pipeline-experimenter.md
@@ -18,7 +18,8 @@ exp = Experimenter(df, path='./exp', sp=StratifiedKFold(n_splits=5))
 
 ```python
 exp.set_grp('scaler', role='stage', processor=StandardScaler,
-            edges={'X': [(None, features)]}, method='fit_transform')
+            edges={'X': [(None, features)]}, method='fit_transform',
+            desc='Standard scaling for numeric features')
 
 exp.set_grp('lgbm', role='head', processor=LGBMClassifier,
             edges={'X': [(None, features)], 'y': [(None, 'target')]},
@@ -29,11 +30,13 @@ exp.set_grp('lgbm', role='head', processor=LGBMClassifier,
 **Nodes** (`set_node`) are the executable units inside a group:
 
 ```python
-exp.set_node('lgbm_v1', grp='lgbm', params={'num_leaves': 31})
-exp.set_node('lgbm_v2', grp='lgbm', params={'num_leaves': 63})
+exp.set_node('lgbm_v1', grp='lgbm', params={'num_leaves': 31}, desc='baseline')
+exp.set_node('lgbm_v2', grp='lgbm', params={'num_leaves': 63}, desc='deeper leaves')
 ```
 
 Node parameters override group parameters. Processor, edges, method, and adapter are inherited if not specified on the node.
+
+`desc` is a free-text annotation for documentation purposes. It is **not** inherited from the group, and changing it does not trigger a rebuild of dependent nodes.
 
 #### Name Restrictions
 

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -324,10 +324,10 @@ class Experimenter():
         grp_path = self.get_grp_path(node.grp)
         return grp_path / node.name
 
-    def set_grp(self, name, role=None, processor=None, edges=None, method=None, parent=None, adapter=None, params=None, exist = 'diff'):
+    def set_grp(self, name, role=None, processor=None, edges=None, method=None, parent=None, adapter=None, params=None, desc=None, exist='diff'):
         self._check_open()
         result_obj = self.pipeline.set_grp(
-            name, role, processor, edges, method, parent, adapter, params, exist
+            name, role, processor, edges, method, parent, adapter, params, desc=desc, exist=exist
         )
         
         affected_nodes = result_obj['affected_nodes']
@@ -450,12 +450,12 @@ class Experimenter():
         self._save()
 
     def set_node(
-        self, name, grp, processor = None, edges = None,
-        method = None, adapter = None, params = None, exist = 'diff'
+        self, name, grp, processor=None, edges=None,
+        method=None, adapter=None, params=None, desc=None, exist='diff'
     ):
         self._check_open()
         result_obj = self.pipeline.set_node(
-            name, grp, processor, edges, method, adapter, params, exist
+            name, grp, processor, edges, method, adapter, params, desc=desc, exist=exist
         )
 
         # 기존 노드를 업데이트한 경우, 하위 노드들도 재빌드

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -50,7 +50,7 @@ class PipelineGroup:
     """
 
     def __init__(
-        self, name, role, processor=None, edges=None, method=None, parent=None, adapter=None, params=None
+        self, name, role, processor=None, edges=None, method=None, parent=None, adapter=None, params=None, desc=None
     ):
         self.name = name
         self.role = role  # 'stage' or 'head'
@@ -60,6 +60,7 @@ class PipelineGroup:
         self.parent = parent  # parent group name (str)
         self.adapter = adapter
         self.params = params if params is not None else {}
+        self.desc = desc
         self.children = []  # child group names
         self.nodes = []  # node names in this group
         self.attrs = None
@@ -129,7 +130,7 @@ class PipelineGroup:
     def copy(self):
         ret = PipelineGroup(
             self.name, self.role, self.processor, self.edges.copy(),
-            self.method, self.parent, self.adapter, self.params.copy()
+            self.method, self.parent, self.adapter, self.params.copy(), self.desc
         )
         ret.children = self.children.copy()
         ret.nodes = self.nodes.copy()
@@ -153,7 +154,7 @@ class PipelineNode:
     """
 
     def __init__(
-        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None
+        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, desc=None
     ):
         self.name = name
         self.grp = grp  # group name (str)
@@ -162,6 +163,7 @@ class PipelineNode:
         self.method = method
         self.adapter = adapter
         self.params = params if params is not None else {}
+        self.desc = desc
 
         self.output_edges = []  # 이 노드를 입력으로 사용하는 노드들의 이름
         self.attrs = None
@@ -169,7 +171,7 @@ class PipelineNode:
     def copy(self):
         ret = PipelineNode(
             self.name, self.grp, self.processor, self.edges.copy(),
-            self.method, self.adapter, self.params.copy()
+            self.method, self.adapter, self.params.copy(), self.desc
         )
         ret.output_edges = self.output_edges.copy()
         return ret
@@ -436,7 +438,7 @@ class Pipeline:
         return [i[0] for i in sorted_nodes if i[0] is not None]
 
     def set_grp(
-            self, name, role=None, processor=None, edges=None, method=None, parent=None, adapter=None, params=None, exist='diff'
+            self, name, role=None, processor=None, edges=None, method=None, parent=None, adapter=None, params=None, desc=None, exist='diff'
         ):
         """Create or update a group.
 
@@ -478,7 +480,7 @@ class Pipeline:
         if name not in self.grps:
             self._check_edges(edges)
             grp = PipelineGroup(
-                name, role, processor=processor, edges=edges, method=method, parent=parent, adapter=adapter, params=params
+                name, role, processor=processor, edges=edges, method=method, parent=parent, adapter=adapter, params=params, desc=desc
             )
 
             if parent is not None:
@@ -496,6 +498,7 @@ class Pipeline:
         elif exist == 'diff':
             old_grp = self.grps[name]
             if not old_grp.diff(processor, edges, method, parent, adapter, params):
+                old_grp.desc = desc
                 return {"result": "skip", "grp": old_grp, "affected_nodes": list()}
 
         old_grp = self.grps[name]
@@ -519,6 +522,7 @@ class Pipeline:
         grp.method = method
         grp.adapter = adapter
         grp.params = params
+        grp.desc = desc
 
         grp.update_attrs()
         attrs = grp.get_attrs(self.grps)
@@ -679,7 +683,7 @@ class Pipeline:
                             parent_node.output_edges.append(node_name)
 
     def set_node(
-        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, exist='diff'
+        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, desc=None, exist='diff'
     ):
         """Create or update a node.
 
@@ -725,6 +729,7 @@ class Pipeline:
             elif exist == 'diff':
                 old_node = self.nodes[name]
                 if not old_node.diff(grp, processor, edges, method, adapter, params):
+                    old_node.desc = desc
                     return {'result': 'skip', 'affected_nodes': [], 'old_obj': old_node, 'obj': old_node}
 
         old_edges = None
@@ -736,7 +741,7 @@ class Pipeline:
             old_output_edges = old_node.output_edges
 
         node = PipelineNode(
-            name, grp, processor, edges, method=method, adapter=adapter, params=params
+            name, grp, processor, edges, method=method, adapter=adapter, params=params, desc=desc
         )
 
         grp_obj = self.grps[grp]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -810,3 +810,93 @@ class TestColSelector:
     def test_numpy_pattern(self, numpy_int):
         result = numpy_int.get_column_list(ColSelector(pattern='^0$'))
         assert result == [0]
+
+
+class _DummyProc:
+    def fit_transform(self, X, y=None):
+        return X
+
+
+class TestPipelineDesc:
+    @pytest.fixture
+    def pipeline(self):
+        from mllabs._pipeline import Pipeline
+        p = Pipeline()
+        p.set_grp('g1', role='stage')
+        p.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform')
+        return p
+
+    # --- 기본값 ---
+
+    def test_grp_desc_default_none(self, pipeline):
+        assert pipeline.grps['g1'].desc is None
+
+    def test_node_desc_default_none(self, pipeline):
+        assert pipeline.nodes['n1'].desc is None
+
+    # --- set_grp / set_node ---
+
+    def test_set_grp_desc(self):
+        from mllabs._pipeline import Pipeline
+        p = Pipeline()
+        p.set_grp('g1', role='stage', desc='my group')
+        assert p.grps['g1'].desc == 'my group'
+
+    def test_set_node_desc(self, pipeline):
+        pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='my node', exist='replace')
+        assert pipeline.nodes['n1'].desc == 'my node'
+
+    # --- get_attrs에 desc 포함 안 됨 (상속 없음) ---
+
+    def test_desc_not_in_get_attrs(self, pipeline):
+        pipeline.set_grp('g1', role='stage', desc='group desc', exist='replace')
+        pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='node desc', exist='replace')
+        attrs = pipeline.get_node_attrs('n1')
+        assert 'desc' not in attrs
+
+    def test_node_desc_not_inherited_from_grp(self, pipeline):
+        pipeline.set_grp('g1', role='stage', desc='group desc', exist='replace')
+        assert pipeline.nodes['n1'].desc is None
+
+    # --- copy ---
+
+    def test_grp_copy_preserves_desc(self):
+        from mllabs._pipeline import Pipeline
+        p = Pipeline()
+        p.set_grp('g1', role='stage', desc='group desc')
+        assert p.grps['g1'].copy().desc == 'group desc'
+
+    def test_node_copy_preserves_desc(self, pipeline):
+        pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='node desc', exist='replace')
+        assert pipeline.nodes['n1'].copy().desc == 'node desc'
+
+    # --- desc 변경은 affected_nodes에 영향 없음 ---
+
+    def test_set_grp_desc_only_change_returns_skip(self, pipeline):
+        pipeline.set_grp('g1', role='stage', desc='old', exist='replace')
+        result = pipeline.set_grp('g1', role='stage', desc='new')
+        assert result['result'] == 'skip'
+        assert result['affected_nodes'] == []
+
+    def test_set_grp_desc_only_change_updates_desc(self, pipeline):
+        pipeline.set_grp('g1', role='stage', desc='old', exist='replace')
+        pipeline.set_grp('g1', role='stage', desc='new')
+        assert pipeline.grps['g1'].desc == 'new'
+
+    def test_set_node_desc_only_change_returns_skip(self, pipeline):
+        pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='old', exist='replace')
+        result = pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='new')
+        assert result['result'] == 'skip'
+        assert result['affected_nodes'] == []
+
+    def test_set_node_desc_only_change_updates_desc(self, pipeline):
+        pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='old', exist='replace')
+        pipeline.set_node('n1', 'g1', processor=_DummyProc, edges={'X': [(None, None)]}, method='fit_transform', desc='new')
+        assert pipeline.nodes['n1'].desc == 'new'
+
+    # --- 모델 속성 변경 시 affected_nodes 정상 동작 확인 ---
+
+    def test_set_grp_model_change_returns_update(self, pipeline):
+        from mllabs.processor import CatConverter
+        result = pipeline.set_grp('g1', role='stage', processor=CatConverter)
+        assert result['result'] == 'update'


### PR DESCRIPTION
## Summary

- Add `desc` attribute to `PipelineGroup` and `PipelineNode` for free-text annotations
- `desc` is **not** inherited via `get_attrs` — each element owns its own description independently
- `desc` is excluded from `diff()` — desc-only changes do not mark downstream nodes as affected or trigger rebuilds
- On `exist='diff'` skip path, `desc` is still updated silently
- `Experimenter.set_grp` / `set_node` updated to accept and forward `desc`

## Test plan

- [x] 13 unit tests added in `TestPipelineDesc`
- [x] All existing tests pass (`test_experimenter.py` 61 passed)

Closes #84