### PR TITLE
refactor: decouple Pipeline editing from Experimenter + node serial integrity + DataSourceNode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ CLAUDE.md에서 불필요하게 토큰을 낭비 하지 않도록, 작업 내역
 Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한다.
 커밋 메시지에 "Co-Authored-By" 넣지 마라. PR에 "Generated with Claude Code" 같은 광고성 메시지 넣지 마라.
 
+코드 검증은 `tests/`에서 적절한 `.py`를 찾아 테스트 케이스를 추가하여 진행한다. `python -c` 같은 임시 실행은 하지 않는다.
+
 ## CLI 버전
 - git 2.43.0
 - gh 2.45.0
@@ -21,24 +23,25 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 ## 아키텍처 개요
 - **Pipeline** (`_pipeline.py`): 노드 그래프 자료구조 (ML 관심사 분리)
 - **Experimenter** (`_experimenter.py`): 실험 실행/관리 (Pipeline 사용)
-- **ExpObj** (`_expobj.py`): 노드별 빌드/실험 객체 관리
 - **Trainer** (`_trainer.py`): 학습 실행/관리 (split 기반)
 - **Inferencer** (`_inferencer.py`): 학습된 파이프라인을 새 데이터에 적용
+- **NodeStore** (`_store.py`): 노드 아티팩트 읽기/쓰기 (obj.pkl / result.pkl / info.pkl)
+- **DataFlow / TrainDataFlow** (`_flow.py`): fold별 데이터 흐름 및 stage 빌드
+- **_executor.py**: `_build_flow_single/multi`, `_experiment_single/multi` — 실제 빌드/실험 실행
 
 ## Node/Experiment 상태 모델
 
 ### Node 4-State
 `init → built → finalized` / `init → error → (reset) → init`
 
-| 상태 | Disk | Memory | 설명 |
-|------|------|--------|------|
-| **init** | - | - | Pipeline에 정의만 된 상태 |
-| **built** | O | Stage: O / Head: X | 빌드 완료, 결과 추출 가능 |
-| **finalized** | X | X | 결과 추출 완료, 리소스 해제 (Head 전용) |
-| **error** | - | 에러 정보 | 빌드/실험 중 에러 발생, 내역 보존 |
+| 상태 | Disk | 설명 |
+|------|------|------|
+| **init** | - | Pipeline에 정의만 된 상태 |
+| **built** | O | 빌드 완료, 결과 추출 가능 |
+| **finalized** | info only | 결과 추출 완료, obj/result 삭제 (Head 전용) |
+| **error** | info only | 빌드/실험 중 에러 발생, 내역 보존 |
 
 - Stage는 finalize 불가 (하위 노드에 데이터 지속 공급)
-- 상위 Stage가 error면 하위 노드도 자연스럽게 error (별도 전파 로직 불필요)
 
 ### Experiment 2-State
 `open → closed`
@@ -48,22 +51,31 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 ## 핵심 클래스
 
 ### Node 역할
-- **DataSource** (None): 원본 데이터 제공, Pipeline에 명시적 노드 없음
+- **DataSource** (`DataSourceNode`, key=`None`): 원본 데이터 스키마 및 target 정의
 - **Stage**: 전처리/변환 (TransformProcessor) — 하위 노드에 데이터 공급
 - **Head**: 모델링/예측 (PredictProcessor) — 최종 결과 생산
 
 ### Pipeline 계층 (`_pipeline.py`)
+- `VAR_TYPES = frozenset({'numerical', 'ordinal', 'nominal', 'text', 'binary', 'datetime'})`
 - **`_params_equal(a, b)`**: params dict 안전 비교 헬퍼
   - dict → key별 재귀 비교
   - `__dict__` 있는 객체 → `__dict__` 재귀 비교 (lgb_early_stopping 등 콜백 처리)
   - `__dict__` 없는 객체(primitive, C-ext) → `==` fallback (try/except)
   - 같은 타입이어야 equal 가능, 다른 타입 → False
 - **Pipeline**: 노드 그래프 관리
-  - `nodes`: `{name: PipelineNode}` (None=DataSource), `grps`: `{name: PipelineGroup}`
+  - `nodes`: `{name: PipelineNode}` (`None` → `DataSourceNode`), `grps`: `{name: PipelineGroup}` (`'__datasource__'` 항상 존재)
+  - `datasource`: `nodes[None]` 반환 property
+  - `set_datasource(schema, targets=None)`: DataSource 스키마/target 설정, 변경 시 downstream serial 자동 bump
   - `set_grp(exist='diff'|'skip'|'error'|'replace')`, `set_node(exist=...)`, `rename_grp`, `remove_grp`, `remove_node`
   - `get_node_names(query)`, `get_node_attrs(name)`, `_get_affected_nodes(nodes)`
+  - `_bump_serials(node_names)`: 지정 노드들의 serial을 새 UUID로 교체
   - `copy()`, `copy_stage()`, `copy_nodes(node_names)` — 선택적 복사
   - `compare_nodes(nodes)` → `{processor_name: DataFrame}` (params 차이 + edges['X'] stage별 변수 차이)
+
+- **DataSourceNode** (`PipelineNode` 서브클래스):
+  - `schema`: `{col: var_type}` — var_type은 VAR_TYPES 중 하나
+  - `targets`: `list[str]` — 타겟 컬럼 목록 (타입과 별도)
+  - `get_attrs(grps)`: role='datasource', serial, schema, targets 반환 (processor/edges/method/params 없음)
 
 - **PipelineGroup**: 노드 그룹 (stage/head 역할)
   - 속성: `name`, `role`, `processor`, `edges`, `method`, `parent`, `adapter`, `params`, `desc`
@@ -72,20 +84,21 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
   - `diff(processor, edges, method, parent, adapter, params)`: 달라진 필드명 리스트 반환 (`desc` 제외 → desc-only 변경은 rebuild 미유발)
 
 - **PipelineNode**: 개별 노드
-  - 속성: `name`, `grp`, `processor`, `edges`, `method`, `adapter`, `params`, `desc`
+  - 속성: `name`, `grp`, `processor`, `edges`, `method`, `adapter`, `params`, `desc`, **`serial`** (UUID str)
+  - `serial`: 노드 정의가 변경될 때마다 `_bump_serials`에 의해 새 UUID로 교체 → 아티팩트 무결성 추적
   - `output_edges`: 이 노드를 입력으로 사용하는 노드명 리스트
-  - `get_attrs(grps)`: 그룹 속성과 노드 속성 병합
+  - `get_attrs(grps)`: 그룹 속성과 노드 속성 병합 (`serial` 포함)
   - `diff(grp, processor, edges, method, adapter, params)`: 달라진 필드명 리스트 반환 (`desc` 제외)
   - `set_grp`/`set_node`: `desc` 파라미터 수락; exist='diff' skip 경로에서도 `desc`는 업데이트됨
 
 ### Experimenter (`_experimenter.py`)
 - 생성자: `(data, path, ..., cache_maxsize=4GB, logger, aug_data=None)`
-- `pipeline`: Pipeline 인스턴스
-- `node_objs`: `{node_name: StageObj}` — stage 노드만; head 노드 상태는 `get_head_status`로 on-demand 조회
+- `pipeline`: Pipeline 인스턴스 — **Pipeline 편집은 반드시 `exp.pipeline.*` 을 통해 수행**
 - `cache`: DataCache (LRU, 용량 기반)
 - 실행: `build(nodes, rebuild=False)` (stage), `exp(nodes, finalize=False, include_train=True)` (head)
+  - build/exp 시작 시 serial mismatch 노드 자동 감지 → `reset_nodes()` 후 재빌드
 - `close_exp()`: open→closed 전환, Stage 객체 일괄 정리 (Collector 데이터 유지)
-- 상태관리: `reset_nodes(nodes)` - node_objs, cache, collectors 초기화
+- 상태관리: `reset_nodes(nodes)` - cache, collectors 초기화
 - 에러 조회: `show_error_nodes(nodes=None, traceback=False)` - error 상태 노드 출력
 - `add_collector(collector)`: Collector 등록 (path 설정, save)
 - `get_collector(name)`: Collector 반환 (없으면 None)
@@ -106,36 +119,34 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 - `get_data(node, typ, idx)`, `put_data(node, typ, idx, data)`
 - `clear_nodes(nodes)`: 특정 노드들의 캐시 삭제
 
