### PR TITLE
feat: add device parameter to _NNBase for GPU assignment

### DIFF
--- a/mllabs/adapter/_nn.py
+++ b/mllabs/adapter/_nn.py
@@ -37,18 +37,19 @@ class _ProgressCallback(_keras_cb):
 class NNAdapter(ModelAdapter):
 
     def get_gpu_usage(self, params):
-        gpu = (params or {}).get('gpu', 'auto')
-        if gpu != 'auto':
-            raise ValueError(f"NNAdapter only supports gpu='auto', got {gpu!r}")
+        device = (params or {}).get('device', None)
+        if device:
+            return GPU_YES
         return GPU_POSSIBLE
+
+    def inject_gpu_id(self, params, gpu_id):
+        params['device'] = f'/GPU:{gpu_id}'
 
     def get_params(self, params, logger=None):
         if params is None:
             return {}
         params = params.copy()
-        gpu = params.pop('gpu', 'auto')
-        if gpu != 'auto':
-            raise ValueError(f"NNAdapter only supports gpu='auto', got {gpu!r}")
+        params.pop('gpu', None)
         return params
 
     def get_fit_params(self, data_dict, params=None, logger=None):

--- a/mllabs/nn/_estimator.py
+++ b/mllabs/nn/_estimator.py
@@ -1,3 +1,4 @@
+import contextlib
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
@@ -52,6 +53,7 @@ class _NNBase(BaseEstimator):
         loss=None,
         metrics=None,
         random_state=None,
+        device=None,
     ):
         self.cat_cols = cat_cols
         self.embedding_dims = embedding_dims
@@ -69,6 +71,7 @@ class _NNBase(BaseEstimator):
         self.loss = loss
         self.metrics = metrics
         self.random_state = random_state
+        self.device = device
 
     # ------------------------------------------------------------------
     # Column detection
@@ -184,6 +187,19 @@ class _NNBase(BaseEstimator):
     # ------------------------------------------------------------------
 
     def fit(self, X, y, eval_set=None, callbacks=None):
+        if tf is None:
+            scope = contextlib.nullcontext()
+        elif self.device == 'mirror':
+            scope = tf.distribute.MirroredStrategy().scope()
+        elif self.device:
+            scope = tf.device(self.device)
+        else:
+            scope = contextlib.nullcontext()
+
+        with scope:
+            return self._fit(X, y, eval_set=eval_set, callbacks=callbacks)
+
+    def _fit(self, X, y, eval_set=None, callbacks=None):
         self._fit_encoder(X)
         y_encoded = self._prepare_target(y)
         self.model_ = self._build_model(X, self._n_output())


### PR DESCRIPTION
## Summary

Preparatory work for #98 (parallel processing).

- Add `device=None` to `_NNBase.__init__` — applies to `NNClassifier` and `NNRegressor` via inheritance
- `device='/GPU:N'` → wraps `fit` with `tf.device('/GPU:N')`
- `device='mirror'` → wraps `fit` with `tf.distribute.MirroredStrategy().scope()`
- `NNAdapter.inject_gpu_id(params, gpu_id)` → sets `params['device'] = '/GPU:{gpu_id}'`
- `NNAdapter.get_gpu_usage` → returns `GPU_YES` when `device` is set, `GPU_POSSIBLE` otherwise

Closes #103