### PR TITLE
refactor: Pipeline as root container for Experimenter and Trainer (#116)

### DIFF
--- a/mllabs/_cache.py
+++ b/mllabs/_cache.py
@@ -1,0 +1,33 @@
+import sys
+from cachetools import LRUCache
+
+
+def _get_data_size(data):
+    if data is None:
+        return 0
+    if isinstance(data, (list, tuple)):
+        return sum(_get_data_size(item) for item in data)
+    if hasattr(data, 'nbytes'):
+        return data.nbytes
+    if hasattr(data, 'memory_usage'):
+        return data.memory_usage(deep=True).sum()
+    return sys.getsizeof(data)
+
+
+class DataCache:
+    def __init__(self, maxsize=4 * 1024 ** 3):
+        self.cache_dic = LRUCache(maxsize=maxsize, getsizeof=_get_data_size)
+
+    def get_data(self, node, outer_idx, inner_idx, typ):
+        return self.cache_dic.get((node, outer_idx, inner_idx, typ), None)
+
+    def put_data(self, node, outer_idx, inner_idx, typ, data):
+        self.cache_dic[(node, outer_idx, inner_idx, typ)] = data
+
+    def clear(self):
+        self.cache_dic.clear()
+
+    def clear_nodes(self, nodes):
+        node_set = set(nodes)
+        for k in [k for k in self.cache_dic if k[0] in node_set]:
+            del self.cache_dic[k]

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -1,6 +1,4 @@
-import re
 import os
-import sys
 import uuid
 import pickle as pkl
 import shutil
@@ -9,7 +7,6 @@ import warnings
 from pathlib import Path
 
 import pandas as pd
-from cachetools import LRUCache
 
 from sklearn.model_selection import ShuffleSplit
 
@@ -18,12 +15,12 @@ from ._flow import TrainDataFlow
 from ._store import NodeStore
 from ._describer import desc_spec, desc_status
 from ._logger import DefaultLogger
+from ._cache import DataCache
 
 from ._pipeline import Pipeline
 from ._node_processor import resolve_columns
 from ._connector import Connector
 from .collector import Collector, MetricCollector, StackingCollector, ModelAttrCollector, SHAPCollector, OutputCollector, ProcessCollector
-from ._trainer import Trainer
 
 
 class OuterFold:
@@ -70,48 +67,6 @@ class OuterFold:
         return self.get_data(test_source, edges, inner_idx)
 
 
-
-def _get_data_size(data):
-    if data is None:
-        return 0
-    if isinstance(data, list):
-        return sum(_get_data_size(item) for item in data)
-    if isinstance(data, tuple):
-        return sum(_get_data_size(item) for item in data)
-    if hasattr(data, 'nbytes'):
-        return data.nbytes
-    if hasattr(data, 'memory_usage'):
-        return data.memory_usage(deep=True).sum()
-    return sys.getsizeof(data)
-
-class DataCache():
-    """LRU cache for Stage node outputs, keyed by ``(node, type, fold_idx)``.
-
-    Capacity is measured in bytes using ``nbytes`` / ``memory_usage``.
-
-    Args:
-        maxsize (int): Maximum cache capacity in bytes. Default 4 GB.
-    """
-
-    def __init__(self, maxsize=4 * 1024 ** 3):  # 4GB 기본값
-        self.cache_dic = LRUCache(maxsize=maxsize, getsizeof=_get_data_size)
-
-    def get_data(self, node, outer_idx, inner_idx, typ):
-        key = (node, outer_idx, inner_idx, typ)
-        return self.cache_dic.get(key, None)
-
-    def put_data(self, node, outer_idx, inner_idx, typ, data):
-        key = (node, outer_idx, inner_idx, typ)
-        self.cache_dic[key] = data
-
-    def clear(self):
-        self.cache_dic.clear()
-
-    def clear_nodes(self, nodes):
-        node_set = set(nodes)
-        keys_to_delete = [k for k in self.cache_dic.keys() if k[0] in node_set]
-        for k in keys_to_delete:
-            del self.cache_dic[k]
 
 class Experimenter():
     """Executes and manages a Pipeline experiment on a single dataset.
@@ -186,7 +141,8 @@ class Experimenter():
                 inner_folds = [(outer_train_idx, None)]
             raw_splits.append((test_idx, inner_folds))
 
-        self.pipeline = Pipeline()
+        self.pipeline = None
+        self.pipeline_id = None
         self.cache = DataCache(maxsize=cache_maxsize)
 
         self.outer_folds = [
@@ -202,10 +158,36 @@ class Experimenter():
             for i, (test_idx, inner_folds) in enumerate(raw_splits)
         ]
         self.collectors = {}
-        self.trainers = {}
         self.status = "open"
         if _save:
             self._save()
+
+    def attach(self, pipeline):
+        """Attach a Pipeline to this Experimenter.
+
+        If this Experimenter has already been associated with a pipeline,
+        the given pipeline must have the same pipeline_id.
+
+        Args:
+            pipeline (Pipeline): Pipeline instance to attach.
+
+        Raises:
+            ValueError: If pipeline_id does not match the previously recorded one.
+        """
+        if self.pipeline_id is not None and pipeline.pipeline_id != self.pipeline_id:
+            raise ValueError(
+                f"Pipeline ID mismatch: expected '{self.pipeline_id}', got '{pipeline.pipeline_id}'"
+            )
+        self.pipeline = pipeline
+        self.pipeline_id = pipeline.pipeline_id
+        self.logger.info(
+            f"Attached: {len(self.pipeline.nodes) - 1} node(s), "
+            f"{len(self.pipeline.grps)} group(s), {len(self.outer_folds)} fold(s)"
+        )
+
+    def _check_pipeline(self):
+        if self.pipeline is None:
+            raise RuntimeError("No pipeline attached. Call attach(pipeline) first.")
 
     def _check_open(self):
         """상태가 open인지 확인하고, 아니면 에러 발생"""
@@ -308,65 +290,6 @@ class Experimenter():
                     result[node] = 'not_collected'
         return result
 
-    def get_trainer(self, name):
-        return self.trainers.get(name)
-
-    def remove_trainer(self, name):
-        if name in self.trainers:
-            del self.trainers[name]
-            self._save()
-
-    def add_trainer(self, name, data=None, splitter="same", splitter_params=None, exist='skip', aug_data=None):
-        """Create and register a Trainer.
-
-        Args:
-            name (str): Trainer name.
-            data: Dataset for the Trainer. ``None`` → use Experimenter's data.
-            splitter: Splitter to use. ``'same'`` reuses ``sp_v``; pass a
-                sklearn splitter object for a custom split strategy; ``None``
-                trains on the full dataset.
-            splitter_params (dict): Column mappings for the splitter. Must be
-                ``None`` when ``splitter='same'``.
-            exist (str): ``'skip'`` (default) returns existing if name already
-                registered; ``'error'`` raises.
-
-        Returns:
-            Trainer: The newly created (or existing) Trainer.
-        """
-        if name in self.trainers:
-            if exist == 'skip':
-                return self.trainers[name]
-            elif exist == 'error':
-                raise RuntimeError(f"Trainer '{name}' already exists")
-
-        if data is None:
-            trainer_data = self.data
-        else:
-            trainer_data = wrap(data)
-
-        if splitter == 'same':
-            if splitter_params is not None:
-                raise ValueError("splitter_params must be None when splitter='same'")
-            trainer_splitter = self.sp_v
-            trainer_splitter_params = self.splitter_params
-        else:
-            trainer_splitter = splitter
-            trainer_splitter_params = splitter_params if splitter_params is not None else {}
-
-        trainer = Trainer(
-            name=name,
-            pipeline=self.pipeline,
-            data=trainer_data,
-            path=self.path / '__trainer' / name,
-            splitter=trainer_splitter,
-            splitter_params=trainer_splitter_params,
-            logger=self.logger,
-            cache=self.cache,
-            aug_data=aug_data,
-        )
-        self.trainers[name] = trainer
-        self._save()
-        return trainer
 
     def get_status(self, node_name):
         """Return the disk status of a head node across all folds.
@@ -521,9 +444,6 @@ class Experimenter():
         self.cache.clear_nodes(nodes)
 
         for v in self.collectors.values():
-            v.reset_nodes(nodes)
-
-        for v in self.trainers.values():
             v.reset_nodes(nodes)
 
     def _reset_serial_stale_nodes(self, node_names):
@@ -832,9 +752,8 @@ class Experimenter():
             'splitter_params': self.splitter_params,
             'cache_maxsize': self.cache_maxsize,
             'exp_id': self.exp_id,
-            'pipeline': self.pipeline,
+            'pipeline_id': self.pipeline_id,
             'collector_keys': {name: type(c).__name__ for name, c in self.collectors.items()},
-            'trainer_keys': list(self.trainers.keys()),
             'status': self.status
         }
 