-### ExpObj (`_expobj.py`)
-- **StageObj**: stage 역할 노드의 빌드 객체
-  - `status`: None(init) / 'built' / 'finalized' / 'error'
-  - `error`: 에러 정보 dict `{type, message, traceback, fold}` (error 상태 시)
-  - `load()`, `start_build()`, `build_idx()`, `end_build()`, `get_objs(idx)`, `finalize()`
+### NodeStore (`_store.py`)
+- fold 경로 아래 노드별 아티팩트 관리: `{path}/{node_name}/`
+  - `obj.pkl` — processor 객체
+  - `result.pkl` — fit_transform/fit_predict 출력
+  - `info.pkl` — `{status, build_id, node_serial, fit_time, edges, train_shape, ...}`
+- `status(name)`: `None`(init) / `'built'` / `'finalized'` / `'error'`
+- `get_info(name)`: info dict (lazy cache), `node_serial` 키로 serial 추적
+- `finalize(name)`: obj/result 삭제, info status → 'finalized'
+- `reset_node(name)`: 디렉토리 전체 삭제, cache 무효화
 
-- **Head 노드 함수 기반 관리** (HeadObj 없음):
-  - `get_head_status(path, name)` → `None`(init) / `'built'` / `'finalized'` / `'error'` — 디스크 on-demand 조회
-    - dir 없음 또는 빈 dir → `None`, `obj0_0.pkl` 존재 → `'built'`, `finalized.pkl` 존재 → `'finalized'`, `error.txt` 존재 → `'error'`
-  - `get_head_error(path, name)` → error dict 또는 None
-  - `set_head_error(path, name, error_info)` → `error.txt` 기록
-  - `finalize_head(path, name)` → obj pkl에서 spec 추출 → `finalized.pkl` 저장 → obj pkl 삭제
-  - `get_head_objs(path, name, idx)` → generator, `(obj, train_, spec)` yield
-  - `exp_node(node_attrs, data_dict_it, idx, logger, collectors, finalize, include_train, include_input)`:
-    - 이미 빌드된 경우(first_file 존재): 디스크에서 로드 후 collector dispatch
-    - 신규 빌드: `_build_iter_output` 호출, warning 캐치 + 에러 시 `set_head_error` 기록
-    - 반환값: `True`(성공) / `False`(에러)
-  - `_safe_collector_call(collector, node, method, logger, *args)`: `_collect`/`_end_idx`용 safe wrapper
-  - `_start`/`_end`는 Experimenter에서 직접 호출 (safe wrapper 없음)
-
-- **에러 처리**: build/exp 중 노드별 try/except, error 시 나머지 노드 계속 진행
+### DataFlow / TrainDataFlow (`_flow.py`)
+- **DataFlow** (NodeStore 상속): 디스크에서 stage processor 로드, 소스 데이터를 stage 그래프로 변환
+  - `node_objs`: `{name: (obj, result, info)}`, `_node_edges`: `{name: edges}`
+  - `load()`: 초기화 시 디스크에서 built 노드 자동 로드
+  - `get_data(source_data, edges)` → `{key: data}`
+- **TrainDataFlow** (DataFlow 상속): stage 빌드 기능 추가
+  - `data_source`: DataWrapperProvider (train/valid 제공)
+  - `set_objs(name, obj, result, info)`: 빌드 완료 후 메모리에 등록
+  - `get_train(edges)`, `get_valid(edges)`: train/valid 데이터 반환
+  - `get_missing_stages(pipeline)`: 미빌드 stage 목록
 
 ### Trainer (`_trainer.py`)
 - 생성자: `(name, pipeline, data, path, splitter, splitter_params, cache, logger)`
-- `split_indices`: 생성자에서 `_make_splits()` 호출하여 생성. `splitter=None`이면 `None` (전체 데이터, split 없음)
+- `train_folds`: `[TrainFold]` — split별 `(TrainDataFlow, NodeStore)` 쌍
 - `selected_stages`, `selected_heads`: `select_head(nodes)`로 설정
-- `node_objs`: `{node_name: TrainStageObj|TrainHeadObj}`
-- `cache`: Experimenter에서 전달받은 DataCache 공유 (type key: `"train_all"`)
-- `select_head(nodes)`: head 노드 지정 + upstream stage 자동 수집, `_get_affected_nodes`로 순서 정렬
-- `train()`: 미빌드 노드만 대상, 노드별 전체 split 처리 후 다음 노드로 진행
+- `cache`: Experimenter에서 전달받은 DataCache 공유
+- `select_head(nodes)`: head 노드 지정 + upstream stage 자동 수집, 위상 순서 정렬
+- `train()`: serial mismatch 자동 감지 후 미빌드 노드만 대상으로 학습
 - `process(data, v=None)`: generator, split마다 head output을 v로 필터 후 concat하여 yield
 - `to_inferencer(v=None)`: 학습된 Processor를 추출하여 Inferencer 생성
 - `reset_nodes(nodes)`: 하위 종속 노드 포함 초기화
@@ -149,16 +160,6 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
   - `nodes`: str/list — 출력할 head 노드 선택 (None=전체). 미등록 노드 지정 시 ValueError
 - 저장/로드: `save(path)`, `load(cls, path)` — 단일 `__inferencer.pkl`에 node_objs 포함
 
-### TrainObj (`_trainobj.py`)
-- `_train_build(node_attrs, data_dict, logger)`: Processor 생성 → fit/fit_process → `(obj, result, info)` 반환
-- **TrainStageObj**: stage 노드용, `objs_` dict에 메모리 보관
-  - `get_obj()`: generator, split 순서대로 `(obj, result, info)` yield
-  - 파일: `obj{split_idx}.pkl`
-- **TrainHeadObj**: head 노드용, 디스크에서 lazy load
-  - `get_obj()`: generator, 파일에서 순차 로드하여 yield
-  - 파일: `obj{split_idx}.pkl`
-- Trainer용 `data_dict`: `{key: (train, valid)}` (Experimenter의 `((train, train_v), valid)`과 다름)
-
 ### Connector (`_connector.py`)
 - `__init__(node_query=None, edges=None, processor=None, role=None)` — 4요소 선택적 매칭
 - `match(node_name, node_attrs)`: 설정된 요소만 검사, 모두 충족 시 True
@@ -168,7 +169,7 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 - **Collector** (`_base.py`): 기본 클래스
   - `__init__(name, connector)`, `path`는 add_collector 시 설정
   - 라이프사이클: `_start(node)`, `_collect(node, idx, inner_idx, context)`, `_end_idx(node, idx)`, `_end(node)`
-  - 에러 처리: `_collect`/`_end_idx`는 `_safe_collector_call`(`_expobj.py`)로 try/except 래핑; `_start`/`_end`는 직접 호출 — 에러 시 예외 전파 대신 `warnings` 리스트에 저장 (`{method, node, type, message, traceback}`) 후 warning 로그
+  - 에러 처리: `_collect`/`_end_idx`는 safe wrapper로 try/except 래핑; `_start`/`_end`는 직접 호출 — 에러 시 `warnings` 리스트에 저장 후 warning 로그
   - `on_attach(experimenter)`: `add_collector`/`collect` 호출 시 자동 실행 — experimenter identity 비교로 중복 재계산 방지; `_on_attach(experimenter)` no-op 훅을 subclass에서 override
   - `_experimenter`: pickle 제외 (save/load 시 None으로 초기화)
   - `has(node)`: 수집 결과 보유 여부 (has_node에 위임)
@@ -236,8 +237,23 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 - `'error'`: 이미 존재하면 ValueError
 - `'replace'`: 기존 객체를 무조건 업데이트
 
-### set_grp replace 동작
-- `edges`, `params` 모두 `None→{}` 변환 후 모든 필드 직접 대입 (기존 값 유지 없음)
+### set_grp 업데이트 동작 (중요)
+`exist='diff'`에서 변경이 감지되면 **제공된 모든 값으로 전체 필드를 대입**한다.
+`None`/빈 값은 그대로 `None`/`{}`으로 덮어쓰므로, **유지하려는 필드도 반드시 명시**해야 한다.
+```python
+# 잘못된 예 — processor/edges/method가 None으로 덮어써짐
+exp.pipeline.set_grp('scale', params={'with_std': False})
+
+# 올바른 예
+exp.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+                     method='transform', edges={'X': [(None, cols)]},
+                     params={'with_std': False})
+```
+
+## Serial 무결성 추적
+- 노드 정의(`set_grp`/`set_node`/`set_datasource`) 변경 시 영향받는 노드들의 `serial`이 새 UUID로 자동 교체 (`_bump_serials`)
+- 아티팩트 `info.pkl`에 `node_serial` 저장
+- `build()`, `exp()`, `train()` 시작 시 현재 serial vs 저장된 serial 비교 → 불일치 노드 자동 reset 후 재빌드
 
 ## Processor (`_node_processor.py`)
 - **TransformProcessor**: `fit`, `fit_process`, `process`
