### PR TITLE
feat: serialize Pipeline to SQLite for kernel-free editing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,6 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 - `remove_trainer(name)`: Trainer 제거 후 `_save()`
 - `collect(collector, nodes=None, exist='skip')`: ad-hoc 수집 (빌드 완료된 head 노드 대상, nodes로 범위 제한 가능, progress 포함)
 - `get_node_output(node, idx, v=None)`, `get_node_train_output(node, idx, v=None)`, `get_node_valid_output(node, idx, v=None)`: 노드 출력 추출 (파라미터 순서: node → idx)
-- `process_ext(data, node, idx)`: 임의 외부 데이터를 outer fold `idx`의 upstream stage들에 통과시켜 node 입력 데이터를 inner split 수만큼 yield — ProcessCollector에서 사용
 - `aug_data`: 외부 데이터를 DataSource 수준에서 inner train split에 append — 미퍼시스트, create/load 시 전달
 - `add_trainer(name, ..., aug_data=None)`: Trainer 생성 시 aug_data 전달 가능
 - 저장/로드: `_save()`, `load(filepath, data, data_key)`
@@ -217,11 +216,11 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
   - 쿼리: `get_output(node, idx, inner_idx)`, `get_outputs(node)`
 
 - **ProcessCollector** (`_process.py`): 외부(테스트) 데이터에 대한 예측 수집
-  - `__init__(name, connector, ext_data, experimenter, output_var=None, method='mean')`
-  - `_collect`: `experimenter.process_ext(ext_data, node, idx)`로 inner fold별 upstream stage 통과 → `context['processor'].process()` 호출
+  - `__init__(name, connector, ext_data, output_var=None, method='mean')`
+  - `collect`: `context['output_ext']`에서 결과 추출 → `output_var`로 컬럼 필터
   - inner fold 결과는 `method`(mean/mode/simple)로 outer fold별 집계, 파일 저장: `{path}/{node}/{idx}.pkl`
   - 쿼리: `get_output(nodes=None, agg='mean')` — nodes 필터(None/list/regex) + outer fold 집계 후 column-wise concat 반환
-  - save/load 시 `ext_data`, `experimenter`는 미저장 (런타임 전달)
+  - save/load 시 `ext_data`는 미저장 (런타임 전달)
 
 ## edges 구조
 - dict 형태: `{key: [(node_name, var_spec), ...], ...}`

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -418,7 +418,7 @@ class Experimenter():
                     self.logger.info(f"Finalize '{i}'")
                     for outer_fold in self.outer_folds:
                         for artifact_store in outer_fold.artifact_stores:
-                            artifact_store.finalize(i)  
+                            artifact_store.finalize(i)
 
     def reinitialize(self, nodes):
         self._check_open()
@@ -761,13 +761,6 @@ class Experimenter():
             self.logger.remove_session(1)
             self.logger.remove_session(0)
         return collector
-
-    def process_ext(self, data, node_name, outer_idx):
-        node_attrs = self.pipeline.get_node_attrs(node_name)
-        edges = node_attrs['edges']
-        ext_wrapped = wrap(data)
-        for train_flow in self.outer_folds[outer_idx].train_data_flows:
-            yield train_flow.get_data(ext_wrapped, edges)
 
     def get_train_data(self, edges, o_idx=0, i_idx=0):
         return self.outer_folds[o_idx].train_data_flows[i_idx].get_train(edges)

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -1,6 +1,9 @@
 import re
 import uuid
+import sqlite3
+import json
 import pandas as pd
+from pathlib import Path
 from ._describer import desc_pipeline, desc_node
 from .adapter  import get_adapter
 
