### PR TITLE
fix: attrs cache invalidation on set_grp and inferencer DataSource column resolution

### DIFF
--- a/mllabs/_inferencer.py
+++ b/mllabs/_inferencer.py
@@ -103,7 +103,10 @@ class Inferencer:
         for src_node, var in edge_list:
             src, obj = data_dicts[src_node]
             if var is not None:
-                cols = resolve_columns(src, var, processor=obj)
+                if src_node is None:
+                    cols = var
+                else:
+                    cols = resolve_columns(src, var, processor=obj)
                 src = src.select_columns(cols)
             parts.append(src)
         if len(parts) == 1:

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -415,6 +415,11 @@ class Pipeline:
             result.extend(self._get_all_nodes_in_grp(child_grp))
         return result
 
+    def _cascade_clear_attrs(self, grp_name):
+        for child_name in self.grps[grp_name].children:
+            self.grps[child_name].update_attrs()
+            self._cascade_clear_attrs(child_name)
+
     def _get_affected_nodes(self, nodes):
         priorities = {}
         queue = []
@@ -529,6 +534,7 @@ class Pipeline:
         new_edges = attrs['edges']
         affected_nodes = self._get_all_nodes_in_grp(grp)
         self.grps[name] = grp
+        self._cascade_clear_attrs(name)
         if len(new_edges) > 0 or len(affected_nodes) > 0:
             for node_name in affected_nodes:
                 if node_name not in self.nodes:
@@ -551,6 +557,12 @@ class Pipeline:
                     cycle_info = ", ".join([f"'{e}'" for e in cycle_edges])
                     self.grps[name] = old_grp
                     raise ValueError(f"Cannot update group '{name}': node '{node_name}' would create cycle through edge(s) {cycle_info}")
+
+            # Clear node attrs cache after cycle check to prevent stale data
+            # from being used when nodes are next built.
+            for node_name in affected_nodes:
+                if node_name in self.nodes:
+                    self.nodes[node_name].update_attrs()
 
         return {
             "result": "update", "affected_nodes": affected_nodes, "old_grp": old_grp, "grp": grp

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -793,3 +793,56 @@ class TestGetParents:
 
     def test_not_found(self, p):
         assert p.get_parents('no_exist') == []
+
+
+class TestAdapterAttrsCacheInvalidation:
+    class DummyAdapter:
+        def __init__(self, mode):
+            self.mode = mode
+        def __eq__(self, other):
+            return type(self) is type(other) and self.__dict__ == other.__dict__
+        def __hash__(self):
+            return id(self)
+
+    def test_direct_grp_adapter_change_detected(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]}, adapter=self.DummyAdapter('a'))
+        r = p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                      edges={'X': [(None, None)]}, adapter=self.DummyAdapter('b'), exist='diff')
+        assert r['result'] == 'update'
+
+    def test_direct_grp_adapter_change_applied(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]}, adapter=self.DummyAdapter('a'))
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]}, adapter=self.DummyAdapter('b'), exist='diff')
+        assert p.grps['g1'].adapter.mode == 'b'
+
+    def test_parent_grp_adapter_change_clears_child_grp_cache(self, p):
+        p.set_grp('parent', role='stage', adapter=self.DummyAdapter('a'))
+        p.set_grp('child', role='stage', parent='parent', processor=DummyStage,
+                  method='transform', edges={'X': [(None, None)]})
+        _ = p.grps['child'].get_attrs(p.grps)
+        p.set_grp('parent', role='stage', adapter=self.DummyAdapter('b'), exist='replace')
+        assert p.grps['child'].attrs is None
+
+    def test_parent_grp_adapter_change_reflected_in_node(self, p):
+        p.set_grp('parent', role='stage', adapter=self.DummyAdapter('a'))
+        p.set_grp('child', role='stage', parent='parent', processor=DummyStage,
+                  method='transform', edges={'X': [(None, None)]})
+        p.set_node('n1', grp='child')
+        _ = p.nodes['n1'].get_attrs(p.grps)
+        p.set_grp('parent', role='stage', adapter=self.DummyAdapter('b'), exist='replace')
+        attrs = p.nodes['n1'].get_attrs(p.grps)
+        assert attrs['adapter'].mode == 'b'
+
+    def test_grandchild_grp_attrs_cleared(self, p):
+        p.set_grp('gp', role='stage', adapter=self.DummyAdapter('a'))
+        p.set_grp('par', role='stage', parent='gp')
+        p.set_grp('child', role='stage', parent='par', processor=DummyStage,
+                  method='transform', edges={'X': [(None, None)]})
+        p.set_node('n1', grp='child')
+        _ = p.nodes['n1'].get_attrs(p.grps)
+        p.set_grp('gp', role='stage', adapter=self.DummyAdapter('b'), exist='replace')
+        attrs = p.nodes['n1'].get_attrs(p.grps)
+        assert attrs['adapter'].mode == 'b'


### PR DESCRIPTION
## Summary

- **Pipeline**: `set_grp()` now recursively clears child group attrs cache (`_cascade_clear_attrs`) and node attrs cache after cycle check — prevents stale adapter/params being resolved when a parent group is updated
- **Inferencer**: `_get_process_data()` skips `resolve_columns` for DataSource edges (`src_node=None`); uses `var` directly as column spec
- **Tests**: 5 new cases in `TestAdapterAttrsCacheInvalidation` covering direct, parent, and grandparent group adapter changes

## Test plan

- [ ] `pytest tests/test_pipeline.py::TestAdapterAttrsCacheInvalidation` — all 5 pass
- [ ] `pytest tests/test_pipeline.py` — full suite (121 tests) passes