@@ -295,23 +311,23 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 ## 저장 구조
 ```
 {experimenter.path}/
-  __exp.pkl                    # pipeline, node_obj_keys, collector_keys, 메타정보
+  __exp.pkl                         # pipeline, collector_keys, trainer_keys, 메타정보
   __collector/{name}/
-    __config.pkl               # Collector 설정 + 데이터
-    {node}.pkl                 # StackingCollector 노드별 데이터
-    {node}/{idx}_{inner_idx}.pkl  # OutputCollector fold별 데이터
-  {grp_path}/{node_name}/
-    obj{idx}_{no}.pkl          # 빌드 결과 (StageObj: obj+train+spec / head: obj+result+info)
-    finalized.pkl              # head finalize 후: {(outer, inner): spec} dict
-    error.txt                  # head 에러 시: {type, message, traceback, fold}
+    __config.pkl                    # Collector 설정 + 데이터
+    {node}.pkl                      # StackingCollector 노드별 데이터
+    {node}/{idx}_{inner_idx}.pkl    # OutputCollector fold별 데이터
+  __folds/{outer_idx}/{inner_idx}/{node_name}/
+    obj.pkl                         # processor 객체
+    result.pkl                      # fit_transform/fit_predict 출력
+    info.pkl                        # {status, build_id, node_serial, fit_time, edges, ...}
 
 {trainer.path}/
-  __trainer.pkl                # name, splitter, selected_stages/heads, node_obj_keys, split_indices
-  {grp_path}/{node_name}/
-    obj{split_idx}.pkl         # 빌드 결과 (TrainStageObj/TrainHeadObj)
+  __trainer.pkl                     # name, splitter, selected_stages/heads, split_indices
+  {split_idx}/{node_name}/
+    obj.pkl / result.pkl / info.pkl
 
 {inferencer_path}/
-  __inferencer.pkl             # pipeline, selected_stages/heads, n_splits, node_objs, v (단일 파일)
+  __inferencer.pkl                  # pipeline, selected_stages/heads, n_splits, node_objs, v (단일 파일)
 ```
 
 ## 패키지 정보
@@ -335,6 +351,3 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
     - CLS token prepend + N × FTBlock (pre-LN, MHA + FFN/GELU, residual dropout) → CLS token 반환
     - 파라미터: `d_model=192`, `n_heads=8`, `n_layers=3`, `ffn_factor=4/3`, `attention_dropout=0.2`, `ffn_dropout=0.1`, `residual_dropout=0.0`
 - `NNAdapter` (`adapter/_nn.py`): eval_set 전달 + `_ProgressCallback` (epoch 진행률 로깅) + `evals_result` result_obj
-
-## 향후 방향
-- v0.7.0: TBD