@@ -284,9 +287,338 @@ class Pipeline:
             ``None`` is the DataSource.
     """
 
-    def __init__(self):
+    def __init__(self, path=None, name='pipeline'):
         self.grps = {'__datasource__': PipelineGroup('__datasource__', role='datasource')}
         self.nodes = {None: DataSourceNode()}
+        self._db_path = None
+
+        if path is not None:
+            db_path = Path(path) / f'{name}.db'
+            self._db_path = db_path
+            if db_path.exists():
+                self._load_db()
+            else:
+                Path(path).mkdir(parents=True, exist_ok=True)
+                with sqlite3.connect(str(db_path)) as conn:
+                    self._init_db(conn)
+
+    def _init_db(self, conn):
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            CREATE TABLE IF NOT EXISTS grps (
+                name TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                processor TEXT,
+                edges TEXT,
+                method TEXT,
+                parent TEXT,
+                adapter TEXT,
+                params TEXT,
+                desc TEXT
+            );
+            CREATE TABLE IF NOT EXISTS nodes (
+                name TEXT PRIMARY KEY,
+                grp TEXT NOT NULL,
+                processor TEXT,
+                edges TEXT,
+                method TEXT,
+                adapter TEXT,
+                params TEXT,
+                desc TEXT,
+                serial TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS datasource (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                schema TEXT NOT NULL,
+                targets TEXT NOT NULL,
+                serial TEXT NOT NULL
+            );
+        """)
+        ds = self.nodes[None]
+        conn.execute(
+            "INSERT INTO datasource (id, schema, targets, serial) VALUES (1, ?, ?, ?)",
+            (json.dumps(ds.schema), json.dumps(ds.targets), ds.serial)
+        )
+        conn.execute("INSERT INTO meta (key, value) VALUES ('version', '1')")
+
+    def _load_db(self):
+        from ._serialize import deserialize_from_json
+        with sqlite3.connect(str(self._db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+
+            row = conn.execute("SELECT * FROM datasource WHERE id = 1").fetchone()
+            if row:
+                ds = DataSourceNode()
+                ds.schema = json.loads(row['schema'])
+                ds.targets = json.loads(row['targets'])
+                ds.serial = row['serial']
+                self.nodes[None] = ds
+
+            self.grps = {'__datasource__': PipelineGroup('__datasource__', role='datasource')}
+            for row in conn.execute("SELECT * FROM grps ORDER BY rowid").fetchall():
+                grp = PipelineGroup(
+                    name=row['name'],
+                    role=row['role'],
+                    processor=deserialize_from_json(row['processor']),
+                    edges=deserialize_from_json(row['edges']) or {},
+                    method=row['method'],
+                    parent=row['parent'],
+                    adapter=deserialize_from_json(row['adapter']),
+                    params=deserialize_from_json(row['params']) or {},
+                    desc=row['desc'],
+                )
+                self.grps[row['name']] = grp
+
+            for name, grp in self.grps.items():
+                if name == '__datasource__':
+                    continue
+                if grp.parent is not None and grp.parent in self.grps:
+                    parent_grp = self.grps[grp.parent]
+                    if name not in parent_grp.children:
+                        parent_grp.children.append(name)
+
+            self.nodes = {None: self.nodes[None]}
+            for row in conn.execute("SELECT * FROM nodes ORDER BY rowid").fetchall():
+                node = PipelineNode(
+                    name=row['name'],
+                    grp=row['grp'],
+                    processor=deserialize_from_json(row['processor']),
+                    edges=deserialize_from_json(row['edges']) or {},
+                    method=row['method'],
+                    adapter=deserialize_from_json(row['adapter']),
+                    params=deserialize_from_json(row['params']) or {},
+                    desc=row['desc'],
+                )
+                node.serial = row['serial']
+                self.nodes[row['name']] = node
+                if row['grp'] in self.grps and row['name'] not in self.grps[row['grp']].nodes:
+                    self.grps[row['grp']].nodes.append(row['name'])
+
+            for name, node in list(self.nodes.items()):
+                if name is None or node.grp not in self.grps:
+                    continue
+                attrs = node.get_attrs(self.grps)
+                for key, edge_list in attrs.get('edges', {}).items():
+                    for src_name, _ in edge_list:
+                        if src_name in self.nodes:
+                            src_node = self.nodes[src_name]
+                            if name not in src_node.output_edges:
+                                src_node.output_edges.append(name)
+
+    def _db_write(self, fn):
+        if self._db_path is None:
+            return
+        with sqlite3.connect(str(self._db_path)) as conn:
+            fn(conn)
+
+    def _write_grp(self, conn, grp):
+        from ._serialize import serialize_to_json
+        conn.execute(
+            "INSERT OR REPLACE INTO grps "
+            "(name, role, processor, edges, method, parent, adapter, params, desc) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (grp.name, grp.role,
+             serialize_to_json(grp.processor) if grp.processor is not None else None,
+             serialize_to_json(grp.edges),
+             grp.method, grp.parent,
+             serialize_to_json(grp.adapter) if grp.adapter is not None else None,
+             serialize_to_json(grp.params),
+             grp.desc)
+        )
+
+    def _write_node(self, conn, node):
+        from ._serialize import serialize_to_json
+        conn.execute(
+            "INSERT OR REPLACE INTO nodes "
+            "(name, grp, processor, edges, method, adapter, params, desc, serial) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (node.name, node.grp,
+             serialize_to_json(node.processor) if node.processor is not None else None,
+             serialize_to_json(node.edges),
+             node.method,
+             serialize_to_json(node.adapter) if node.adapter is not None else None,
+             serialize_to_json(node.params),
+             node.desc,
+             node.serial)
+        )
+
+    def _write_datasource(self, conn):
+        ds = self.nodes[None]
+        conn.execute(
+            "INSERT OR REPLACE INTO datasource (id, schema, targets, serial) VALUES (1, ?, ?, ?)",
+            (json.dumps(ds.schema), json.dumps(ds.targets), ds.serial)
+        )
+
+    def sync(self):
+        """Update in-memory Pipeline state to match the SQLite DB.
+
+        DB is always the source of truth. Each element is compared and
+        overwritten if different. After applying all changes, children,
+        grp.nodes, and output_edges are fully rebuilt.
+
+        Returns:
+            dict: {
+                'datasource': 'updated' | 'skip',
+                'grps': {'added': [...], 'removed': [...], 'updated': [...]},
+                'nodes': {'added': [...], 'removed': [...], 'updated': [...]},
+            }
+
+        Raises:
+            ValueError: If Pipeline has no DB path.
+        """
+        if self._db_path is None:
+            raise ValueError("Pipeline has no DB path; cannot sync")
+
+        from ._serialize import deserialize_from_json
+
+        changes = {
+            'datasource': 'skip',
+            'grps': {'added': [], 'removed': [], 'updated': []},
+            'nodes': {'added': [], 'removed': [], 'updated': []},
+        }
+
+        with sqlite3.connect(str(self._db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+
+            # datasource
+            row = conn.execute("SELECT * FROM datasource WHERE id = 1").fetchone()
+            if row and row['serial'] != self.nodes[None].serial:
+                ds = self.nodes[None]
+                ds.schema = json.loads(row['schema'])
+                ds.targets = json.loads(row['targets'])
+                ds.serial = row['serial']
+                ds.update_attrs()
+                changes['datasource'] = 'updated'
+
+            # grps
+            db_grps = {}
+            for row in conn.execute("SELECT * FROM grps ORDER BY rowid").fetchall():
+                db_grps[row['name']] = {
+                    'role': row['role'],
+                    'processor': deserialize_from_json(row['processor']),
+                    'edges': deserialize_from_json(row['edges']) or {},
+                    'method': row['method'],
+                    'parent': row['parent'],
+                    'adapter': deserialize_from_json(row['adapter']),
+                    'params': deserialize_from_json(row['params']) or {},
+                    'desc': row['desc'],
+                }
+
+            mem_grp_names = set(self.grps.keys()) - {'__datasource__'}
+            db_grp_names = set(db_grps.keys())
+
+            for name in mem_grp_names - db_grp_names:
+                del self.grps[name]
+                changes['grps']['removed'].append(name)
+
+            for name in db_grp_names - mem_grp_names:
+                d = db_grps[name]
+                self.grps[name] = PipelineGroup(
+                    name=name, role=d['role'], processor=d['processor'],
+                    edges=d['edges'], method=d['method'], parent=d['parent'],
+                    adapter=d['adapter'], params=d['params'], desc=d['desc'],
+                )
+                changes['grps']['added'].append(name)
+
+            for name in mem_grp_names & db_grp_names:
+                d = db_grps[name]
+                grp = self.grps[name]
+                changed = grp.diff(d['processor'], d['edges'], d['method'],
+                                   d['parent'], d['adapter'], d['params'])
+                if changed or grp.role != d['role'] or grp.desc != d['desc']:
+                    grp.role = d['role']
+                    grp.processor = d['processor']
+                    grp.edges = d['edges']
+                    grp.method = d['method']
+                    grp.parent = d['parent']
+                    grp.adapter = d['adapter']
+                    grp.params = d['params']
+                    grp.desc = d['desc']
+                    grp.update_attrs()
+                    changes['grps']['updated'].append(name)
+
+            # nodes
+            db_nodes = {}
+            for row in conn.execute("SELECT * FROM nodes ORDER BY rowid").fetchall():
+                db_nodes[row['name']] = {
+                    'grp': row['grp'],
+                    'processor': deserialize_from_json(row['processor']),
+                    'edges': deserialize_from_json(row['edges']) or {},
+                    'method': row['method'],
+                    'adapter': deserialize_from_json(row['adapter']),
+                    'params': deserialize_from_json(row['params']) or {},
+                    'desc': row['desc'],
+                    'serial': row['serial'],
+                }
+
+            mem_node_names = set(self.nodes.keys()) - {None}
+            db_node_names = set(db_nodes.keys())
+
+            for name in mem_node_names - db_node_names:
+                del self.nodes[name]
+                changes['nodes']['removed'].append(name)
+
+            for name in db_node_names - mem_node_names:
+                d = db_nodes[name]
+                node = PipelineNode(
+                    name=name, grp=d['grp'], processor=d['processor'],
+                    edges=d['edges'], method=d['method'], adapter=d['adapter'],
+                    params=d['params'], desc=d['desc'],
+                )
+                node.serial = d['serial']
+                self.nodes[name] = node
+                changes['nodes']['added'].append(name)
+
+            for name in mem_node_names & db_node_names:
+                d = db_nodes[name]
+                node = self.nodes[name]
+                if node.serial != d['serial']:
+                    node.grp = d['grp']
+                    node.processor = d['processor']
+                    node.edges = d['edges']
+                    node.method = d['method']
+                    node.adapter = d['adapter']
+                    node.params = d['params']
+                    node.desc = d['desc']
+                    node.serial = d['serial']
+                    node.update_attrs()
+                    changes['nodes']['updated'].append(name)
+
+        # Rebuild derived state
+        for name, grp in self.grps.items():
+            if name != '__datasource__':
+                grp.children = []
+                grp.nodes = []
+
+        for name, grp in self.grps.items():
+            if name == '__datasource__':
+                continue
+            if grp.parent and grp.parent in self.grps:
+                if name not in self.grps[grp.parent].children:
+                    self.grps[grp.parent].children.append(name)
+
+        for name, node in self.nodes.items():
+            if name is None:
+                continue
+            node.output_edges = []
+            if node.grp in self.grps and name not in self.grps[node.grp].nodes:
+                self.grps[node.grp].nodes.append(name)
+
+        for name, node in list(self.nodes.items()):
+            if name is None or node.grp not in self.grps:
+                continue
+            attrs = node.get_attrs(self.grps)
+            for key, edge_list in attrs.get('edges', {}).items():
+                for src_name, _ in edge_list:
+                    if src_name in self.nodes:
+                        src_node = self.nodes[src_name]
+                        if name not in src_node.output_edges:
+                            src_node.output_edges.append(name)
+
+        return changes
 
     @property
     def datasource(self):
@@ -329,6 +661,7 @@ class Pipeline:
         ds.update_attrs()
 
         self._bump_serials(self._get_affected_nodes([None]))
+        self._db_write(lambda conn: self._write_datasource(conn))
         return 'update'
 
     def copy(self):
@@ -511,6 +844,15 @@ class Pipeline:
                 self.nodes[name].serial = str(uuid.uuid4())
                 self.nodes[name].update_attrs()
 
+        def _do(conn):
+            for name in node_names:
+                if name is not None and name in self.nodes:
+                    conn.execute(
+                        "UPDATE nodes SET serial = ? WHERE name = ?",
+                        (self.nodes[name].serial, name)
+                    )
+        self._db_write(_do)
+
     def _get_affected_nodes(self, nodes):
         priorities = {}
         queue = []
@@ -585,6 +927,7 @@ class Pipeline:
                 self.grps[parent].children.append(name)
 
             self.grps[name] = grp
+            self._db_write(lambda conn: self._write_grp(conn, grp))
             return {
                 "result": "new", "grp": grp, "affected_nodes": list()
             }
@@ -597,6 +940,9 @@ class Pipeline:
             old_grp = self.grps[name]
             if not old_grp.diff(processor, edges, method, parent, adapter, params):
                 old_grp.desc = desc
+                self._db_write(lambda conn: conn.execute(
+                    "UPDATE grps SET desc = ? WHERE name = ?", (desc, name)
+                ))
                 return {"result": "skip", "grp": old_grp, "affected_nodes": list()}
 
         old_grp = self.grps[name]
@@ -658,6 +1004,7 @@ class Pipeline:
                     self.nodes[node_name].update_attrs()
 
         self._bump_serials(self._get_affected_nodes(affected_nodes))
+        self._db_write(lambda conn: self._write_grp(conn, grp))
 
         return {
             "result": "update", "affected_nodes": affected_nodes, "old_grp": old_grp, "grp": grp
@@ -692,6 +1039,13 @@ class Pipeline:
         del self.grps[name_from]
         self.grps[name_to] = grp
 
+        def _do_rename(conn):
+            conn.execute("DELETE FROM grps WHERE name = ?", (name_from,))
+            self._write_grp(conn, grp)
+            conn.execute("UPDATE nodes SET grp = ? WHERE grp = ?", (name_to, name_from))
+            conn.execute("UPDATE grps SET parent = ? WHERE parent = ?", (name_to, name_from))
+        self._db_write(_do_rename)
+
     def remove_grp(self, name):
         if name not in self.grps:
             raise ValueError(f"Group '{name}' not found")
@@ -708,6 +1062,7 @@ class Pipeline:
             self.grps[grp.parent].children.remove(name)
 
         del self.grps[name]
+        self._db_write(lambda conn: conn.execute("DELETE FROM grps WHERE name = ?", (name,)))
 
     def get_parents(self, node_name):
         if node_name not in self.nodes:
@@ -771,6 +1126,7 @@ class Pipeline:
                 grp.nodes.remove(name)
 
         del self.nodes[name]
+        self._db_write(lambda conn: conn.execute("DELETE FROM nodes WHERE name = ?", (name,)))
 
     def _update_output_edges(self, node_name, old_edges, new_edges):
         if old_edges is not None:
@@ -837,6 +1193,9 @@ class Pipeline:
                 old_node = self.nodes[name]
                 if not old_node.diff(grp, processor, edges, method, adapter, params):
                     old_node.desc = desc
+                    self._db_write(lambda conn: conn.execute(
+                        "UPDATE nodes SET desc = ? WHERE name = ?", (desc, name)
+                    ))
                     return {'result': 'skip', 'affected_nodes': [], 'old_obj': old_node, 'obj': old_node}
 
         old_edges = None
@@ -890,6 +1249,8 @@ class Pipeline:
 
         if is_update:
             self._bump_serials(affected_nodes)
+
+        self._db_write(lambda conn: self._write_node(conn, node))
 
         return {
             'result': 'update' if is_update else 'new',

--- a/mllabs/_serialize.py
+++ b/mllabs/_serialize.py
@@ -1,0 +1,114 @@
+import importlib
+import json
+
+try:
+    import numpy as _np
+    _NP_INT = (_np.integer,)
+    _NP_FLOAT = (_np.floating,)
+except ImportError:
+    _NP_INT = ()
+    _NP_FLOAT = ()
+
+
+def _obj_to_ref(obj):
+    return f"{obj.__module__}.{obj.__qualname__}"
+
+
+def _ref_to_obj(ref):
+    module_path, _, attr = ref.rpartition('.')
+    mod = importlib.import_module(module_path)
+    return getattr(mod, attr)
+
+
+def serialize_value(v):
+    """Reduce any Python value to a JSON-serializable form.
+
+    Supported:
+      - None, bool, int, float, str  → as-is
+      - numpy integer/float          → int/float
+      - list                         → list (elements recursed)
+      - tuple                        → {"__type__": "tuple", "__items__": [...]}
+      - dict                         → dict (values recursed)
+      - type (class)                 → {"__type__": "class",    "__ref__": "mod.Cls"}
+      - importable callable          → {"__type__": "callable", "__ref__": "mod.fn"}
+      - instance w/ get_params       → {"__type__": "instance", "__ref__": "...", "__params__": {...}}
+      - instance w/ __dict__         → same, using __dict__
+      - lambda / local function      → ValueError
+    """
+    if v is None or isinstance(v, bool):
+        return v
+    if isinstance(v, _NP_INT):
+        return int(v)
+    if isinstance(v, _NP_FLOAT):
+        return float(v)
+    if isinstance(v, (int, float, str)):
+        return v
+    if isinstance(v, tuple):
+        return {"__type__": "tuple", "__items__": [serialize_value(x) for x in v]}
+    if isinstance(v, list):
+        return [serialize_value(x) for x in v]
+    if isinstance(v, dict):
+        return {k: serialize_value(val) for k, val in v.items()}
+    if isinstance(v, type):
+        return {"__type__": "class", "__ref__": _obj_to_ref(v)}
+    if callable(v):
+        qualname = getattr(v, '__qualname__', '')
+        if '<lambda>' in qualname or '<locals>' in qualname:
+            raise ValueError(
+                f"Cannot serialize lambda or local function: {v!r}. "
+                "Use an importable function or class instead."
+            )
+        return {"__type__": "callable", "__ref__": _obj_to_ref(v)}
+    if hasattr(v, '__class__'):
+        ref = _obj_to_ref(type(v))
+        if hasattr(v, 'get_params'):
+            try:
+                raw = v.get_params()
+            except TypeError:
+                raw = v.__dict__ if hasattr(v, '__dict__') else {}
+        elif hasattr(v, '__dict__'):
+            raw = v.__dict__
+        else:
+            raise ValueError(f"Cannot serialize {type(v)!r}: {v!r}")
+        return {
+            "__type__": "instance",
+            "__ref__": ref,
+            "__params__": {k: serialize_value(val) for k, val in raw.items()},
+        }
+    raise ValueError(f"Cannot serialize {type(v)!r}: {v!r}")
+
+
+def deserialize_value(d):
+    """Restore a value produced by serialize_value back to a Python object."""
+    if d is None or isinstance(d, (bool, int, float, str)):
+        return d
+    if isinstance(d, list):
+        return [deserialize_value(x) for x in d]
+    if not isinstance(d, dict):
+        return d
+    typ = d.get("__type__")
+    if typ is None:
+        return {k: deserialize_value(v) for k, v in d.items()}
+    if typ == "tuple":
+        return tuple(deserialize_value(x) for x in d["__items__"])
+    if typ == "class":
+        return _ref_to_obj(d["__ref__"])
+    if typ == "callable":
+        return _ref_to_obj(d["__ref__"])
+    if typ == "instance":
+        cls = _ref_to_obj(d["__ref__"])
+        params = {k: deserialize_value(v) for k, v in d.get("__params__", {}).items()}
+        return cls(**params)
+    raise ValueError(f"Unknown __type__ marker: {typ!r}")
+
+
+def serialize_to_json(v):
+    """serialize_value → compact JSON string."""
+    return json.dumps(serialize_value(v), ensure_ascii=False, separators=(',', ':'))
+
+
+def deserialize_from_json(s):
+    """Compact JSON string → deserialize_value."""
+    if s is None:
+        return None
+    return deserialize_value(json.loads(s))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1065,3 +1065,313 @@ class TestDataSourceNode:
         cp = p.copy()
         cp.set_datasource({**SCHEMA_SIMPLE, 'extra': 'text'})
         assert 'extra' not in p.datasource.schema
+
+
+class TestPipelineSQLite:
+    def test_init_creates_db(self, tmp_path):
+        p = Pipeline(path=tmp_path, name='test')
+        assert (tmp_path / 'test.db').exists()
+
+    def test_path_none_no_db(self):
+        p = Pipeline()
+        assert p._db_path is None
+
+    def test_copy_no_db(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        cp = p.copy()
+        assert cp._db_path is None
+
+    def test_set_grp_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('scale', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 'scale' in p2.grps
+        assert p2.grps['scale'].role == 'stage'
+        assert p2.grps['scale'].processor is StandardScaler
+        assert p2.grps['scale'].method == 'transform'
+
+    def test_set_node_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('scale', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('scaler', grp='scale')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 'scaler' in p2.nodes
+        assert p2.nodes['scaler'].grp == 'scale'
+        assert 'scaler' in p2.grps['scale'].nodes
+
+    def test_node_serial_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('scale', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('scaler', grp='scale')
+        serial = p.nodes['scaler'].serial
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.nodes['scaler'].serial == serial
+
+    def test_set_datasource_persists(self, tmp_path):
+        p = Pipeline(path=tmp_path, name='test')
+        schema = {'f1': 'numerical', 'f2': 'nominal', 'target': 'binary'}
+        p.set_datasource(schema, targets=['target'])
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.datasource.schema == schema
+        assert p2.datasource.targets == ['target']
+
+    def test_datasource_serial_persists(self, tmp_path):
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_datasource({'f1': 'numerical', 'target': 'binary'})
+        serial = p.datasource.serial
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.datasource.serial == serial
+
+    def test_remove_grp_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('scale', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.remove_grp('scale')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 'scale' not in p2.grps
+
+    def test_remove_node_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('scale', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('scaler', grp='scale')
+        p.remove_node('scaler')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 'scaler' not in p2.nodes
+        assert 'scaler' not in p2.grps['scale'].nodes
+
+    def test_rename_grp_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('scale', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('scaler', grp='scale')
+        p.rename_grp('scale', 'scaler_grp')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 'scale' not in p2.grps
+        assert 'scaler_grp' in p2.grps
+        assert p2.nodes['scaler'].grp == 'scaler_grp'
+        assert 'scaler' in p2.grps['scaler_grp'].nodes
+
+    def test_output_edges_reconstructed(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('s1', grp='g1')
+        p.set_grp('g2', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [('s1', None)]})
+        p.set_node('s2', grp='g2')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 's2' in p2.nodes['s1'].output_edges
+
+    def test_children_reconstructed(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('parent', role='stage')
+        p.set_grp('child', role='stage', parent='parent', processor=StandardScaler,
+                  method='transform', edges={'X': [(None, None)]})
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert 'child' in p2.grps['parent'].children
+
+    def test_bump_serial_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p._bump_serials(['n1'])
+        new_serial = p.nodes['n1'].serial
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.nodes['n1'].serial == new_serial
+
+    def test_edges_with_list_var_roundtrip(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, ['f1', 'f2'])]})
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.grps['g1'].edges == {'X': [(None, ['f1', 'f2'])]}
+
+    def test_params_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]}, params={'with_std': False})
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.grps['g1'].params == {'with_std': False}
+
+    def test_set_grp_update_serial_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]}, params={'with_std': False}, exist='replace')
+        serial = p.nodes['n1'].serial
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.nodes['n1'].serial == serial
+
+    def test_parent_grp_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('parent', role='stage')
+        p.set_grp('child', role='stage', parent='parent', processor=StandardScaler,
+                  method='transform', edges={'X': [(None, None)]})
+        p.set_node('n1', grp='child')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.grps['child'].parent == 'parent'
+        assert p2.nodes['n1'].grp == 'child'
+
+
+class TestPipelineSync:
+    def _make(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        return p
+
+    def test_sync_no_db_raises(self):
+        p = Pipeline()
+        with pytest.raises(ValueError):
+            p.sync()
+
+    def test_sync_no_change(self, tmp_path):
+        p = self._make(tmp_path)
+        result = p.sync()
+        assert result['datasource'] == 'skip'
+        assert result['grps'] == {'added': [], 'removed': [], 'updated': []}
+        assert result['nodes'] == {'added': [], 'removed': [], 'updated': []}
+
+    def test_sync_datasource_updated(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        schema = {'f1': 'numerical', 'target': 'binary'}
+        # B changes datasource
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_datasource(schema, targets=['target'])
+        # A syncs
+        result = p.sync()
+        assert result['datasource'] == 'updated'
+        assert p.datasource.schema == schema
+        assert p.datasource.targets == ['target']
+
+    def test_sync_grp_added(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B adds a new group
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_grp('g2', role='stage', processor=StandardScaler, method='transform',
+                   edges={'X': [('n1', None)]})
+        # A syncs
+        result = p.sync()
+        assert 'g2' in result['grps']['added']
+        assert 'g2' in p.grps
+        assert p.grps['g2'].processor is StandardScaler
+
+    def test_sync_grp_removed(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B removes the group
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.remove_node('n1')
+        p2.remove_grp('g1')
+        # A syncs
+        result = p.sync()
+        assert 'g1' in result['grps']['removed']
+        assert 'g1' not in p.grps
+
+    def test_sync_grp_updated(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B updates params
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                   edges={'X': [(None, None)]}, params={'with_std': False}, exist='replace')
+        # A syncs
+        result = p.sync()
+        assert 'g1' in result['grps']['updated']
+        assert p.grps['g1'].params == {'with_std': False}
+
+    def test_sync_node_added(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B adds a node
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_node('n2', grp='g1')
+        # A syncs
+        result = p.sync()
+        assert 'n2' in result['nodes']['added']
+        assert 'n2' in p.nodes
+
+    def test_sync_node_removed(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B removes the node
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.remove_node('n1')
+        # A syncs
+        result = p.sync()
+        assert 'n1' in result['nodes']['removed']
+        assert 'n1' not in p.nodes
+
+    def test_sync_node_updated(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        old_serial = p.nodes['n1'].serial
+        # B updates grp (bumps n1 serial)
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                   edges={'X': [(None, None)]}, params={'with_std': False}, exist='replace')
+        # A syncs
+        result = p.sync()
+        assert 'n1' in result['nodes']['updated']
+        assert p.nodes['n1'].serial != old_serial
+        assert p.nodes['n1'].serial == p2.nodes['n1'].serial
+
+    def test_sync_rebuilds_output_edges(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B adds g2/n2 that references n1
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_grp('g2', role='stage', processor=StandardScaler, method='transform',
+                   edges={'X': [('n1', None)]})
+        p2.set_node('n2', grp='g2')
+        # A syncs
+        p.sync()
+        assert 'n2' in p.nodes['n1'].output_edges
+
+    def test_sync_rebuilds_children(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B adds child group
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_grp('g1child', role='stage', parent='g1', processor=StandardScaler,
+                   method='transform', edges={'X': [(None, None)]})
+        # A syncs
+        p.sync()
+        assert 'g1child' in p.grps['g1'].children
+
+    def test_sync_rebuilds_grp_nodes(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        # B adds another node to g1
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_node('n2', grp='g1')
+        # A syncs
+        p.sync()
+        assert 'n2' in p.grps['g1'].nodes

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,260 @@
+import pytest
+import json
+
+from sklearn.preprocessing import StandardScaler
+from sklearn.tree import DecisionTreeClassifier
+
+from mllabs._serialize import (
+    serialize_value, deserialize_value,
+    serialize_to_json, deserialize_from_json,
+    _obj_to_ref, _ref_to_obj,
+)
+
+
+# ---------------------------------------------------------------------------
+# _obj_to_ref / _ref_to_obj
+# ---------------------------------------------------------------------------
+
+class TestObjRef:
+    def test_class_to_ref(self):
+        ref = _obj_to_ref(StandardScaler)
+        assert 'StandardScaler' in ref
+        assert '.' in ref
+
+    def test_ref_roundtrip_class(self):
+        ref = _obj_to_ref(StandardScaler)
+        assert _ref_to_obj(ref) is StandardScaler
+
+    def test_ref_roundtrip_function(self):
+        from sklearn.metrics import accuracy_score
+        ref = _obj_to_ref(accuracy_score)
+        assert _ref_to_obj(ref) is accuracy_score
+
+    def test_ref_invalid_raises(self):
+        with pytest.raises(Exception):
+            _ref_to_obj("not.a.real.module.Thing")
+
+
+# ---------------------------------------------------------------------------
+# serialize_value primitives
+# ---------------------------------------------------------------------------
+
+class TestSerializePrimitives:
+    def test_none(self):
+        assert serialize_value(None) is None
+
+    def test_bool(self):
+        assert serialize_value(True) is True
+        assert serialize_value(False) is False
+
+    def test_int(self):
+        assert serialize_value(42) == 42
+
+    def test_float(self):
+        assert serialize_value(3.14) == pytest.approx(3.14)
+
+    def test_str(self):
+        assert serialize_value("hello") == "hello"
+
+    def test_list(self):
+        assert serialize_value([1, 2, 3]) == [1, 2, 3]
+
+    def test_nested_list(self):
+        result = serialize_value([[1, 2], [3, 4]])
+        assert result == [[1, 2], [3, 4]]
+
+    def test_dict(self):
+        result = serialize_value({"a": 1, "b": "x"})
+        assert result == {"a": 1, "b": "x"}
+
+    def test_tuple(self):
+        result = serialize_value((1, "a", None))
+        assert result == {"__type__": "tuple", "__items__": [1, "a", None]}
+
+    def test_numpy_int(self):
+        import numpy as np
+        result = serialize_value(np.int64(7))
+        assert result == 7
+        assert isinstance(result, int)
+
+    def test_numpy_float(self):
+        import numpy as np
+        result = serialize_value(np.float32(1.5))
+        assert isinstance(result, float)
+
+
+# ---------------------------------------------------------------------------
+# serialize_value classes / callables / instances
+# ---------------------------------------------------------------------------
+
+class TestSerializeObjects:
+    def test_class(self):
+        result = serialize_value(StandardScaler)
+        assert result["__type__"] == "class"
+        assert "StandardScaler" in result["__ref__"]
+
+    def test_callable_function(self):
+        from sklearn.metrics import accuracy_score
+        result = serialize_value(accuracy_score)
+        assert result["__type__"] == "callable"
+        assert "accuracy_score" in result["__ref__"]
+
+    def test_instance_with_get_params(self):
+        scaler = StandardScaler(with_std=False)
+        result = serialize_value(scaler)
+        assert result["__type__"] == "instance"
+        assert "StandardScaler" in result["__ref__"]
+        assert result["__params__"]["with_std"] is False
+
+    def test_instance_default_params(self):
+        clf = DecisionTreeClassifier(max_depth=3)
+        result = serialize_value(clf)
+        assert result["__type__"] == "instance"
+        assert result["__params__"]["max_depth"] == 3
+
+    def test_lambda_raises(self):
+        with pytest.raises(ValueError, match="lambda"):
+            serialize_value(lambda x: x)
+
+    def test_local_function_raises(self):
+        def local():
+            pass
+        with pytest.raises(ValueError):
+            serialize_value(local)
+
+    def test_instance_in_params(self):
+        from mllabs.adapter import LightGBMAdapter
+        adapter = LightGBMAdapter()
+        result = serialize_value(adapter)
+        assert result["__type__"] == "instance"
+        assert "LightGBMAdapter" in result["__ref__"]
+
+
+# ---------------------------------------------------------------------------
+# deserialize_value
+# ---------------------------------------------------------------------------
+
+class TestDeserializeValue:
+    def test_primitives(self):
+        for v in [None, True, False, 1, 3.14, "hello"]:
+            assert deserialize_value(v) == v
+
+    def test_list(self):
+        assert deserialize_value([1, 2, 3]) == [1, 2, 3]
+
+    def test_plain_dict(self):
+        assert deserialize_value({"a": 1}) == {"a": 1}
+
+    def test_tuple(self):
+        d = {"__type__": "tuple", "__items__": [1, "a", None]}
+        result = deserialize_value(d)
+        assert result == (1, "a", None)
+        assert isinstance(result, tuple)
+
+    def test_class(self):
+        d = {"__type__": "class", "__ref__": _obj_to_ref(StandardScaler)}
+        assert deserialize_value(d) is StandardScaler
+
+    def test_callable(self):
+        from sklearn.metrics import accuracy_score
+        d = {"__type__": "callable", "__ref__": _obj_to_ref(accuracy_score)}
+        assert deserialize_value(d) is accuracy_score
+
+    def test_instance(self):
+        scaler = StandardScaler(with_std=False)
+        d = serialize_value(scaler)
+        restored = deserialize_value(d)
+        assert isinstance(restored, StandardScaler)
+        assert restored.with_std is False
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown"):
+            deserialize_value({"__type__": "bogus", "__ref__": "x"})
+
+
+# ---------------------------------------------------------------------------
+# roundtrip
+# ---------------------------------------------------------------------------
+
+class TestRoundtrip:
+    def _rt(self, v):
+        return deserialize_value(serialize_value(v))
+
+    def test_none(self):
+        assert self._rt(None) is None
+
+    def test_primitives(self):
+        for v in [True, 42, 3.14, "hello"]:
+            assert self._rt(v) == v
+
+    def test_list(self):
+        assert self._rt([1, "a", None]) == [1, "a", None]
+
+    def test_tuple(self):
+        result = self._rt((1, "x"))
+        assert result == (1, "x")
+        assert isinstance(result, tuple)
+
+    def test_nested(self):
+        v = {"key": [1, (2, 3), None]}
+        result = self._rt(v)
+        assert result["key"][0] == 1
+        assert result["key"][1] == (2, 3)
+        assert result["key"][2] is None
+
+    def test_class_roundtrip(self):
+        assert self._rt(StandardScaler) is StandardScaler
+
+    def test_instance_roundtrip(self):
+        scaler = StandardScaler(with_mean=False, with_std=True)
+        restored = self._rt(scaler)
+        assert isinstance(restored, StandardScaler)
+        assert restored.with_mean is False
+        assert restored.with_std is True
+
+    def test_adapter_roundtrip(self):
+        from mllabs.adapter import LightGBMAdapter
+        adapter = LightGBMAdapter(eval_mode='train', verbose=0.5)
+        restored = self._rt(adapter)
+        assert type(restored) is LightGBMAdapter
+        assert restored.eval_mode == 'train'
+        assert restored.verbose == pytest.approx(0.5)
+
+    def test_edges_roundtrip(self):
+        edges = {'X': [(None, ['f1', 'f2']), ('scaler', None)], 'y': [(None, 'target')]}
+        result = self._rt(edges)
+        assert result['X'][0] == (None, ['f1', 'f2'])
+        assert result['X'][1] == ('scaler', None)
+        assert result['y'][0] == (None, 'target')
+
+    def test_params_with_class_roundtrip(self):
+        params = {'max_depth': 3, 'criterion': 'gini', 'random_state': 42}
+        assert self._rt(params) == params
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers
+# ---------------------------------------------------------------------------
+
+class TestJsonHelpers:
+    def test_serialize_to_json_returns_string(self):
+        result = serialize_to_json({"a": 1, "b": [2, 3]})
+        assert isinstance(result, str)
+        assert json.loads(result) == {"a": 1, "b": [2, 3]}
+
+    def test_deserialize_from_json_none(self):
+        assert deserialize_from_json(None) is None
+
+    def test_json_roundtrip_instance(self):
+        scaler = StandardScaler(with_std=False)
+        s = serialize_to_json(scaler)
+        restored = deserialize_from_json(s)
+        assert isinstance(restored, StandardScaler)
+        assert restored.with_std is False
+
+    def test_json_roundtrip_tuple_in_edges(self):
+        edges = {'X': [(None, ['f1', 'f2'])]}
+        s = serialize_to_json(edges)
+        restored = deserialize_from_json(s)
+        assert restored['X'][0] == (None, ['f1', 'f2'])
+        assert isinstance(restored['X'][0], tuple)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -123,6 +123,7 @@ class TestSerializeObjects:
             serialize_value(local)
 
     def test_instance_in_params(self):
+        pytest.importorskip("lightgbm")
         from mllabs.adapter import LightGBMAdapter
         adapter = LightGBMAdapter()
         result = serialize_value(adapter)
@@ -213,6 +214,7 @@ class TestRoundtrip:
         assert restored.with_std is True
 
     def test_adapter_roundtrip(self):
+        pytest.importorskip("lightgbm")
         from mllabs.adapter import LightGBMAdapter
         adapter = LightGBMAdapter(eval_mode='train', verbose=0.5)
         restored = self._rt(adapter)


### PR DESCRIPTION
## Summary

- Add `_serialize.py`: `serialize_value`/`deserialize_value`, `obj_to_ref`/`ref_to_obj` — reduces any Python value (class, instance, callable, primitive) to JSON-serializable form
- `Pipeline.__init__` accepts `path`/`name`; auto-creates or loads SQLite DB on init
- Every mutating operation (`set_grp`, `set_node`, `set_datasource`, `rename_grp`, `remove_grp`, `remove_node`, `_bump_serials`) writes to DB immediately — no separate save step needed
- Add `Pipeline.sync()` to pull external DB edits back into memory (for kernel-free editing workflows)
- Remove `Experimenter.process_ext` (superseded by `context['output_ext']` in `ProcessCollector`)

Closes #117