@@ -892,7 +811,7 @@ class Experimenter():
             logger = logger
         )
         exp.exp_id = save_data['exp_id']
-        exp.pipeline = save_data['pipeline']
+        exp.pipeline_id = save_data.get('pipeline_id')
         exp.status = save_data['status']
 
         # Collector 복원
@@ -906,31 +825,9 @@ class Experimenter():
                 collector = cls.load(coll_path)
                 exp.collectors[coll_name] = collector
 
-        # Trainer 복원
-        from ._trainer import Trainer
-        for trainer_name in save_data.get('trainer_keys', []):
-            trainer_path = filepath / '__trainer' / trainer_name
-            if (trainer_path / '__trainer.pkl').exists():
-                trainer = Trainer._load(
-                    trainer_path,
-                    pipeline=exp.pipeline,
-                    data=exp.data,
-                    cache=exp.cache,
-                    logger=exp.logger,
-                )
-                exp.trainers[trainer_name] = trainer
-
-        exp.logger.info(f"Loaded: {len(exp.pipeline.nodes) - 1} node(s), {len(exp.pipeline.grps)} group(s), {len(exp.outer_folds)} fold(s)")
+        exp.logger.info(f"Loaded. Call attach(pipeline) to complete.")
         return exp
 
-    def export_pipeline(self):
-        return self.pipeline.copy()
-
-    def import_pipeline(self, pipeline):
-        if len(self.pipeline.nodes) > 0 or len(self.pipeline.grps) > 0:
-            raise RuntimeError("")
-        self.pipeline = pipeline.copy()
-    
     def desc_status(self):
         return desc_status(self)
 

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -613,7 +613,6 @@ class Experimenter():
             self.logger.info(f"Exp complete: {n_ok}/{len(target_nodes)} node(s), {len(error_nodes)} error(s): {error_nodes}")
         else:
             self.logger.info(f"Exp complete: {len(target_nodes)} node(s)")
-        self._save()
 
     def collect(self, collector, nodes=None, exist='skip'):
         """Run a Collector ad-hoc over already-built Head nodes.
@@ -834,8 +833,3 @@ class Experimenter():
     def desc_spec(self):
         return desc_spec(self)
 
-    def desc_pipeline(self, max_depth=None, direction='TD'):
-        return self.pipeline.desc_pipeline(max_depth, direction)
-
-    def desc_node(self, node_name, direction='TD', show_params=False):
-        return self.pipeline.desc_node(node_name, direction, show_params)

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -295,6 +295,7 @@ class Pipeline:
         self._db_path = None
         self.pipeline_id = str(uuid.uuid4())
         self.trainers = {}
+        self.experiments = {}
 
         if path is not None:
             db_path = Path(path) / f'{name}.db'
@@ -1418,7 +1419,7 @@ class Pipeline:
         return result
 
     def add_trainer(self, name, data, splitter=None, splitter_params=None, path=None,
-                    cache=None, logger=None, aug_data=None, exist='skip'):
+                    cache=None, logger=None, aug_data=None, tags=None, exist='skip'):
         """Create and register a Trainer on this Pipeline.
 
         Args:
@@ -1464,6 +1465,15 @@ class Pipeline:
             cache=cache if cache is not None else DataCache(),
             aug_data=aug_data,
         )
+        if tags is not None:
+            matching = [
+                n for n, node in self.nodes.items()
+                if n is not None and self.grps[node.grp].role == 'head'
+                and set(node.tag) & set(tags)
+            ]
+            if matching:
+                trainer.select_head(matching)
+
         self.trainers[name] = trainer
         return trainer
 
@@ -1473,6 +1483,69 @@ class Pipeline:
     def remove_trainer(self, name):
         if name in self.trainers:
             del self.trainers[name]
+
+    def _check_data_compatibility(self, data):
+        from ._data_wrapper import wrap
+        schema_cols = set(self.datasource.schema.keys())
+        if not schema_cols:
+            return
+        data_cols = set(wrap(data).get_columns())
+        missing = schema_cols - data_cols
+        if missing:
+            raise ValueError(
+                f"Data is missing columns defined in datasource schema: {sorted(missing)}"
+            )
+
+    def add_experiment(self, name, data, sp=None, sp_v=None, splitter_params=None,
+                       collectors=None, tags=None, path=None, exist='skip',
+                       data_key=None, cache_maxsize=4 * 1024 ** 3, logger=None, aug_data=None):
+        if name in self.experiments:
+            if exist == 'skip':
+                return self.experiments[name]
+            elif exist == 'error':
+                raise ValueError(f"Experiment '{name}' already exists")
+
+        self._check_data_compatibility(data)
+
+        if path is None:
+            if self._db_path is not None:
+                path = self._db_path.parent / '__experiments' / name
+            else:
+                raise ValueError("path is required when Pipeline has no DB path")
+
+        from ._experimenter import Experimenter
+        from ._logger import DefaultLogger
+        from sklearn.model_selection import ShuffleSplit as _SS
+
+        e = Experimenter(
+            data=data,
+            path=path,
+            sp=sp if sp is not None else _SS(n_splits=1, random_state=1),
+            sp_v=sp_v,
+            splitter_params=splitter_params if splitter_params is not None else {},
+            data_key=data_key,
+            cache_maxsize=cache_maxsize,
+            logger=logger if logger is not None else DefaultLogger(level=['info', 'progress']),
+            aug_data=aug_data,
+        )
+        e.attach(self)
+
+        if collectors:
+            for c in collectors:
+                e.add_collector(c)
+
+        if tags is not None:
+            e.tags = tags
+
+        self.experiments[name] = e
+        return e
+
+    def get_experiment(self, name):
+        return self.experiments.get(name)
+
+    def remove_experiment(self, name):
+        if name in self.experiments:
+            del self.experiments[name]
 
     def desc_node(self, node_name, direction='TD', show_params=False):
         """특정 노드까지의 연결 구조를 Mermaid Markdown으로 반환

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -161,7 +161,7 @@ class PipelineNode:
     """
 
     def __init__(
-        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, desc=None
+        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, desc=None, tag=None
     ):
         self.name = name
         self.grp = grp  # group name (str)
@@ -171,6 +171,7 @@ class PipelineNode:
         self.adapter = adapter
         self.params = params if params is not None else {}
         self.desc = desc
+        self.tag = tag if tag is not None else []
         self.serial = str(uuid.uuid4())
 
         self.output_edges = []  # 이 노드를 입력으로 사용하는 노드들의 이름
@@ -179,7 +180,7 @@ class PipelineNode:
     def copy(self):
         ret = PipelineNode(
             self.name, self.grp, self.processor, self.edges.copy(),
-            self.method, self.adapter, self.params.copy(), self.desc
+            self.method, self.adapter, self.params.copy(), self.desc, list(self.tag)
         )
         ret.serial = self.serial
         ret.output_edges = self.output_edges.copy()
@@ -216,6 +217,7 @@ class PipelineNode:
             'method': grp_attrs.get('method') if self.method is None else self.method,
             'role': grp_attrs['role'],
             'serial': self.serial,
+            'tag': list(self.tag),
         }
 
         return self.attrs
@@ -328,7 +330,8 @@ class Pipeline:
                 adapter TEXT,
                 params TEXT,
                 desc TEXT,
-                serial TEXT NOT NULL
+                serial TEXT NOT NULL,
+                tag TEXT DEFAULT '[]' NOT NULL
             );
             CREATE TABLE IF NOT EXISTS datasource (
                 id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -391,6 +394,7 @@ class Pipeline:
                     adapter=deserialize_from_json(row['adapter']),
                     params=deserialize_from_json(row['params']) or {},
                     desc=row['desc'],
+                    tag=json.loads(row['tag']) if row['tag'] else [],
                 )
                 node.serial = row['serial']
                 self.nodes[row['name']] = node
@@ -433,8 +437,8 @@ class Pipeline:
         from ._serialize import serialize_to_json
         conn.execute(
             "INSERT OR REPLACE INTO nodes "
-            "(name, grp, processor, edges, method, adapter, params, desc, serial) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "(name, grp, processor, edges, method, adapter, params, desc, serial, tag) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (node.name, node.grp,
              serialize_to_json(node.processor) if node.processor is not None else None,
              serialize_to_json(node.edges),
@@ -442,7 +446,8 @@ class Pipeline:
              serialize_to_json(node.adapter) if node.adapter is not None else None,
              serialize_to_json(node.params),
              node.desc,
-             node.serial)
+             node.serial,
+             json.dumps(node.tag))
         )
 
     def _write_datasource(self, conn):