--- a/mllabs/_executor.py
+++ b/mllabs/_executor.py
@@ -33,6 +33,7 @@ def _process(node_attrs, train_data, valid_data, fit_process, monitor, gpu_id_li
             warn_msgs = [f"{w.category.__name__}: {w.message}" for w in caught]
             info = {
                 'build_id': str(uuid.uuid4()),
+                'node_serial': node_attrs.get('serial'),
                 'fit_time': time.time() - start_time,
                 'train_shape': None,
                 'edges': node_attrs.get('edges'),
@@ -52,6 +53,7 @@ def _process(node_attrs, train_data, valid_data, fit_process, monitor, gpu_id_li
     ref_data = train_data[_ref_key]
     info = {
         'build_id': str(uuid.uuid4()),
+        'node_serial': node_attrs.get('serial'),
         'fit_time': elapsed_time,
         'train_shape': ref_data.get_shape() if ref_data is not None else None,
         'edges': node_attrs.get('edges'),

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -368,107 +368,6 @@ class Experimenter():
         self._save()
         return trainer
 
-    def _validate_name(self, name):
-        """Node 또는 NodeGroup 이름 검증
-
-        Args:
-            name: 검증할 이름
-
-        Raises:
-            ValueError: 이름이 유효하지 않을 경우
-        """
-        if name is None:
-            return
-
-        # '__' 포함 금지
-        if '__' in name:
-            raise ValueError(f"Name '{name}' cannot contain '__'")
-
-        # 파일/폴더명으로 사용 불가한 문자 금지
-        invalid_chars = ['/', '\\', '\0', '<', '>', ':', '"', '|', '?', '*']
-        for char in invalid_chars:
-            if char in name:
-                raise ValueError(f"Name '{name}' cannot contain '{char}'")
-
-    def get_grp_path(self, grp):
-        if self.path is None:
-            return None
-        if isinstance(grp, str):
-            grp = self.pipeline.get_grp(grp)
-        path_parts = [grp.name]
-        current = self.pipeline.get_grp(grp.parent)
-        while current is not None:
-            path_parts.insert(0, current.name)
-            current = self.pipeline.get_grp(current.parent)
-        return self.path / '/'.join(path_parts)
-
-    def get_node_path(self, node):
-        if isinstance(node, str):
-            node = self.pipeline.get_node(node)
-        grp_path = self.get_grp_path(node.grp)
-        return grp_path / node.name
-
-    def set_grp(self, name, role=None, processor=None, edges=None, method=None, parent=None, adapter=None, params=None, desc=None, exist='diff'):
-        self._check_open()
-        result_obj = self.pipeline.set_grp(
-            name, role, processor, edges, method, parent, adapter, params, desc=desc, exist=exist
-        )
-        
-        affected_nodes = result_obj['affected_nodes']
-        self.reset_nodes(affected_nodes)
-        new_grp_path = self.get_grp_path(result_obj['grp'])
-        if "old_grp" in result_obj:
-            old_grp_path = self.get_grp_path(result_obj['old_grp'])
-            if old_grp_path != new_grp_path:
-                os.makedirs(new_grp_path, exist_ok=True)
-                for fname in os.listdir(old_grp_path):
-                    src_path = os.path.join(old_grp_path, fname)
-                    dst_path = os.path.join(new_grp_path, fname)
-                    shutil.move(src_path, dst_path)
-
-            self.logger.info(f"Group '{name}' updated, {len(affected_nodes)} node(s) affected")
-        self._save()
-        return result_obj
-
-    def rename_grp(self, name_from, name_to):
-        self._check_open()
-        old_grp_path = self.get_grp_path(name_from)
-        self.pipeline.rename_grp(name_from, name_to)
-        new_grp_path = self.get_grp_path(name_to)
-        if old_grp_path.exists():
-            os.makedirs(new_grp_path, exist_ok=True)
-            for fname in os.listdir(old_grp_path):
-                src_path = os.path.join(old_grp_path, fname)
-                dst_path = os.path.join(new_grp_path, fname)
-                shutil.move(src_path, dst_path)
-            shutil.rmtree(old_grp_path)
-        self._save()
-    
-    def remove_grp(self, name):
-        self._check_open()
-        self.pipeline.remove_grp(name)
-
-        self.logger.info(f"Group '{name}' removed")
-        self._save()
-
-
-    def remove_node(self, name):
-        """노드를 제거
-
-        Args:
-            name: 제거할 노드 이름
-
-        Raises:
-            ValueError: 노드가 존재하지 않거나, 자식 노드가 있는 경우
-        """
-        self._check_open()
-        self.pipeline.remove_node(name)
-        for v in self.collectors.values():
-            v.reset_nodes([name])
-
-        self.logger.info(f"Node '{name}' removed")
-        self._save()
-
     def get_status(self, node_name):
         """Return the disk status of a head node across all folds.
 
@@ -595,25 +494,6 @@ class Experimenter():
         self.build()
         self._save()
 
-    def set_node(
-        self, name, grp, processor=None, edges=None,
-        method=None, adapter=None, params=None, desc=None, exist='diff'
-    ):
-        self._check_open()
-        result_obj = self.pipeline.set_node(
-            name, grp, processor, edges, method, adapter, params, desc=desc, exist=exist
-        )
-
-        # 기존 노드를 업데이트한 경우, 하위 노드들도 재빌드
-        if len(result_obj['affected_nodes']) > 0:
-            affected_nodes = result_obj['affected_nodes']
-            self.logger.info(f"Affected {len(affected_nodes)} dependent node(s): {sorted(affected_nodes)}")
-            self.reset_nodes(affected_nodes)
-        if result_obj['result'] == 'update':
-            self.reset_nodes([name])
-        self._save()
-        return result_obj
-
     def reset_nodes(self, nodes):
         """Reset nodes to ``init`` state.
 
@@ -645,6 +525,27 @@ class Experimenter():
 
         for v in self.trainers.values():
             v.reset_nodes(nodes)
+
+    def _reset_serial_stale_nodes(self, node_names):
+        stale = []
+        for name in node_names:
+            current_serial = self.pipeline.nodes[name].serial
+            node = self.pipeline.get_node(name)
+            grp = self.pipeline.get_grp(node.grp)
+            stores = []
+            for outer_fold in self.outer_folds:
+                if grp.role == 'stage':
+                    stores.extend(outer_fold.train_data_flows)
+                else:
+                    stores.extend(outer_fold.artifact_stores)
+            for store in stores:
+                info = store.get_info(name)
+                if info is not None and info.get('node_serial') != current_serial:
+                    stale.append(name)
+                    break
+        if stale:
+            self.reset_nodes(stale)
+            self.logger.info(f"Serial mismatch: reset {len(stale)} node(s): {sorted(stale)}")
 
     def show_error_nodes(self, nodes=None, traceback=False):
         """Print nodes in ``error`` state.
@@ -708,6 +609,7 @@ class Experimenter():
         if rebuild:
             self.reset_nodes(target_nodes)
         else:
+            self._reset_serial_stale_nodes(target_nodes)
             target_nodes = [
                 i for i in target_nodes
                 if self.get_status(i) not in ['built', 'finalized']
@@ -753,12 +655,16 @@ class Experimenter():
         from ._tracker import LoggerExecuteTracker
         self._check_open()
         node_names = set(self.pipeline.get_node_names(nodes))
-        target_nodes = [
+        candidate_nodes = [
             i for i in self.pipeline._get_affected_nodes([None])
             if i is not None
             and i in node_names
             and self.pipeline.grps[self.pipeline.nodes[i].grp].role == 'head'
-            and self.get_status(i) not in ['built', 'finalized']
+        ]
+        self._reset_serial_stale_nodes(candidate_nodes)
+        target_nodes = [
+            i for i in candidate_nodes
+            if self.get_status(i) not in ['built', 'finalized']
         ]
         if not target_nodes:
             self.logger.info("No head nodes to experiment")

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -714,7 +714,7 @@ class Pipeline:
             return []
 
         node = self.nodes[node_name]
-        if node.grp is None:
+        if node.grp is None or node.grp == '__datasource__':
             return []
 
         result = []

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -1,7 +1,11 @@
 import re
+import uuid
 import pandas as pd
 from ._describer import desc_pipeline, desc_node
 from .adapter  import get_adapter
+
+
+VAR_TYPES = frozenset({'numerical', 'ordinal', 'nominal', 'text', 'binary', 'datetime'})
 
 
 class ColSelector:
@@ -164,6 +168,7 @@ class PipelineNode:
         self.adapter = adapter
         self.params = params if params is not None else {}
         self.desc = desc
+        self.serial = str(uuid.uuid4())
 
         self.output_edges = []  # 이 노드를 입력으로 사용하는 노드들의 이름
         self.attrs = None
@@ -173,6 +178,7 @@ class PipelineNode:
             self.name, self.grp, self.processor, self.edges.copy(),
             self.method, self.adapter, self.params.copy(), self.desc
         )
+        ret.serial = self.serial
         ret.output_edges = self.output_edges.copy()
         return ret
 
@@ -205,7 +211,8 @@ class PipelineNode:
             'adapter': adapter,
             'params': params,
             'method': grp_attrs.get('method') if self.method is None else self.method,
-            'role': grp_attrs['role']
+            'role': grp_attrs['role'],
+            'serial': self.serial,
         }
 
         return self.attrs
@@ -230,6 +237,41 @@ class PipelineNode:
         return changed
 
 
+class DataSourceNode(PipelineNode):
+    """DataSource node that defines input schema and target columns.
+
+    Attributes:
+        schema (dict[str, str]): {col_name: var_type} where var_type is one of VAR_TYPES.
+        targets (list[str]): Column names designated as targets.
+    """
+
+    def __init__(self):
+        super().__init__("Data_Source", '__datasource__', None, None, None, None)
+        self.schema = {}
+        self.targets = []
+
+    def get_attrs(self, grps):
+        if self.attrs is not None:
+            return self.attrs
+        self.attrs = {
+            'name': self.name,
+            'grp': self.grp,
+            'role': 'datasource',
+            'serial': self.serial,
+            'schema': self.schema.copy(),
+            'targets': list(self.targets),
+        }
+        return self.attrs
+
+    def copy(self):
+        ret = DataSourceNode()
+        ret.serial = self.serial
+        ret.schema = self.schema.copy()
+        ret.targets = list(self.targets)
+        ret.output_edges = self.output_edges.copy()
+        return ret
+
+
 class Pipeline:
     """Node graph that describes an ML workflow.
 
@@ -243,9 +285,51 @@ class Pipeline:
     """
 
     def __init__(self):
-        self.nodes = {}
-        self.grps = {}
-        self.nodes = {None: PipelineNode("Data_Source", None, None, None, None, None)}
+        self.grps = {'__datasource__': PipelineGroup('__datasource__', role='datasource')}
+        self.nodes = {None: DataSourceNode()}
+
+    @property
+    def datasource(self):
+        return self.nodes[None]
+
+    def set_datasource(self, schema, targets=None):
+        """Define the input data schema and target columns.
+
+        Args:
+            schema (dict[str, str]): {col_name: var_type}. var_type must be one of
+                'numerical', 'ordinal', 'nominal', 'text', 'binary', 'datetime'.
+            targets (list[str], optional): Target column names. Must all exist in schema.
+
+        Returns:
+            str: ``'update'`` if schema/targets changed, ``'skip'`` if unchanged.
+
+        Raises:
+            ValueError: If any type is invalid or any target column is not in schema.
+        """
+        if targets is None:
+            targets = []
+        targets = list(targets)
+
+        for col, typ in schema.items():
+            if typ not in VAR_TYPES:
+                raise ValueError(
+                    f"Invalid type '{typ}' for column '{col}'. Must be one of {sorted(VAR_TYPES)}"
+                )
+        for col in targets:
+            if col not in schema:
+                raise ValueError(f"Target column '{col}' not in schema")
+
+        ds = self.nodes[None]
+        if ds.schema == schema and ds.targets == targets:
+            return 'skip'
+
+        ds.schema = dict(schema)
+        ds.targets = targets
+        ds.serial = str(uuid.uuid4())
+        ds.update_attrs()
+
+        self._bump_serials(self._get_affected_nodes([None]))
+        return 'update'
 
     def copy(self):
         """Return a deep copy of the entire pipeline.
@@ -421,6 +505,12 @@ class Pipeline:
             self.grps[child_name].update_attrs()
             self._cascade_clear_attrs(child_name)
 
+    def _bump_serials(self, node_names):
+        for name in node_names:
+            if name is not None and name in self.nodes:
+                self.nodes[name].serial = str(uuid.uuid4())
+                self.nodes[name].update_attrs()
+
     def _get_affected_nodes(self, nodes):
         priorities = {}
         queue = []
@@ -480,6 +570,8 @@ class Pipeline:
                 raise ValueError(f"Parent group '{parent}' not found")
             if role is None:
                 role = self.grps[parent].role
+        if role is None and name in self.grps:
+            role = self.grps[name].role
         if role not in ['stage', 'head']:
             raise ValueError(f"Role must be 'stage' or 'head', got '{role}'")
 
@@ -564,6 +656,8 @@ class Pipeline:
             for node_name in affected_nodes:
                 if node_name in self.nodes:
                     self.nodes[node_name].update_attrs()
+
+        self._bump_serials(self._get_affected_nodes(affected_nodes))
 
         return {
             "result": "update", "affected_nodes": affected_nodes, "old_grp": old_grp, "grp": grp
@@ -793,6 +887,9 @@ class Pipeline:
             affected_nodes = list()
 
         self.nodes[name] = node
+
+        if is_update:
+            self._bump_serials(affected_nodes)
 
         return {
             'result': 'update' if is_update else 'new',

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -194,6 +194,19 @@ class Trainer:
     # train
     # ------------------------------------------------------------------
 
+    def _reset_serial_stale_nodes(self, node_names):
+        stale = []
+        for name in node_names:
+            current_serial = self.pipeline.nodes[name].serial
+            for fold in self.train_folds:
+                info = fold.artifact_stores[0].get_info(name)
+                if info is not None and info.get('node_serial') != current_serial:
+                    stale.append(name)
+                    break
+        if stale:
+            self.reset_nodes(stale)
+            self.logger.info(f"Serial mismatch: reset {len(stale)} node(s): {sorted(stale)}")
+
     def train(self, n_jobs=1, gpu_id_list=None):
         """Train all unbuilt selected nodes across all splits.
 
@@ -205,6 +218,9 @@ class Trainer:
         """
         from ._executor import _build_flow_single, _build_flow_multi, _experiment_single, _experiment_multi
         from ._tracker import LoggerExecuteTracker
+
+        candidate_nodes = self.selected_stages + self.selected_heads
+        self._reset_serial_stale_nodes(candidate_nodes)
 
         target_stages = [
             n for n in self.selected_stages

--- a/mllabs/_trainobj.py
+++ b/mllabs/_trainobj.py
@@ -1,2 +1,0 @@
-# TrainStageObj and TrainHeadObj were removed in the TrainDataFlow refactor.
-# Training is now handled by TrainFold + _executor (_build_flow_single/multi, _experiment_single/multi).

--- a/mllabs/processor/_categorical.py
+++ b/mllabs/processor/_categorical.py
@@ -300,7 +300,6 @@ class CatConverter(BaseEstimator, TransformerMixin):
 
 
 class CatOOVFilter(BaseEstimator, TransformerMixin):
-
     def __init__(
         self,
         columns=None,
@@ -422,6 +421,7 @@ class CatOOVFilter(BaseEstimator, TransformerMixin):
         exprs = []
         for col in self.columns_:
             allowed = set(self.categories_[col])
+            cats = self._get_dtype_categories(col)
             mv = self.missing_value
             tes = self.treat_empty_string_as_missing
 
@@ -438,7 +438,7 @@ class CatOOVFilter(BaseEstimator, TransformerMixin):
             exprs.append(
                 pl.col(col)
                 .map_elements(_map, return_dtype=pl.Utf8)
-                .cast(pl.Categorical)
+                .cast(pl.Enum(cats))
                 .alias(col)
             )
         return X.with_columns(exprs)

--- a/mllabs/processor/_polars.py
+++ b/mllabs/processor/_polars.py
@@ -3,17 +3,18 @@ import polars as pl
 from ._dproc import get_type_df, get_type_pl, merge_type_df
 
 class PolarsLoader(TransformerMixin, BaseEstimator):
-    def __init__(self, predefined_types = {}, read_method = 'read_csv'):
+    def __init__(self, predefined_types = {}, read_method = 'read_csv', infer_schema_length = 100):
         self.predefined_types = predefined_types
         self.read_method = read_method
-    
+        self.infer_schema_length = infer_schema_length
+
     def fit(self, X, y = None):
         if type(X) is list:
             self.df_type_ = merge_type_df([
-                pl.scan_csv(i).pipe(get_type_df) for i in X
+                pl.scan_csv(i, infer_schema_length=self.infer_schema_length).pipe(get_type_df) for i in X
             ])
         else:
-            self.df_type_ = pl.scan_csv(X).pipe(get_type_df)
+            self.df_type_ = pl.scan_csv(X, infer_schema_length=self.infer_schema_length).pipe(get_type_df)
         self.pl_type_ = get_type_pl(
             self.df_type_, self.predefined_types
         )
@@ -32,7 +33,8 @@ class PolarsLoader(TransformerMixin, BaseEstimator):
     def get_params(self, deep = True):
         return {
             'predefined_types': self.predefined_types,
-            'read_method': self.read_method
+            'read_method': self.read_method,
+            'infer_schema_length': self.infer_schema_length,
         }
         
     def set_output(self, transform = 'polars'):

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -45,14 +45,14 @@ def built_exp(tmp_path, sample_data):
         path=tmp_path / 'exp',
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
     )
-    e.set_grp('scale', role='stage', processor=StandardScaler,
+    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
               method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.set_node('scaler', grp='scale')
-    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    e.pipeline.set_node('scaler', grp='scale')
+    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.set_node('dt', grp='model')
+    e.pipeline.set_node('dt', grp='model')
     e.build()
     e.exp()
     return e
@@ -66,11 +66,11 @@ def built_exp_inner(tmp_path, sample_data):
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
     )
-    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.set_node('dt', grp='model')
+    e.pipeline.set_node('dt', grp='model')
     e.build()
     e.exp()
     return e
@@ -83,12 +83,12 @@ def multi_head_exp(tmp_path, sample_data):
         path=tmp_path / 'exp_multi',
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
     )
-    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.set_node('dt1', grp='model')
-    e.set_node('dt2', grp='model', params={'max_depth': 5})
+    e.pipeline.set_node('dt1', grp='model')
+    e.pipeline.set_node('dt2', grp='model', params={'max_depth': 5})
     e.build()
     e.exp()
     return e
@@ -680,11 +680,11 @@ class TestCollectorErrorHandling:
             path=tmp_path / 'exp_pre',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         e.build()
         return e
 
@@ -838,11 +838,11 @@ class TestProcessCollector:
             path=tmp_path / 'exp_proba',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict_proba',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         e.build()
         e.exp()
         return e
@@ -878,11 +878,11 @@ class TestFinalizedBeforeCollect:
             path=tmp_path / 'exp_fin',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         e.build()
         e.exp()
         e.finalize('dt')
@@ -948,11 +948,11 @@ class TestGetCollectStatus:
             path=tmp_path / 'exp_notexp',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         e.build()
         return e
 
@@ -963,11 +963,11 @@ class TestGetCollectStatus:
             path=tmp_path / 'exp_fin2',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         e.build()
         e.exp()
         e.finalize('dt')
@@ -980,10 +980,10 @@ class TestGetCollectStatus:
             path=tmp_path / 'exp_err',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=FailPredictor,
+        e.pipeline.set_grp('model', role='head', processor=FailPredictor,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         e.build()
         e.exp()
         return e
@@ -1034,12 +1034,12 @@ class TestGetCollectStatus:
             path=tmp_path / 'exp_mixed',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt1', grp='model')
-        e.set_node('dt2', grp='model', params={'max_depth': 5})
+        e.pipeline.set_node('dt1', grp='model')
+        e.pipeline.set_node('dt2', grp='model', params={'max_depth': 5})
         e.build()
         e.exp('dt1')
         e.exp('dt2')

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -74,17 +74,17 @@ def exp(tmp_path, sample_data):
 
 
 def _setup_stage(e):
-    e.set_grp('scale', role='stage', processor=StandardScaler,
-              method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.set_node('scaler', grp='scale')
+    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+                       method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
+    e.pipeline.set_node('scaler', grp='scale')
 
 
 def _setup_head(e):
-    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
-              method='predict', edges={'X': [(None, ['f1', 'f2', 'f3'])],
-                                        'y': [(None, 'target')]},
-              params={'max_depth': 3, 'random_state': 42})
-    e.set_node('dt', grp='model')
+    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+                       method='predict', edges={'X': [(None, ['f1', 'f2', 'f3'])],
+                                                'y': [(None, 'target')]},
+                       params={'max_depth': 3, 'random_state': 42})
+    e.pipeline.set_node('dt', grp='model')
 
 
 def _setup_full(e):
@@ -165,46 +165,12 @@ class TestExperimenterInit:
         assert exp.status == 'open'
 
     def test_pipeline_empty(self, exp):
-        assert len(exp.pipeline.grps) == 0
+        user_grps = {k: v for k, v in exp.pipeline.grps.items() if not k.startswith('__')}
+        assert len(user_grps) == 0
 
     def test_data_key(self, tmp_path, sample_data):
         e = Experimenter(data=sample_data, path=tmp_path / 'dk', data_key='test_key')
         assert e.data_key == 'test_key'
-
-
-class TestPipelineDelegation:
-    def test_set_grp(self, exp):
-        r = exp.set_grp('g1', role='stage')
-        assert r['result'] == 'new'
-        assert 'g1' in exp.pipeline.grps
-
-    def test_set_node(self, exp):
-        exp.set_grp('g1', role='stage', processor=StandardScaler,
-                    method='transform', edges={'X': [(None, None)]})
-        r = exp.set_node('n1', grp='g1')
-        assert r['result'] == 'new'
-        assert 'n1' in exp.pipeline.nodes
-
-    def test_remove_node(self, exp):
-        _setup_stage(exp)
-        exp.remove_node('scaler')
-        assert 'scaler' not in exp.pipeline.nodes
-
-    def test_remove_grp(self, exp):
-        exp.set_grp('g1', role='stage')
-        exp.remove_grp('g1')
-        assert 'g1' not in exp.pipeline.grps
-
-    def test_rename_grp(self, exp):
-        exp.set_grp('old', role='stage')
-        exp.rename_grp('old', 'new')
-        assert 'new' in exp.pipeline.grps
-        assert 'old' not in exp.pipeline.grps
-
-    def test_closed_status_blocks_modification(self, exp):
-        exp.close()
-        with pytest.raises(RuntimeError):
-            exp.set_grp('g1', role='stage')
 
 
 class TestBuild:
@@ -224,27 +190,43 @@ class TestBuild:
         assert flow.get_info('scaler')['build_id'] == build_id
 
     def test_build_error_continues(self, exp):
-        exp.set_grp('good', role='stage', processor=StandardScaler,
-                    method='transform', edges={'X': [(None, ['f1'])]})
-        exp.set_node('good_node', grp='good')
-        exp.set_grp('bad', role='stage', processor=BadProcessor,
-                    method='transform', edges={'X': [(None, ['f2'])]})
-        exp.set_node('bad_node', grp='bad')
+        exp.pipeline.set_grp('good', role='stage', processor=StandardScaler,
+                             method='transform', edges={'X': [(None, ['f1'])]})
+        exp.pipeline.set_node('good_node', grp='good')
+        exp.pipeline.set_grp('bad', role='stage', processor=BadProcessor,
+                             method='transform', edges={'X': [(None, ['f2'])]})
+        exp.pipeline.set_node('bad_node', grp='bad')
         exp.build()
         flow = _flow(exp)
         assert flow.status('good_node') == 'built'
         assert flow.status('bad_node') == 'error'
 
     def test_build_error_dict(self, exp):
-        exp.set_grp('err', role='stage', processor=ErrorProcessor,
-                    method='transform', edges={'X': [(None, ['f1'])]})
-        exp.set_node('err_node', grp='err')
+        exp.pipeline.set_grp('err', role='stage', processor=ErrorProcessor,
+                             method='transform', edges={'X': [(None, ['f1'])]})
+        exp.pipeline.set_node('err_node', grp='err')
         exp.build()
         info = _flow(exp).get_info('err_node')
         err = info['error']
         assert err['type'] == 'TypeError'
         assert 'test error msg' in err['message']
         assert 'traceback' in err
+
+    def test_build_info_contains_node_serial(self, exp):
+        _setup_stage(exp)
+        exp.build()
+        expected_serial = exp.pipeline.nodes['scaler'].serial
+        info = _flow(exp).get_info('scaler')
+        assert info['node_serial'] == expected_serial
+
+    def test_build_error_info_contains_node_serial(self, exp):
+        exp.pipeline.set_grp('err', role='stage', processor=ErrorProcessor,
+                             method='transform', edges={'X': [(None, ['f1'])]})
+        exp.pipeline.set_node('err_node', grp='err')
+        exp.build()
+        expected_serial = exp.pipeline.nodes['err_node'].serial
+        info = _flow(exp).get_info('err_node')
+        assert info['node_serial'] == expected_serial
 
 
 class TestExp:
@@ -264,10 +246,10 @@ class TestExp:
         assert store.get_info('dt')['build_id'] == build_id
 
     def test_exp_error(self, exp):
-        exp.set_grp('bad_model', role='head', processor=BadPredictor,
-                    method='predict', edges={'X': [(None, ['f1'])],
-                                              'y': [(None, 'target')]})
-        exp.set_node('bad_dt', grp='bad_model')
+        exp.pipeline.set_grp('bad_model', role='head', processor=BadPredictor,
+                             method='predict', edges={'X': [(None, ['f1'])],
+                                                     'y': [(None, 'target')]})
+        exp.pipeline.set_node('bad_dt', grp='bad_model')
         exp.exp()
         assert exp.get_status('bad_dt') == 'error'
 
@@ -334,13 +316,15 @@ class TestResetNodes:
         exp.reset_nodes(['scaler'])
         assert exp.cache.get_data('scaler', 0, 0, 'train') is None
 
-    def test_set_node_replace_resets(self, exp):
+    def test_pipeline_set_node_replace_then_build_resets(self, exp):
         _setup_stage(exp)
         exp.build()
         flow = _flow(exp)
         assert flow.status('scaler') == 'built'
-        exp.set_node('scaler', grp='scale', exist='replace')
-        assert flow.status('scaler') is None
+        exp.pipeline.set_node('scaler', grp='scale', exist='replace')
+        # artifact still on disk until build() triggers serial mismatch reset
+        exp.build()
+        assert flow.status('scaler') == 'built'
 
 
 class TestRebuild:
@@ -359,7 +343,7 @@ class TestRebuild:
         exp.build()
         flow = _flow(exp)
         old_obj = flow.node_objs['scaler'][0]
-        exp.set_node('scaler', grp='scale', exist='replace')
+        exp.pipeline.set_node('scaler', grp='scale', exist='replace')
         exp.build()
         new_obj = _flow(exp).node_objs['scaler'][0]
         assert new_obj is not old_obj
@@ -374,6 +358,41 @@ class TestRebuild:
         assert exp.get_status('dt') is None
         exp.exp()
         assert exp.get_status('dt') == 'built'
+
+    def test_build_auto_resets_on_serial_mismatch_stage(self, exp):
+        _setup_stage(exp)
+        exp.build()
+        old_build_id = _flow(exp).get_info('scaler')['build_id']
+        # Simulate pipeline node change by bumping serial directly
+        exp.pipeline._bump_serials(['scaler'])
+        exp.build()
+        new_build_id = _flow(exp).get_info('scaler')['build_id']
+        assert new_build_id != old_build_id
+
+    def test_build_skips_when_serial_matches_stage(self, exp):
+        _setup_stage(exp)
+        exp.build()
+        build_id = _flow(exp).get_info('scaler')['build_id']
+        exp.build()  # serial unchanged — should skip
+        assert _flow(exp).get_info('scaler')['build_id'] == build_id
+
+    def test_exp_auto_resets_on_serial_mismatch_head(self, exp):
+        _setup_full(exp)
+        exp.build()
+        exp.exp()
+        old_build_id = exp.outer_folds[0].artifact_stores[0].get_info('dt')['build_id']
+        exp.pipeline._bump_serials(['dt'])
+        exp.exp()
+        new_build_id = exp.outer_folds[0].artifact_stores[0].get_info('dt')['build_id']
+        assert new_build_id != old_build_id
+
+    def test_exp_skips_when_serial_matches_head(self, exp):
+        _setup_full(exp)
+        exp.build()
+        exp.exp()
+        build_id = exp.outer_folds[0].artifact_stores[0].get_info('dt')['build_id']
+        exp.exp()  # serial unchanged, already built — should skip
+        assert exp.outer_folds[0].artifact_stores[0].get_info('dt')['build_id'] == build_id
 
 
 class TestStateManagement:
@@ -498,24 +517,6 @@ class TestSaveLoad:
         assert loaded.get_n_splits_inner() == exp.get_n_splits_inner()
 
 
-class TestPaths:
-    def test_get_grp_path(self, exp):
-        exp.set_grp('g1', role='stage')
-        path = exp.get_grp_path('g1')
-        assert path == exp.path / 'g1'
-
-    def test_get_grp_path_nested(self, exp):
-        exp.set_grp('parent', role='stage')
-        exp.set_grp('child', role='stage', parent='parent')
-        path = exp.get_grp_path('child')
-        assert path == exp.path / 'parent' / 'child'
-
-    def test_get_node_path(self, exp):
-        _setup_stage(exp)
-        path = exp.get_node_path('scaler')
-        assert path == exp.path / 'scale' / 'scaler'
-
-
 class TestGetStatus:
     def test_get_status_none_before_exp(self, exp):
         _setup_full(exp)
@@ -536,10 +537,10 @@ class TestGetStatus:
         assert exp.get_status('dt') == 'finalized'
 
     def test_get_status_error(self, exp):
-        exp.set_grp('bad_model', role='head', processor=BadPredictor,
-                    method='predict', edges={'X': [(None, ['f1'])],
-                                              'y': [(None, 'target')]})
-        exp.set_node('bad_dt', grp='bad_model')
+        exp.pipeline.set_grp('bad_model', role='head', processor=BadPredictor,
+                             method='predict', edges={'X': [(None, ['f1'])],
+                                                     'y': [(None, 'target')]})
+        exp.pipeline.set_node('bad_dt', grp='bad_model')
         exp.exp()
         assert exp.get_status('bad_dt') == 'error'
 

--- a/tests/test_inferencer.py
+++ b/tests/test_inferencer.py
@@ -31,14 +31,14 @@ def exp(tmp_path, sample_data):
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
     )
-    e.set_grp('scale', role='stage', processor=StandardScaler,
+    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
               method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.set_node('scaler', grp='scale')
-    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    e.pipeline.set_node('scaler', grp='scale')
+    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.set_node('dt', grp='model')
+    e.pipeline.set_node('dt', grp='model')
     e.build()
     e.exp()
     return e
@@ -106,11 +106,11 @@ class TestProcess:
         assert len(results) == inf.n_splits
 
     def test_v_parameter(self, exp, sample_data):
-        exp.set_grp('model_proba', role='head', processor=DecisionTreeClassifier,
+        exp.pipeline.set_grp('model_proba', role='head', processor=DecisionTreeClassifier,
                     method='predict_proba',
                     edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
                     params={'max_depth': 3, 'random_state': 42})
-        exp.set_node('dt_proba', grp='model_proba')
+        exp.pipeline.set_node('dt_proba', grp='model_proba')
         exp.build()
         exp.exp()
         trainer = exp.add_trainer('t_proba')

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 import pytest
 import pandas as pd
-from mllabs._pipeline import Pipeline, PipelineGroup, PipelineNode
+from mllabs._pipeline import Pipeline, PipelineGroup, PipelineNode, DataSourceNode, VAR_TYPES
 
 
 class DummyStage:
@@ -35,8 +35,12 @@ class TestInit:
         assert None in p.nodes
         assert p.nodes[None].name == 'Data_Source'
 
-    def test_empty_grps(self, p):
-        assert p.grps == {}
+    def test_datasource_grp_exists(self, p):
+        assert '__datasource__' in p.grps
+        assert p.grps['__datasource__'].role == 'datasource'
+
+    def test_datasource_is_datasource_node(self, p):
+        assert isinstance(p.nodes[None], DataSourceNode)
 
 
 class TestSetGrp:
@@ -329,6 +333,23 @@ class TestNodeAttrs:
         a1 = p.nodes['n1'].get_attrs(p.grps)
         a2 = p.nodes['n1'].get_attrs(p.grps)
         assert a1 is a2
+
+    def test_attrs_includes_serial(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        attrs = p.get_node_attrs('n1')
+        assert 'serial' in attrs
+        assert attrs['serial'] == p.nodes['n1'].serial
+
+    def test_attrs_serial_updated_after_bump(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        old_serial = p.get_node_attrs('n1')['serial']
+        p._bump_serials(['n1'])
+        new_serial = p.get_node_attrs('n1')['serial']
+        assert new_serial != old_serial
 
 
 class TestNameValidation:
@@ -846,3 +867,201 @@ class TestAdapterAttrsCacheInvalidation:
         p.set_grp('gp', role='stage', adapter=self.DummyAdapter('b'), exist='replace')
         attrs = p.nodes['n1'].get_attrs(p.grps)
         assert attrs['adapter'].mode == 'b'
+
+
+class TestNodeSerial:
+    def _is_uuid(self, s):
+        import uuid
+        try:
+            uuid.UUID(s)
+            return True
+        except (ValueError, AttributeError):
+            return False
+
+    def test_node_has_serial_at_creation(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        assert self._is_uuid(p.nodes['n1'].serial)
+
+    def test_datasource_has_serial(self, p):
+        assert self._is_uuid(p.nodes[None].serial)
+
+    def test_different_nodes_have_different_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p.set_node('n2', grp='g1')
+        assert p.nodes['n1'].serial != p.nodes['n2'].serial
+
+    def test_copy_preserves_serial(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        cp = p.copy()
+        assert cp.nodes['n1'].serial == serial_before
+
+    def test_set_node_no_change_preserves_serial(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        p.set_node('n1', grp='g1')  # exist='diff', no change
+        assert p.nodes['n1'].serial == serial_before
+
+    def test_set_node_update_changes_serial(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        p.set_node('n1', grp='g1', params={'with_std': False})
+        assert p.nodes['n1'].serial != serial_before
+
+    def test_set_node_update_bumps_descendant_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p.set_grp('g2', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [('n1', None)]})
+        p.set_node('n2', grp='g2')
+        p.set_grp('g3', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [('n2', None)]})
+        p.set_node('n3', grp='g3')
+        serial_n2 = p.nodes['n2'].serial
+        serial_n3 = p.nodes['n3'].serial
+        p.set_node('n1', grp='g1', params={'with_std': False})
+        assert p.nodes['n2'].serial != serial_n2
+        assert p.nodes['n3'].serial != serial_n3
+
+    def test_set_node_skip_preserves_descendant_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p.set_grp('g2', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [('n1', None)]})
+        p.set_node('n2', grp='g2')
+        serial_n1 = p.nodes['n1'].serial
+        serial_n2 = p.nodes['n2'].serial
+        p.set_node('n1', grp='g1', exist='skip')
+        assert p.nodes['n1'].serial == serial_n1
+        assert p.nodes['n2'].serial == serial_n2
+
+    def test_set_grp_no_change_preserves_node_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})  # exist='diff', no change
+        assert p.nodes['n1'].serial == serial_before
+
+    def test_set_grp_update_bumps_node_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        p.set_grp('g1', role='stage', processor=AnotherProcessor, method='transform',
+                  edges={'X': [(None, None)]}, exist='replace')
+        assert p.nodes['n1'].serial != serial_before
+
+    def test_set_grp_update_bumps_descendant_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p.set_grp('g2', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [('n1', None)]})
+        p.set_node('n2', grp='g2')
+        serial_n2 = p.nodes['n2'].serial
+        p.set_grp('g1', role='stage', processor=AnotherProcessor, method='transform',
+                  edges={'X': [(None, None)]}, exist='replace')
+        assert p.nodes['n2'].serial != serial_n2
+
+
+SCHEMA_SIMPLE = {'f1': 'numerical', 'f2': 'nominal', 'target': 'binary'}
+
+
+class TestDataSourceNode:
+    def test_get_node_attrs_works(self, p):
+        attrs = p.get_node_attrs(None)
+        assert attrs['role'] == 'datasource'
+        assert attrs['name'] == 'Data_Source'
+        assert 'serial' in attrs
+        assert 'schema' in attrs
+        assert 'targets' in attrs
+
+    def test_datasource_property(self, p):
+        assert p.datasource is p.nodes[None]
+        assert isinstance(p.datasource, DataSourceNode)
+
+    def test_set_datasource_basic(self, p):
+        result = p.set_datasource(SCHEMA_SIMPLE, targets=['target'])
+        assert result == 'update'
+        assert p.datasource.schema == SCHEMA_SIMPLE
+        assert p.datasource.targets == ['target']
+
+    def test_set_datasource_skip_when_unchanged(self, p):
+        p.set_datasource(SCHEMA_SIMPLE, targets=['target'])
+        serial_before = p.datasource.serial
+        result = p.set_datasource(SCHEMA_SIMPLE, targets=['target'])
+        assert result == 'skip'
+        assert p.datasource.serial == serial_before
+
+    def test_set_datasource_bumps_serial_on_schema_change(self, p):
+        p.set_datasource(SCHEMA_SIMPLE)
+        serial_before = p.datasource.serial
+        p.set_datasource({**SCHEMA_SIMPLE, 'f3': 'ordinal'})
+        assert p.datasource.serial != serial_before
+
+    def test_set_datasource_bumps_serial_on_targets_change(self, p):
+        p.set_datasource(SCHEMA_SIMPLE, targets=[])
+        serial_before = p.datasource.serial
+        p.set_datasource(SCHEMA_SIMPLE, targets=['target'])
+        assert p.datasource.serial != serial_before
+
+    def test_set_datasource_bumps_downstream_node_serials(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        p.set_datasource(SCHEMA_SIMPLE)
+        assert p.nodes['n1'].serial != serial_before
+
+    def test_set_datasource_invalid_type(self, p):
+        with pytest.raises(ValueError, match='Invalid type'):
+            p.set_datasource({'col': 'unknown_type'})
+
+    def test_set_datasource_target_not_in_schema(self, p):
+        with pytest.raises(ValueError, match='not in schema'):
+            p.set_datasource(SCHEMA_SIMPLE, targets=['missing_col'])
+
+    def test_all_var_types_accepted(self, p):
+        schema = {t: t for t in VAR_TYPES}
+        result = p.set_datasource(schema)
+        assert result == 'update'
+
+    def test_attrs_serial_reflects_datasource_serial(self, p):
+        p.set_datasource(SCHEMA_SIMPLE)
+        attrs = p.get_node_attrs(None)
+        assert attrs['serial'] == p.datasource.serial
+
+    def test_attrs_cache_invalidated_after_set_datasource(self, p):
+        p.set_datasource(SCHEMA_SIMPLE)
+        old_attrs = p.get_node_attrs(None)
+        p.set_datasource({**SCHEMA_SIMPLE, 'f3': 'datetime'})
+        new_attrs = p.get_node_attrs(None)
+        assert new_attrs is not old_attrs
+        assert 'f3' in new_attrs['schema']
+
+    def test_copy_preserves_schema_and_targets(self, p):
+        p.set_datasource(SCHEMA_SIMPLE, targets=['target'])
+        cp = p.copy()
+        assert cp.datasource.schema == SCHEMA_SIMPLE
+        assert cp.datasource.targets == ['target']
+        assert cp.datasource.serial == p.datasource.serial
+
+    def test_copy_is_independent(self, p):
+        p.set_datasource(SCHEMA_SIMPLE)
+        cp = p.copy()
+        cp.set_datasource({**SCHEMA_SIMPLE, 'extra': 'text'})
+        assert 'extra' not in p.datasource.schema

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -498,8 +498,8 @@ class TestCatOOVFilter:
         filt = CatOOVFilter()
         filt.fit(oov_polars_df)
         result = filt.transform(oov_polars_df)
-        assert result["cat1"].dtype == pl.Categorical
-        assert result["cat2"].dtype == pl.Categorical
+        assert result["cat1"].dtype == pl.Enum(filt.categories_["cat1"])
+        assert result["cat2"].dtype == pl.Enum(filt.categories_["cat2"])
 
     @requires_polars
     def test_polars_oov_filter(self, oov_polars_df):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -294,11 +294,11 @@ class TestTrainerAugData:
             sp=ShuffleSplit(n_splits=1, test_size=0.2, random_state=42),
             sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
         )
-        e.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.set_node('dt', grp='model')
+        e.pipeline.set_node('dt', grp='model')
         return e
 
     def test_add_trainer_stores_aug_data(self, exp, aug_df):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -40,14 +40,14 @@ def exp(tmp_path, sample_data):
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
         sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
     )
-    e.set_grp('scale', role='stage', processor=StandardScaler,
-              method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.set_node('scaler', grp='scale')
-    e.set_grp('model', role='head', processor=DecisionTreeClassifier,
-              method='predict',
-              edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
-              params={'max_depth': 3, 'random_state': 42})
-    e.set_node('dt', grp='model')
+    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+                       method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
+    e.pipeline.set_node('scaler', grp='scale')
+    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+                       method='predict',
+                       edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                       params={'max_depth': 3, 'random_state': 42})
+    e.pipeline.set_node('dt', grp='model')
     e.build()
     e.exp()
     return e
@@ -92,11 +92,11 @@ class TestSelectHead:
         assert 'scaler' in trainer.selected_stages
 
     def test_select_head_multiple(self, exp):
-        exp.set_grp('model2', role='head', processor=DecisionTreeClassifier,
-                    method='predict',
-                    edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
-                    params={'max_depth': 5, 'random_state': 0})
-        exp.set_node('dt2', grp='model2')
+        exp.pipeline.set_grp('model2', role='head', processor=DecisionTreeClassifier,
+                             method='predict',
+                             edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                             params={'max_depth': 5, 'random_state': 0})
+        exp.pipeline.set_node('dt2', grp='model2')
         trainer = exp.add_trainer('t1')
         trainer.select_head(['dt'])
         trainer.select_head(['dt2'])
@@ -135,10 +135,10 @@ class TestTrain:
         assert trainer.get_status('dt') == 'built'
 
     def test_train_error(self, exp):
-        exp.set_grp('bad', role='head', processor=BadProcessor,
-                    method='transform',
-                    edges={'X': [(None, ['f1'])]})
-        exp.set_node('bad_node', grp='bad')
+        exp.pipeline.set_grp('bad', role='head', processor=BadProcessor,
+                             method='transform',
+                             edges={'X': [(None, ['f1'])]})
+        exp.pipeline.set_node('bad_node', grp='bad')
         trainer = exp.add_trainer('t_err')
         trainer.select_head(['bad_node'])
         trainer.train()
@@ -148,10 +148,10 @@ class TestTrain:
         assert 'intentional error' in err['message']
 
     def test_train_error_continues_other_nodes(self, exp):
-        exp.set_grp('bad', role='head', processor=BadProcessor,
-                    method='transform',
-                    edges={'X': [(None, ['f1'])]})
-        exp.set_node('bad_node', grp='bad')
+        exp.pipeline.set_grp('bad', role='head', processor=BadProcessor,
+                             method='transform',
+                             edges={'X': [(None, ['f1'])]})
+        exp.pipeline.set_node('bad_node', grp='bad')
         trainer = exp.add_trainer('t_mixed')
         trainer.select_head(['dt', 'bad_node'])
         trainer.train()
@@ -165,6 +165,74 @@ class TestTrain:
         trainer.train()
         for fold in trainer.train_folds:
             assert fold.artifact_stores[0].status('dt') == 'built'
+
+    def test_serial_in_info(self, exp):
+        trainer = exp.add_trainer('t1')
+        trainer.select_head(['dt'])
+        trainer.train()
+        expected_serial = exp.pipeline.nodes['dt'].serial
+        for fold in trainer.train_folds:
+            info = fold.artifact_stores[0].get_info('dt')
+            assert info['node_serial'] == expected_serial
+
+    def test_serial_mismatch_triggers_reset(self, exp):
+        trainer = exp.add_trainer('t1')
+        trainer.select_head(['dt'])
+        trainer.train()
+
+        build_ids_before = [
+            fold.artifact_stores[0].get_info('dt')['build_id']
+            for fold in trainer.train_folds
+        ]
+
+        exp.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+                             method='predict',
+                             edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                             params={'max_depth': 5, 'random_state': 42})
+        trainer.train()
+
+        build_ids_after = [
+            fold.artifact_stores[0].get_info('dt')['build_id']
+            for fold in trainer.train_folds
+        ]
+        assert build_ids_before != build_ids_after
+
+    def test_serial_mismatch_stage_cascades(self, exp):
+        trainer = exp.add_trainer('t1')
+        trainer.select_head(['dt'])
+        trainer.train()
+
+        build_ids_before = {
+            name: [fold.artifact_stores[0].get_info(name)['build_id'] for fold in trainer.train_folds]
+            for name in ['scaler', 'dt']
+        }
+
+        exp.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+                             method='transform',
+                             edges={'X': [(None, ['f1', 'f2', 'f3'])]},
+                             params={'with_std': False})
+        trainer.train()
+
+        for name in ['scaler', 'dt']:
+            build_ids_after = [fold.artifact_stores[0].get_info(name)['build_id'] for fold in trainer.train_folds]
+            assert build_ids_before[name] != build_ids_after
+
+    def test_no_serial_mismatch_skips_rebuild(self, exp):
+        trainer = exp.add_trainer('t1')
+        trainer.select_head(['dt'])
+        trainer.train()
+
+        build_ids_before = [
+            fold.artifact_stores[0].get_info('dt')['build_id']
+            for fold in trainer.train_folds
+        ]
+        trainer.train()
+
+        build_ids_after = [
+            fold.artifact_stores[0].get_info('dt')['build_id']
+            for fold in trainer.train_folds
+        ]
+        assert build_ids_before == build_ids_after
 
 
 class TestProcess:


### PR DESCRIPTION
Closes #114

## Summary

- **Node serial integrity**: `PipelineNode` gets a UUID `serial` on creation; bumped via `_bump_serials()` whenever its definition changes. `build()`, `exp()`, and `train()` now auto-detect stale artifacts by comparing stored vs current serial and reset them before building.
- **Pipeline decoupling**: Removed `set_grp`, `set_node`, `rename_grp`, `remove_grp`, `remove_node`, `get_grp_path`, `get_node_path` from `Experimenter`. Pipeline editing goes through `exp.pipeline.*` directly.
- **DataSourceNode**: Explicit first-class DataSource node with `schema: {col: var_type}` and `targets: list`. `VAR_TYPES = {'numerical', 'ordinal', 'nominal', 'text', 'binary', 'datetime'}`. Accessible via `pipeline.datasource` and `pipeline.set_datasource()`.

## Breaking changes

- `Experimenter.set_grp` / `set_node` / `rename_grp` / `remove_grp` / `remove_node` removed → use `exp.pipeline.*`
- Artifacts built before this change have no `node_serial` in `info.pkl` → treated as mismatch (auto-reset on next build)
- `_trainobj.py` removed (superseded by `NodeStore` + `DataFlow` architecture)

## Test plan

- [ ] `pytest tests/test_pipeline.py` — `TestNodeSerial`, `TestDataSourceNode`, serial attrs
- [ ] `pytest tests/test_experimenter.py` — serial mismatch rebuild, pipeline delegation removed
- [ ] `pytest tests/test_trainer.py` — serial-in-info, mismatch triggers rebuild, cascade reset