@@ -552,6 +557,7 @@ class Pipeline:
                     'params': deserialize_from_json(row['params']) or {},
                     'desc': row['desc'],
                     'serial': row['serial'],
+                    'tag': json.loads(row['tag']) if row['tag'] else [],
                 }
 
             mem_node_names = set(self.nodes.keys()) - {None}
@@ -566,7 +572,7 @@ class Pipeline:
                 node = PipelineNode(
                     name=name, grp=d['grp'], processor=d['processor'],
                     edges=d['edges'], method=d['method'], adapter=d['adapter'],
-                    params=d['params'], desc=d['desc'],
+                    params=d['params'], desc=d['desc'], tag=d['tag'],
                 )
                 node.serial = d['serial']
                 self.nodes[name] = node
@@ -583,6 +589,7 @@ class Pipeline:
                     node.adapter = d['adapter']
                     node.params = d['params']
                     node.desc = d['desc']
+                    node.tag = d['tag']
                     node.serial = d['serial']
                     node.update_attrs()
                     changes['nodes']['updated'].append(name)
@@ -1146,7 +1153,7 @@ class Pipeline:
                             parent_node.output_edges.append(node_name)
 
     def set_node(
-        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, desc=None, exist='diff'
+        self, name, grp, processor=None, edges=None, method=None, adapter=None, params=None, desc=None, tag=None, exist='diff'
     ):
         """Create or update a node.
 
@@ -1193,8 +1200,10 @@ class Pipeline:
                 old_node = self.nodes[name]
                 if not old_node.diff(grp, processor, edges, method, adapter, params):
                     old_node.desc = desc
+                    old_node.tag = tag if tag is not None else []
                     self._db_write(lambda conn: conn.execute(
-                        "UPDATE nodes SET desc = ? WHERE name = ?", (desc, name)
+                        "UPDATE nodes SET desc = ?, tag = ? WHERE name = ?",
+                        (desc, json.dumps(old_node.tag), name)
                     ))
                     return {'result': 'skip', 'affected_nodes': [], 'old_obj': old_node, 'obj': old_node}
 
@@ -1207,7 +1216,7 @@ class Pipeline:
             old_output_edges = old_node.output_edges
 
         node = PipelineNode(
-            name, grp, processor, edges, method=method, adapter=adapter, params=params, desc=desc
+            name, grp, processor, edges, method=method, adapter=adapter, params=params, desc=desc, tag=tag
         )
 
         grp_obj = self.grps[grp]
@@ -1261,6 +1270,36 @@ class Pipeline:
 
     def get_node(self, name):
         return self.nodes.get(name, None)
+
+    def add_tag(self, name, *tags):
+        if name not in self.nodes or name is None:
+            raise ValueError(f"Node '{name}' not found")
+        node = self.nodes[name]
+        changed = False
+        for tag in tags:
+            if tag not in node.tag:
+                node.tag.append(tag)
+                changed = True
+        if changed:
+            node.update_attrs()
+            self._db_write(lambda conn: conn.execute(
+                "UPDATE nodes SET tag = ? WHERE name = ?", (json.dumps(node.tag), name)
+            ))
+
+    def remove_tag(self, name, *tags):
+        if name not in self.nodes or name is None:
+            raise ValueError(f"Node '{name}' not found")
+        node = self.nodes[name]
+        changed = False
+        for tag in tags:
+            if tag in node.tag:
+                node.tag.remove(tag)
+                changed = True
+        if changed:
+            node.update_attrs()
+            self._db_write(lambda conn: conn.execute(
+                "UPDATE nodes SET tag = ? WHERE name = ?", (json.dumps(node.tag), name)
+            ))
 
     def get_node_attrs(self, name):
         """Return fully resolved attributes for a node (group hierarchy merged).

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -293,6 +293,8 @@ class Pipeline:
         self.grps = {'__datasource__': PipelineGroup('__datasource__', role='datasource')}
         self.nodes = {None: DataSourceNode()}
         self._db_path = None
+        self.pipeline_id = str(uuid.uuid4())
+        self.trainers = {}
 
         if path is not None:
             db_path = Path(path) / f'{name}.db'
@@ -346,11 +348,16 @@ class Pipeline:
             (json.dumps(ds.schema), json.dumps(ds.targets), ds.serial)
         )
         conn.execute("INSERT INTO meta (key, value) VALUES ('version', '1')")
+        conn.execute("INSERT INTO meta (key, value) VALUES ('pipeline_id', ?)", (self.pipeline_id,))
 
     def _load_db(self):
         from ._serialize import deserialize_from_json
         with sqlite3.connect(str(self._db_path)) as conn:
             conn.row_factory = sqlite3.Row
+
+            row = conn.execute("SELECT value FROM meta WHERE key = 'pipeline_id'").fetchone()
+            if row:
+                self.pipeline_id = row['value']
 
             row = conn.execute("SELECT * FROM datasource WHERE id = 1").fetchone()
             if row:
@@ -1409,6 +1416,63 @@ class Pipeline:
             result[proc_name] = df
 
         return result
+
+    def add_trainer(self, name, data, splitter=None, splitter_params=None, path=None,
+                    cache=None, logger=None, aug_data=None, exist='skip'):
+        """Create and register a Trainer on this Pipeline.
+
+        Args:
+            name (str): Trainer name.
+            data: Training dataset.
+            splitter: sklearn splitter, or ``None`` (train on full dataset).
+            splitter_params (dict): Column mappings for the splitter.
+            path (str | Path): Artifact directory. Defaults to
+                ``{pipeline_dir}/__trainers/{name}`` when Pipeline has a DB path.
+            cache: DataCache instance. Creates a fresh one if ``None``.
+            logger: Logger instance. Creates a DefaultLogger if ``None``.
+            aug_data: Augmentation data appended to inner train split.
+            exist (str): ``'skip'`` returns existing; ``'error'`` raises.
+
+        Returns:
+            Trainer: The newly created (or existing) Trainer.
+        """
+        if name in self.trainers:
+            if exist == 'skip':
+                return self.trainers[name]
+            elif exist == 'error':
+                raise ValueError(f"Trainer '{name}' already exists")
+
+        if path is None:
+            if self._db_path is not None:
+                path = self._db_path.parent / '__trainers' / name
+            else:
+                raise ValueError("path is required when Pipeline has no DB path")
+
+        from ._cache import DataCache
+        from ._logger import DefaultLogger
+        from ._trainer import Trainer
+        from ._data_wrapper import wrap
+
+        trainer = Trainer(
+            name=name,
+            pipeline=self,
+            data=wrap(data),
+            path=path,
+            splitter=splitter,
+            splitter_params=splitter_params if splitter_params is not None else {},
+            logger=logger if logger is not None else DefaultLogger(level=['info', 'progress']),
+            cache=cache if cache is not None else DataCache(),
+            aug_data=aug_data,
+        )
+        self.trainers[name] = trainer
+        return trainer
+
+    def get_trainer(self, name):
+        return self.trainers.get(name)
+
+    def remove_trainer(self, name):
+        if name in self.trainers:
+            del self.trainers[name]
 
     def desc_node(self, node_name, direction='TD', show_params=False):
         """특정 노드까지의 연결 구조를 Mermaid Markdown으로 반환

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -7,6 +7,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import ShuffleSplit, KFold
 
+from mllabs._pipeline import Pipeline
 from mllabs._experimenter import Experimenter
 from mllabs import Connector, MetricCollector, StackingCollector, ModelAttrCollector, OutputCollector, ProcessCollector
 
@@ -40,19 +41,17 @@ def sample_data():
 
 @pytest.fixture
 def built_exp(tmp_path, sample_data):
-    e = Experimenter(
-        data=sample_data,
-        path=tmp_path / 'exp',
-        sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-    )
-    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+    p = Pipeline(path=tmp_path / 'pipeline_built')
+    p.set_grp('scale', role='stage', processor=StandardScaler,
               method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.pipeline.set_node('scaler', grp='scale')
-    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    p.set_node('scaler', grp='scale')
+    p.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.pipeline.set_node('dt', grp='model')
+    p.set_node('dt', grp='model')
+    e = p.add_experiment('main', data=sample_data,
+                         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
     e.build()
     e.exp()
     return e
@@ -60,17 +59,15 @@ def built_exp(tmp_path, sample_data):
 
 @pytest.fixture
 def built_exp_inner(tmp_path, sample_data):
-    e = Experimenter(
-        data=sample_data,
-        path=tmp_path / 'exp_inner',
-        sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
-    )
-    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    p = Pipeline(path=tmp_path / 'pipeline_inner')
+    p.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.pipeline.set_node('dt', grp='model')
+    p.set_node('dt', grp='model')
+    e = p.add_experiment('main', data=sample_data,
+                         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
+                         sp_v=KFold(n_splits=3, shuffle=True, random_state=42))
     e.build()
     e.exp()
     return e
@@ -78,17 +75,15 @@ def built_exp_inner(tmp_path, sample_data):
 
 @pytest.fixture
 def multi_head_exp(tmp_path, sample_data):
-    e = Experimenter(
-        data=sample_data,
-        path=tmp_path / 'exp_multi',
-        sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-    )
-    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    p = Pipeline(path=tmp_path / 'pipeline_multi')
+    p.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.pipeline.set_node('dt1', grp='model')
-    e.pipeline.set_node('dt2', grp='model', params={'max_depth': 5})
+    p.set_node('dt1', grp='model')
+    p.set_node('dt2', grp='model', params={'max_depth': 5})
+    e = p.add_experiment('main', data=sample_data,
+                         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
     e.build()
     e.exp()
     return e
@@ -675,16 +670,14 @@ class TestBaseCollector:
 class TestCollectorErrorHandling:
     @pytest.fixture
     def pre_exp(self, tmp_path, sample_data):
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_pre',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline_pre')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         return e
 
@@ -833,16 +826,14 @@ class TestProcessCollector:
 
     @pytest.fixture
     def proba_exp(self, tmp_path, sample_data):
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_proba',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline_proba')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict_proba',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         e.exp()
         return e
@@ -873,16 +864,14 @@ class TestFinalizedBeforeCollect:
 
     @pytest.fixture
     def finalized_exp(self, tmp_path, sample_data):
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_fin',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline_fin')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         e.exp()
         e.finalize('dt')
@@ -943,31 +932,27 @@ class TestGetCollectStatus:
     @pytest.fixture
     def not_exp_exp(self, tmp_path, sample_data):
         """Stage built but head exp() not called."""
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_notexp',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline_notexp')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         return e
 
     @pytest.fixture
     def finalized_exp(self, tmp_path, sample_data):
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_fin2',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline_fin2')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         e.exp()
         e.finalize('dt')
@@ -975,15 +960,13 @@ class TestGetCollectStatus:
 
     @pytest.fixture
     def error_exp(self, tmp_path, sample_data):
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_err',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=FailPredictor,
+        p = Pipeline(path=tmp_path / 'pipeline_err')
+        p.set_grp('model', role='head', processor=FailPredictor,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         e.exp()
         return e
@@ -1029,17 +1012,15 @@ class TestGetCollectStatus:
         assert 'dt2' not in status
 
     def test_mixed_status(self, tmp_path, sample_data):
-        e = Experimenter(
-            data=sample_data,
-            path=tmp_path / 'exp_mixed',
-            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline_mixed')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2', 'f3'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt1', grp='model')
-        e.pipeline.set_node('dt2', grp='model', params={'max_depth': 5})
+        p.set_node('dt1', grp='model')
+        p.set_node('dt2', grp='model', params={'max_depth': 5})
+        e = p.add_experiment('main', data=sample_data,
+                             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42))
         e.build()
         e.exp('dt1')
         e.exp('dt2')

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -7,7 +7,8 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import ShuffleSplit, KFold
 
-from mllabs._experimenter import Experimenter, DataCache
+from mllabs._experimenter import Experimenter
+from mllabs._cache import DataCache
 from mllabs._store import NodeStore
 from mllabs._flow import DataFlow
 from mllabs._pipeline import Pipeline
@@ -64,12 +65,18 @@ def sample_data():
 
 
 @pytest.fixture
-def exp(tmp_path, sample_data):
+def pipeline():
+    return Pipeline()
+
+
+@pytest.fixture
+def exp(tmp_path, sample_data, pipeline):
     e = Experimenter(
         data=sample_data,
         path=tmp_path / 'exp',
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
     )
+    e.attach(pipeline)
     return e
 
 
@@ -150,6 +157,7 @@ class TestExperimenterInit:
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
             sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
         )
+        e.attach(Pipeline())
         assert e.get_n_splits() == 2
         assert e.get_n_splits_inner() == 3
         flow = e.outer_folds[0].train_data_flows[0]
@@ -170,6 +178,7 @@ class TestExperimenterInit:
 
     def test_data_key(self, tmp_path, sample_data):
         e = Experimenter(data=sample_data, path=tmp_path / 'dk', data_key='test_key')
+        e.attach(Pipeline())
         assert e.data_key == 'test_key'
 
 
@@ -462,6 +471,7 @@ class TestStateManagement:
         exp.close_exp()
 
         loaded = Experimenter.load(exp.path, sample_data)
+        loaded.attach(exp.pipeline)
         assert loaded.status == 'closed'
 
     def test_reopen_exp_after_save_load(self, exp, sample_data):
@@ -474,6 +484,7 @@ class TestStateManagement:
         exp.close_exp()
 
         loaded = Experimenter.load(exp.path, sample_data)
+        loaded.attach(exp.pipeline)
         assert loaded.status == 'closed'
         loaded.reopen_exp()
         assert loaded.status == 'open'
@@ -497,6 +508,7 @@ class TestSaveLoad:
         path = exp.path
 
         loaded = Experimenter.load(path, sample_data)
+        loaded.attach(exp.pipeline)
         assert set(loaded.pipeline.grps.keys()) == set(exp.pipeline.grps.keys())
         flow = loaded.outer_folds[0].train_data_flows[0]
         assert 'scaler' in flow.node_objs
@@ -504,8 +516,8 @@ class TestSaveLoad:
         assert loaded.get_status('dt') == 'built'
 
     def test_load_data_key_mismatch(self, tmp_path, sample_data):
-        e = Experimenter(data=sample_data, path=tmp_path / 'dk',
-                        data_key='key_a')
+        e = Experimenter(data=sample_data, path=tmp_path / 'dk', data_key='key_a')
+        e.attach(Pipeline())
         with pytest.raises(ValueError, match='data_key'):
             Experimenter.load(tmp_path / 'dk', sample_data, data_key='key_b')
 
@@ -513,6 +525,7 @@ class TestSaveLoad:
         _setup_stage(exp)
         path = exp.path
         loaded = Experimenter.load(path, sample_data)
+        loaded.attach(exp.pipeline)
         assert loaded.get_n_splits() == exp.get_n_splits()
         assert loaded.get_n_splits_inner() == exp.get_n_splits_inner()
 

--- a/tests/test_inferencer.py
+++ b/tests/test_inferencer.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import ShuffleSplit, KFold
 
-from mllabs._experimenter import Experimenter
+from mllabs._pipeline import Pipeline
 from mllabs._inferencer import Inferencer
 from mllabs._data_wrapper import unwrap
 
@@ -25,28 +25,27 @@ def sample_data():
 
 @pytest.fixture
 def exp(tmp_path, sample_data):
-    e = Experimenter(
-        data=sample_data,
-        path=tmp_path / 'exp',
-        sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
-    )
-    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+    p = Pipeline(path=tmp_path / 'pipeline')
+    p.set_grp('scale', role='stage', processor=StandardScaler,
               method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.pipeline.set_node('scaler', grp='scale')
-    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+    p.set_node('scaler', grp='scale')
+    p.set_grp('model', role='head', processor=DecisionTreeClassifier,
               method='predict',
               edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
               params={'max_depth': 3, 'random_state': 42})
-    e.pipeline.set_node('dt', grp='model')
+    p.set_node('dt', grp='model')
+    e = p.add_experiment('main', data=sample_data,
+                         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
+                         sp_v=KFold(n_splits=3, shuffle=True, random_state=42))
     e.build()
     e.exp()
     return e
 
 
 @pytest.fixture
-def trained_trainer(exp):
-    trainer = exp.add_trainer('t1')
+def trained_trainer(tmp_path, exp, sample_data):
+    trainer = exp.pipeline.add_trainer('t1', data=sample_data, path=tmp_path / 'trainer_t1',
+                                       splitter=KFold(n_splits=2, shuffle=True, random_state=0))
     trainer.select_head(['dt'])
     trainer.train()
     return trainer
@@ -72,8 +71,9 @@ class TestToInferencer:
         assert 'scaler' in inf.pipeline.nodes
         assert 'dt' in inf.pipeline.nodes
 
-    def test_not_trained_raises(self, exp):
-        trainer = exp.add_trainer('t_no_train')
+    def test_not_trained_raises(self, tmp_path, exp, sample_data):
+        trainer = exp.pipeline.add_trainer('t_no_train', data=sample_data,
+                                           path=tmp_path / 'trainer_t_no_train')
         trainer.select_head(['dt'])
         with pytest.raises(RuntimeError, match="not built"):
             trainer.to_inferencer()
@@ -105,7 +105,7 @@ class TestProcess:
         assert isinstance(results, list)
         assert len(results) == inf.n_splits
 
-    def test_v_parameter(self, exp, sample_data):
+    def test_v_parameter(self, tmp_path, exp, sample_data):
         exp.pipeline.set_grp('model_proba', role='head', processor=DecisionTreeClassifier,
                     method='predict_proba',
                     edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
@@ -113,15 +113,18 @@ class TestProcess:
         exp.pipeline.set_node('dt_proba', grp='model_proba')
         exp.build()
         exp.exp()
-        trainer = exp.add_trainer('t_proba')
+        trainer = exp.pipeline.add_trainer('t_proba', data=sample_data,
+                                           path=tmp_path / 'trainer_t_proba')
         trainer.select_head(['dt_proba'])
         trainer.train()
         inf = trainer.to_inferencer(v=slice(-1, None))
         result = inf.process(sample_data)
         assert result.shape[1] == 1
 
-    def test_single_split(self, exp, sample_data):
-        trainer = exp.add_trainer('t_nosplit', splitter=None)
+    def test_single_split(self, tmp_path, exp, sample_data):
+        trainer = exp.pipeline.add_trainer('t_nosplit', data=sample_data,
+                                           path=tmp_path / 'trainer_nosplit',
+                                           splitter=None)
         trainer.select_head(['dt'])
         trainer.train()
         inf = trainer.to_inferencer()
@@ -166,7 +169,6 @@ class TestSaveLoad:
         assert (save_path / '__inferencer.pkl').exists()
 
     def test_save_load_with_v(self, trained_trainer, sample_data, tmp_path):
-        exp = trained_trainer
         inf = trained_trainer.to_inferencer(v=[0])
         save_path = tmp_path / 'inferencer_v'
         inf.save(save_path)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,10 @@ import pandas as pd
 from mllabs._pipeline import Pipeline, PipelineGroup, PipelineNode, DataSourceNode, VAR_TYPES
 
 
+def _dummy_metric(y, p):
+    return 0.5
+
+
 class DummyStage:
     __name__ = 'DummyStage'
 
@@ -1522,3 +1526,151 @@ class TestPipelineSync:
         ))
         p.sync()
         assert p.nodes['n1'].tag == ['cv']
+
+
+class TestAddExperiment:
+    @pytest.fixture
+    def sample_data(self):
+        import numpy as np
+        np.random.seed(0)
+        n = 60
+        return pd.DataFrame({
+            'f1': np.random.randn(n),
+            'f2': np.random.randn(n),
+            'target': np.random.randint(0, 2, n),
+        })
+
+    @pytest.fixture
+    def pipeline(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        from sklearn.tree import DecisionTreeClassifier
+        p = Pipeline(path=tmp_path / 'pipeline')
+        p.set_grp('scale', role='stage', processor=StandardScaler,
+                  method='transform', edges={'X': [(None, ['f1', 'f2'])]})
+        p.set_node('scaler', grp='scale')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
+                  method='predict',
+                  edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                  params={'max_depth': 3, 'random_state': 0})
+        p.set_node('dt', grp='model')
+        return p
+
+    def test_creates_experimenter(self, pipeline, sample_data):
+        from mllabs._experimenter import Experimenter
+        e = pipeline.add_experiment('exp1', sample_data)
+        assert isinstance(e, Experimenter)
+        assert pipeline.get_experiment('exp1') is e
+
+    def test_attach_sets_pipeline(self, pipeline, sample_data):
+        e = pipeline.add_experiment('exp1', sample_data)
+        assert e.pipeline is pipeline
+
+    def test_skip_returns_existing(self, pipeline, sample_data):
+        e1 = pipeline.add_experiment('exp1', sample_data)
+        e2 = pipeline.add_experiment('exp1', sample_data, exist='skip')
+        assert e1 is e2
+
+    def test_error_on_duplicate(self, pipeline, sample_data):
+        pipeline.add_experiment('exp1', sample_data)
+        with pytest.raises(ValueError):
+            pipeline.add_experiment('exp1', sample_data, exist='error')
+
+    def test_no_db_path_requires_explicit_path(self, sample_data):
+        p = Pipeline()
+        with pytest.raises(ValueError):
+            p.add_experiment('exp1', sample_data)
+
+    def test_explicit_path(self, sample_data, tmp_path):
+        p = Pipeline()
+        e = p.add_experiment('exp1', sample_data, path=tmp_path / 'exp1')
+        assert e is not None
+
+    def test_remove_experiment(self, pipeline, sample_data):
+        pipeline.add_experiment('exp1', sample_data)
+        pipeline.remove_experiment('exp1')
+        assert pipeline.get_experiment('exp1') is None
+
+    def test_datasource_compatibility_check(self, tmp_path, sample_data):
+        p = Pipeline(path=tmp_path / 'pipeline')
+        p.set_datasource({'f1': 'numerical', 'f2': 'numerical', 'missing_col': 'numerical'})
+        with pytest.raises(ValueError, match='missing_col'):
+            p.add_experiment('exp1', sample_data)
+
+    def test_datasource_no_schema_no_check(self, pipeline, sample_data):
+        partial = sample_data[['f1', 'target']]
+        e = pipeline.add_experiment('exp1', partial)
+        assert e is not None
+
+    def test_collectors_registered(self, pipeline, sample_data):
+        from mllabs import MetricCollector, Connector
+        mc = MetricCollector('acc', Connector(), output_var=None, metric_func=_dummy_metric)
+        e = pipeline.add_experiment('exp1', sample_data, collectors=[mc])
+        assert e.get_collector('acc') is not None
+
+    def test_tags_stored_on_experimenter(self, pipeline, sample_data):
+        e = pipeline.add_experiment('exp1', sample_data, tags=['cv'])
+        assert e.tags == ['cv']
+
+    def test_add_experiment_then_build_exp(self, pipeline, sample_data):
+        from sklearn.model_selection import ShuffleSplit
+        e = pipeline.add_experiment('exp1', sample_data,
+                                    sp=ShuffleSplit(n_splits=2, test_size=0.3, random_state=0))
+        e.build()
+        e.exp()
+        assert e.get_status('dt') == 'built'
+
+
+class TestAddTrainerTags:
+    @pytest.fixture
+    def sample_data(self):
+        import numpy as np
+        np.random.seed(0)
+        n = 60
+        return pd.DataFrame({
+            'f1': np.random.randn(n),
+            'f2': np.random.randn(n),
+            'target': np.random.randint(0, 2, n),
+        })
+
+    @pytest.fixture
+    def pipeline(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        from sklearn.tree import DecisionTreeClassifier
+        from sklearn.model_selection import KFold
+        p = Pipeline(path=tmp_path / 'pipeline')
+        p.set_grp('scale', role='stage', processor=StandardScaler,
+                  method='transform', edges={'X': [(None, ['f1', 'f2'])]})
+        p.set_node('scaler', grp='scale')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
+                  method='predict',
+                  edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                  params={'max_depth': 3, 'random_state': 0})
+        p.set_node('dt', grp='model', tag=['cv', 'final'])
+        p.set_node('dt2', grp='model', tag=['final'])
+        return p
+
+    def test_tags_selects_matching_heads(self, pipeline, sample_data):
+        from sklearn.model_selection import KFold
+        trainer = pipeline.add_trainer('t1', sample_data, splitter=KFold(n_splits=3),
+                                       tags=['cv'])
+        assert 'dt' in trainer.selected_heads
+        assert 'dt2' not in trainer.selected_heads
+
+    def test_tags_no_match_empty_selection(self, pipeline, sample_data):
+        from sklearn.model_selection import KFold
+        trainer = pipeline.add_trainer('t1', sample_data, splitter=KFold(n_splits=3),
+                                       tags=['nonexistent'])
+        assert trainer.selected_heads == []
+
+    def test_tags_none_no_auto_select(self, pipeline, sample_data):
+        from sklearn.model_selection import KFold
+        trainer = pipeline.add_trainer('t1', sample_data, splitter=KFold(n_splits=3),
+                                       tags=None)
+        assert trainer.selected_heads == []
+
+    def test_tags_multiple_match(self, pipeline, sample_data):
+        from sklearn.model_selection import KFold
+        trainer = pipeline.add_trainer('t1', sample_data, splitter=KFold(n_splits=3),
+                                       tags=['final'])
+        assert 'dt' in trainer.selected_heads
+        assert 'dt2' in trainer.selected_heads

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -229,6 +229,99 @@ class TestSetNode:
         p.set_node('n1', grp='g1', params={'b': 2})
         assert p.nodes['n1'].params == {'b': 2}
 
+    def test_tag_default_empty(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        assert p.nodes['n1'].tag == []
+
+    def test_tag_set_on_creation(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1', tag=['cv', 'holdout'])
+        assert p.nodes['n1'].tag == ['cv', 'holdout']
+
+    def test_tag_change_alone_no_serial_bump(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        serial_before = p.nodes['n1'].serial
+        r = p.set_node('n1', grp='g1', tag=['new_tag'])
+        assert r['result'] == 'skip'
+        assert p.nodes['n1'].serial == serial_before
+
+    def test_tag_updated_in_diff_skip_path(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1', tag=['old'])
+        p.set_node('n1', grp='g1', tag=['new'])
+        assert p.nodes['n1'].tag == ['new']
+
+
+class TestAddRemoveTag:
+    def test_add_tag_basic(self, sp):
+        sp.add_tag('h1', 'cv')
+        assert 'cv' in sp.nodes['h1'].tag
+
+    def test_add_multiple_tags(self, sp):
+        sp.add_tag('h1', 'cv', 'holdout')
+        assert sp.nodes['h1'].tag == ['cv', 'holdout']
+
+    def test_add_tag_no_duplicate(self, sp):
+        sp.add_tag('h1', 'cv')
+        sp.add_tag('h1', 'cv')
+        assert sp.nodes['h1'].tag.count('cv') == 1
+
+    def test_add_tag_no_serial_bump(self, sp):
+        serial_before = sp.nodes['h1'].serial
+        sp.add_tag('h1', 'cv')
+        assert sp.nodes['h1'].serial == serial_before
+
+    def test_add_tag_invalidates_attrs_cache(self, sp):
+        sp.nodes['h1'].get_attrs(sp.grps)
+        sp.add_tag('h1', 'cv')
+        assert sp.nodes['h1'].attrs is None
+
+    def test_add_tag_node_not_found(self, sp):
+        with pytest.raises(ValueError):
+            sp.add_tag('no_exist', 'cv')
+
+    def test_remove_tag_basic(self, sp):
+        sp.add_tag('h1', 'cv', 'holdout')
+        sp.remove_tag('h1', 'cv')
+        assert 'cv' not in sp.nodes['h1'].tag
+        assert 'holdout' in sp.nodes['h1'].tag
+
+    def test_remove_multiple_tags(self, sp):
+        sp.add_tag('h1', 'cv', 'holdout')
+        sp.remove_tag('h1', 'cv', 'holdout')
+        assert sp.nodes['h1'].tag == []
+
+    def test_remove_tag_nonexistent_ignored(self, sp):
+        sp.remove_tag('h1', 'no_such_tag')
+        assert sp.nodes['h1'].tag == []
+
+    def test_remove_tag_no_serial_bump(self, sp):
+        sp.add_tag('h1', 'cv')
+        serial_before = sp.nodes['h1'].serial
+        sp.remove_tag('h1', 'cv')
+        assert sp.nodes['h1'].serial == serial_before
+
+    def test_remove_tag_node_not_found(self, sp):
+        with pytest.raises(ValueError):
+            sp.remove_tag('no_exist', 'cv')
+
+    def test_add_remove_tag_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p.add_tag('n1', 'cv', 'holdout')
+        p.remove_tag('n1', 'holdout')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.nodes['n1'].tag == ['cv']
+
 
 class TestGroupHierarchy:
     def test_edges_extend(self, p):
@@ -350,6 +443,21 @@ class TestNodeAttrs:
         p._bump_serials(['n1'])
         new_serial = p.get_node_attrs('n1')['serial']
         assert new_serial != old_serial
+
+    def test_attrs_includes_tag(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1', tag=['cv'])
+        attrs = p.get_node_attrs('n1')
+        assert attrs['tag'] == ['cv']
+
+    def test_attrs_tag_is_copy(self, p):
+        p.set_grp('g1', role='stage', processor=DummyStage, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1', tag=['cv'])
+        attrs = p.get_node_attrs('n1')
+        attrs['tag'].append('mutated')
+        assert p.nodes['n1'].tag == ['cv']
 
 
 class TestNameValidation:
@@ -1212,6 +1320,24 @@ class TestPipelineSQLite:
         p2 = Pipeline(path=tmp_path, name='test')
         assert p2.grps['g1'].params == {'with_std': False}
 
+    def test_node_tag_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1', tag=['cv', 'holdout'])
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.nodes['n1'].tag == ['cv', 'holdout']
+
+    def test_node_tag_default_empty_persists(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = Pipeline(path=tmp_path, name='test')
+        p.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                  edges={'X': [(None, None)]})
+        p.set_node('n1', grp='g1')
+        p2 = Pipeline(path=tmp_path, name='test')
+        assert p2.nodes['n1'].tag == []
+
     def test_set_grp_update_serial_persists(self, tmp_path):
         from sklearn.preprocessing import StandardScaler
         p = Pipeline(path=tmp_path, name='test')
@@ -1375,3 +1501,24 @@ class TestPipelineSync:
         # A syncs
         p.sync()
         assert 'n2' in p.grps['g1'].nodes
+
+    def test_sync_node_added_with_tag(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_node('n2', grp='g1', tag=['cv'])
+        p.sync()
+        assert p.nodes['n2'].tag == ['cv']
+
+    def test_sync_node_updated_tag_applied(self, tmp_path):
+        from sklearn.preprocessing import StandardScaler
+        p = self._make(tmp_path)
+        p2 = Pipeline(path=tmp_path, name='test')
+        p2.set_grp('g1', role='stage', processor=StandardScaler, method='transform',
+                   edges={'X': [(None, None)]}, params={'with_std': False}, exist='replace')
+        p2.nodes['n1'].tag = ['cv']
+        p2._db_write(lambda conn: conn.execute(
+            "UPDATE nodes SET tag = ? WHERE name = ?", ('["cv"]', 'n1')
+        ))
+        p.sync()
+        assert p.nodes['n1'].tag == ['cv']

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -9,6 +9,7 @@ from mllabs.sampler import Sampler, ImbLearnSampler
 from mllabs._data_wrapper import PandasWrapper
 from mllabs._node_processor import TransformProcessor, PredictProcessor
 from mllabs._experimenter import Experimenter
+from mllabs._pipeline import Pipeline
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -288,52 +289,50 @@ class TestExperimenterAugData:
 class TestTrainerAugData:
     @pytest.fixture
     def exp(self, tmp_path, base_data):
-        e = Experimenter(
-            data=base_data,
-            path=tmp_path / 'exp',
-            sp=ShuffleSplit(n_splits=1, test_size=0.2, random_state=42),
-            sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
-        )
-        e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+        p = Pipeline(path=tmp_path / 'pipeline')
+        p.set_grp('model', role='head', processor=DecisionTreeClassifier,
                   method='predict',
                   edges={'X': [(None, ['f1', 'f2'])], 'y': [(None, 'target')]},
                   params={'max_depth': 3, 'random_state': 42})
-        e.pipeline.set_node('dt', grp='model')
+        p.set_node('dt', grp='model')
+        e = p.add_experiment('main', data=base_data,
+                             sp=ShuffleSplit(n_splits=1, test_size=0.2, random_state=42),
+                             sp_v=KFold(n_splits=3, shuffle=True, random_state=42))
         return e
 
-    def test_add_trainer_stores_aug_data(self, exp, aug_df):
-        trainer = exp.add_trainer('t1', aug_data=aug_df)
+    def test_add_trainer_stores_aug_data(self, tmp_path, exp, base_data, aug_df):
+        trainer = exp.pipeline.add_trainer('t1', data=base_data, path=tmp_path / 'tr_t1', aug_data=aug_df)
         assert trainer.aug_data is not None
 
-    def test_add_trainer_no_aug_data(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_add_trainer_no_aug_data(self, tmp_path, exp, base_data):
+        trainer = exp.pipeline.add_trainer('t1', data=base_data, path=tmp_path / 'tr_t1')
         assert trainer.aug_data is None
 
-    def test_trainer_inner_train_size_increased(self, exp, aug_df):
-        trainer_with = exp.add_trainer('t_with', aug_data=aug_df)
-        trainer_without = exp.add_trainer('t_without')
+    def test_trainer_inner_train_size_increased(self, tmp_path, exp, base_data, aug_df):
+        trainer_with = exp.pipeline.add_trainer('t_with', data=base_data, path=tmp_path / 'tr_with', aug_data=aug_df)
+        trainer_without = exp.pipeline.add_trainer('t_without', data=base_data, path=tmp_path / 'tr_without')
         n_with = trainer_with.train_folds[0].train_data_flows[0].data_source.get_train().get_shape()[0]
         n_without = trainer_without.train_folds[0].train_data_flows[0].data_source.get_train().get_shape()[0]
         assert n_with == n_without + len(aug_df)
 
-    def test_trainer_valid_unchanged(self, exp, aug_df):
-        trainer_with = exp.add_trainer('t_with', aug_data=aug_df)
-        trainer_without = exp.add_trainer('t_without')
+    def test_trainer_valid_unchanged(self, tmp_path, exp, base_data, aug_df):
+        trainer_with = exp.pipeline.add_trainer('t_with', data=base_data, path=tmp_path / 'tr_with', aug_data=aug_df)
+        trainer_without = exp.pipeline.add_trainer('t_without', data=base_data, path=tmp_path / 'tr_without')
         for fold_with, fold_without in zip(trainer_with.train_folds, trainer_without.train_folds):
             v_with = fold_with.train_data_flows[0].data_source.get_valid()
             v_without = fold_without.train_data_flows[0].data_source.get_valid()
             if v_with is not None and v_without is not None:
                 assert v_with.get_shape()[0] == v_without.get_shape()[0]
 
-    def test_trainer_no_split_aug_data(self, exp, aug_df):
-        trainer_with = exp.add_trainer('t_with', splitter=None, aug_data=aug_df)
-        trainer_without = exp.add_trainer('t_without', splitter=None)
+    def test_trainer_no_split_aug_data(self, tmp_path, exp, base_data, aug_df):
+        trainer_with = exp.pipeline.add_trainer('t_with', data=base_data, path=tmp_path / 'tr_with', splitter=None, aug_data=aug_df)
+        trainer_without = exp.pipeline.add_trainer('t_without', data=base_data, path=tmp_path / 'tr_without', splitter=None)
         n_with = trainer_with.train_folds[0].train_data_flows[0].data_source.get_train().get_shape()[0]
         n_without = trainer_without.train_folds[0].train_data_flows[0].data_source.get_train().get_shape()[0]
         assert n_with == n_without + len(aug_df)
 
-    def test_trainer_column_filter_applied_to_aug(self, exp, aug_df):
-        trainer = exp.add_trainer('t1', aug_data=aug_df)
+    def test_trainer_column_filter_applied_to_aug(self, tmp_path, exp, base_data, aug_df):
+        trainer = exp.pipeline.add_trainer('t1', data=base_data, path=tmp_path / 'tr_t1', aug_data=aug_df)
         train = trainer.train_folds[0].train_data_flows[0].data_source.get_train()
         selected = train.select_columns(['f1', 'f2'])
         assert selected.get_columns() == ['f1', 'f2']

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -4,10 +4,11 @@ import pandas as pd
 
 from sklearn.preprocessing import StandardScaler
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.model_selection import ShuffleSplit, KFold
+from sklearn.model_selection import KFold
 
-from mllabs._experimenter import Experimenter
 from mllabs._trainer import Trainer
+from mllabs._pipeline import Pipeline
+from mllabs._cache import DataCache
 
 
 class BadProcessor:
@@ -33,71 +34,79 @@ def sample_data():
 
 
 @pytest.fixture
-def exp(tmp_path, sample_data):
-    e = Experimenter(
-        data=sample_data,
-        path=tmp_path / 'exp',
-        sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
-        sp_v=KFold(n_splits=3, shuffle=True, random_state=42),
-    )
-    e.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
-                       method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
-    e.pipeline.set_node('scaler', grp='scale')
-    e.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
-                       method='predict',
-                       edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
-                       params={'max_depth': 3, 'random_state': 42})
-    e.pipeline.set_node('dt', grp='model')
-    e.build()
-    e.exp()
-    return e
+def pipeline(tmp_path):
+    p = Pipeline(path=tmp_path / 'pipeline')
+    p.set_grp('scale', role='stage', processor=StandardScaler,
+               method='transform', edges={'X': [(None, ['f1', 'f2', 'f3'])]})
+    p.set_node('scaler', grp='scale')
+    p.set_grp('model', role='head', processor=DecisionTreeClassifier,
+               method='predict',
+               edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+               params={'max_depth': 3, 'random_state': 42})
+    p.set_node('dt', grp='model')
+    return p
+
+
+@pytest.fixture
+def sp_v():
+    return KFold(n_splits=3, shuffle=True, random_state=42)
+
+
+def _add_trainer(pipeline, sample_data, sp_v, name='t1'):
+    return pipeline.add_trainer(name, sample_data, splitter=sp_v)
 
 
 class TestAddTrainer:
-    def test_default_splitter_same(self, exp):
-        trainer = exp.add_trainer('t1')
-        assert trainer.splitter is exp.sp_v
-        assert trainer.splitter_params == exp.splitter_params
+    def test_add_trainer_creates(self, pipeline, sample_data, sp_v):
+        trainer = pipeline.add_trainer('t1', sample_data, splitter=sp_v)
+        assert trainer.name == 't1'
+        assert pipeline.get_trainer('t1') is trainer
 
-    def test_add_trainer_skip(self, exp):
-        t1 = exp.add_trainer('t1')
-        t2 = exp.add_trainer('t1', exist='skip')
+    def test_add_trainer_skip(self, pipeline, sample_data, sp_v):
+        t1 = pipeline.add_trainer('t1', sample_data, splitter=sp_v)
+        t2 = pipeline.add_trainer('t1', sample_data, splitter=sp_v, exist='skip')
         assert t1 is t2
 
-    def test_add_trainer_error(self, exp):
-        exp.add_trainer('t1')
-        with pytest.raises(RuntimeError):
-            exp.add_trainer('t1', exist='error')
-
-    def test_splitter_same_with_params_raises(self, exp):
+    def test_add_trainer_error(self, pipeline, sample_data, sp_v):
+        pipeline.add_trainer('t1', sample_data, splitter=sp_v)
         with pytest.raises(ValueError):
-            exp.add_trainer('t1', splitter='same', splitter_params={'y': 'target'})
+            pipeline.add_trainer('t1', sample_data, splitter=sp_v, exist='error')
 
-    def test_custom_splitter(self, exp):
-        sp = KFold(n_splits=5)
-        trainer = exp.add_trainer('t1', splitter=sp)
-        assert trainer.splitter is sp
-
-    def test_no_splitter(self, exp):
-        trainer = exp.add_trainer('t1', splitter=None)
+    def test_no_splitter(self, pipeline, sample_data):
+        trainer = pipeline.add_trainer('t1', sample_data, splitter=None)
         assert trainer.splitter is None
         assert trainer.get_n_splits() == 1
 
+    def test_no_db_path_requires_explicit_path(self, sample_data, sp_v, tmp_path):
+        p = Pipeline()
+        with pytest.raises(ValueError):
+            p.add_trainer('t1', sample_data, splitter=sp_v)
+
+    def test_explicit_path(self, sample_data, sp_v, tmp_path):
+        p = Pipeline()
+        trainer = p.add_trainer('t1', sample_data, splitter=sp_v, path=tmp_path / 'tr')
+        assert trainer.name == 't1'
+
+    def test_remove_trainer(self, pipeline, sample_data, sp_v):
+        pipeline.add_trainer('t1', sample_data, splitter=sp_v)
+        pipeline.remove_trainer('t1')
+        assert pipeline.get_trainer('t1') is None
+
 
 class TestSelectHead:
-    def test_select_head_collects_upstream(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_select_head_collects_upstream(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         assert 'dt' in trainer.selected_heads
         assert 'scaler' in trainer.selected_stages
 
-    def test_select_head_multiple(self, exp):
-        exp.pipeline.set_grp('model2', role='head', processor=DecisionTreeClassifier,
-                             method='predict',
-                             edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
-                             params={'max_depth': 5, 'random_state': 0})
-        exp.pipeline.set_node('dt2', grp='model2')
-        trainer = exp.add_trainer('t1')
+    def test_select_head_multiple(self, pipeline, sample_data, sp_v):
+        pipeline.set_grp('model2', role='head', processor=DecisionTreeClassifier,
+                         method='predict',
+                         edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                         params={'max_depth': 5, 'random_state': 0})
+        pipeline.set_node('dt2', grp='model2')
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.select_head(['dt2'])
         assert 'dt' in trainer.selected_heads
@@ -106,15 +115,15 @@ class TestSelectHead:
 
 
 class TestTrain:
-    def test_train_basic(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_train_basic(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
         assert trainer.get_status('scaler') == 'built'
         assert trainer.get_status('dt') == 'built'
 
-    def test_train_skips_built(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_train_skips_built(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
 
@@ -127,19 +136,19 @@ class TestTrain:
             for i, fold in enumerate(trainer.train_folds):
                 assert fold.artifact_stores[0].get_info(name)['build_id'] == build_ids[name][i]
 
-    def test_train_no_splitter(self, exp):
-        trainer = exp.add_trainer('t_nosplit', splitter=None)
+    def test_train_no_splitter(self, pipeline, sample_data):
+        trainer = pipeline.add_trainer('t_nosplit', sample_data, splitter=None)
         trainer.select_head(['dt'])
         trainer.train()
         assert trainer.get_status('scaler') == 'built'
         assert trainer.get_status('dt') == 'built'
 
-    def test_train_error(self, exp):
-        exp.pipeline.set_grp('bad', role='head', processor=BadProcessor,
-                             method='transform',
-                             edges={'X': [(None, ['f1'])]})
-        exp.pipeline.set_node('bad_node', grp='bad')
-        trainer = exp.add_trainer('t_err')
+    def test_train_error(self, pipeline, sample_data, sp_v):
+        pipeline.set_grp('bad', role='head', processor=BadProcessor,
+                         method='transform',
+                         edges={'X': [(None, ['f1'])]})
+        pipeline.set_node('bad_node', grp='bad')
+        trainer = pipeline.add_trainer('t_err', sample_data, splitter=sp_v)
         trainer.select_head(['bad_node'])
         trainer.train()
         assert trainer.get_status('bad_node') == 'error'
@@ -147,36 +156,36 @@ class TestTrain:
         assert err['type'] == 'ValueError'
         assert 'intentional error' in err['message']
 
-    def test_train_error_continues_other_nodes(self, exp):
-        exp.pipeline.set_grp('bad', role='head', processor=BadProcessor,
-                             method='transform',
-                             edges={'X': [(None, ['f1'])]})
-        exp.pipeline.set_node('bad_node', grp='bad')
-        trainer = exp.add_trainer('t_mixed')
+    def test_train_error_continues_other_nodes(self, pipeline, sample_data, sp_v):
+        pipeline.set_grp('bad', role='head', processor=BadProcessor,
+                         method='transform',
+                         edges={'X': [(None, ['f1'])]})
+        pipeline.set_node('bad_node', grp='bad')
+        trainer = pipeline.add_trainer('t_mixed', sample_data, splitter=sp_v)
         trainer.select_head(['dt', 'bad_node'])
         trainer.train()
         assert trainer.get_status('dt') == 'built'
         assert trainer.get_status('bad_node') == 'error'
 
-    def test_train_n_splits(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_train_n_splits(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         assert trainer.get_n_splits() == 3
         trainer.train()
         for fold in trainer.train_folds:
             assert fold.artifact_stores[0].status('dt') == 'built'
 
-    def test_serial_in_info(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_serial_in_info(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
-        expected_serial = exp.pipeline.nodes['dt'].serial
+        expected_serial = pipeline.nodes['dt'].serial
         for fold in trainer.train_folds:
             info = fold.artifact_stores[0].get_info('dt')
             assert info['node_serial'] == expected_serial
 
-    def test_serial_mismatch_triggers_reset(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_serial_mismatch_triggers_reset(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
 
@@ -185,10 +194,10 @@ class TestTrain:
             for fold in trainer.train_folds
         ]
 
-        exp.pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
-                             method='predict',
-                             edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
-                             params={'max_depth': 5, 'random_state': 42})
+        pipeline.set_grp('model', role='head', processor=DecisionTreeClassifier,
+                         method='predict',
+                         edges={'X': [('scaler', None)], 'y': [(None, 'target')]},
+                         params={'max_depth': 5, 'random_state': 42})
         trainer.train()
 
         build_ids_after = [
@@ -197,8 +206,8 @@ class TestTrain:
         ]
         assert build_ids_before != build_ids_after
 
-    def test_serial_mismatch_stage_cascades(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_serial_mismatch_stage_cascades(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
 
@@ -207,18 +216,18 @@ class TestTrain:
             for name in ['scaler', 'dt']
         }
 
-        exp.pipeline.set_grp('scale', role='stage', processor=StandardScaler,
-                             method='transform',
-                             edges={'X': [(None, ['f1', 'f2', 'f3'])]},
-                             params={'with_std': False})
+        pipeline.set_grp('scale', role='stage', processor=StandardScaler,
+                         method='transform',
+                         edges={'X': [(None, ['f1', 'f2', 'f3'])]},
+                         params={'with_std': False})
         trainer.train()
 
         for name in ['scaler', 'dt']:
             build_ids_after = [fold.artifact_stores[0].get_info(name)['build_id'] for fold in trainer.train_folds]
             assert build_ids_before[name] != build_ids_after
 
-    def test_no_serial_mismatch_skips_rebuild(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_no_serial_mismatch_skips_rebuild(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
 
@@ -236,15 +245,15 @@ class TestTrain:
 
 
 class TestProcess:
-    def test_process_yields_per_split(self, exp, sample_data):
-        trainer = exp.add_trainer('t1')
+    def test_process_yields_per_split(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
         results = list(trainer.process(sample_data))
         assert len(results) == trainer.get_n_splits()
 
-    def test_process_output_shape(self, exp, sample_data):
-        trainer = exp.add_trainer('t1')
+    def test_process_output_shape(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
         for output in trainer.process(sample_data):
@@ -252,16 +261,16 @@ class TestProcess:
 
 
 class TestResetNodes:
-    def test_reset_clears_node_objs(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_reset_clears_node_objs(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
         trainer.reset_nodes(['scaler'])
         assert trainer.get_status('scaler') is None
         assert trainer.get_status('dt') is None
 
-    def test_reset_allows_retrain(self, exp):
-        trainer = exp.add_trainer('t1')
+    def test_reset_allows_retrain(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
         trainer.reset_nodes(['dt'])
@@ -271,20 +280,20 @@ class TestResetNodes:
 
 
 class TestSaveLoad:
-    def test_save_load_roundtrip(self, exp, sample_data):
-        trainer = exp.add_trainer('t1')
+    def test_save_creates_file(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
+        assert (trainer.path / '__trainer.pkl').exists()
+
+    def test_save_load_roundtrip(self, pipeline, sample_data, sp_v):
+        trainer = _add_trainer(pipeline, sample_data, sp_v)
         trainer.select_head(['dt'])
         trainer.train()
-        path = exp.path
+        path = trainer.path
 
-        loaded_exp = Experimenter.load(path, sample_data)
-        loaded_trainer = loaded_exp.get_trainer('t1')
-        assert loaded_trainer.name == 't1'
-        assert set(loaded_trainer.selected_stages) == set(trainer.selected_stages)
-        assert set(loaded_trainer.selected_heads) == set(trainer.selected_heads)
-        assert loaded_trainer.get_status('scaler') == 'built'
-        assert loaded_trainer.get_status('dt') == 'built'
-
-    def test_save_creates_file(self, exp):
-        trainer = exp.add_trainer('t1')
-        assert (trainer.path / '__trainer.pkl').exists()
+        loaded = Trainer._load(path, pipeline=pipeline, data=None, cache=DataCache(),
+                               logger=None)
+        assert loaded.name == 't1'
+        assert set(loaded.selected_stages) == set(trainer.selected_stages)
+        assert set(loaded.selected_heads) == set(trainer.selected_heads)
+        assert loaded.get_status('scaler') == 'built'
+        assert loaded.get_status('dt') == 'built'


### PR DESCRIPTION
## Summary

Closes #116

- Add `tag: list[str]` field to `PipelineNode`; `add_tag`/`remove_tag` methods
- Decouple `Experimenter` from `Pipeline` ownership — `Experimenter` now receives a Pipeline reference via `attach()`; `Trainer` management moved to `Pipeline`
- Add `pipeline.add_experiment()` with DataSource compatibility check; `pipeline.add_trainer()` with tag-based head auto-selection
- Remove `Experimenter.desc_pipeline` / `Experimenter.desc_node` (use `pipeline.desc_pipeline()` / `pipeline.desc_node()` directly)
- Drop redundant `_save()` call at end of `Experimenter.exp()`

## Test plan

- [ ] All existing tests pass (`tests/`)