### PR TITLE
fix(Experimenter): a Trial leaves no artifact (#127)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Project(path, cache_maxsize)          경로·캐시 소유. 프로젝트 전역
 - **Inferencer** (`_inferencer.py`): 학습된 processor를 새 데이터에 적용
 - **NodeStore** (`_store.py`): run 하나당 하나 — 노드 아티팩트(obj.pkl/result.pkl) + 실행 이력(`node_hist`) 둘 다 소유
 - **DataFlow / TrainDataFlow** (`_flow.py`): fold별 데이터 흐름 및 노드 빌드 (NodeStore를 컴포지션으로 보유, outer_idx/inner_idx도 보유)
-- **_executor.py**: `_execute_single`(단일 프로세스) + `_execute_multi`(멀티 워커) — 둘 다 노드/Trial 공용, `collectors` 인자로 구분
+- **_executor.py**: `_execute_single`(단일 프로세스) + `_execute_multi`(멀티 워커) — 노드/Trial/Predictor 공용. `store`(그 job 종류의 기록을 소유한 store)와 `chained`(job들이 서로 먹이는가)로 갈림
 
 ## Node/Trial 상태 모델
 
@@ -67,8 +67,11 @@ Project(path, cache_maxsize)          경로·캐시 소유. 프로젝트 전역
 | **built** | O | 빌드 완료, 결과 추출 가능 |
 | **error** | info only | 실행 중 에러 발생, 내역 보존 |
 
+Disk 칸은 **노드(와 Trainer의 Predictor)** 얘기다 — Trial은 아래 참조
+
 - 중간 상태(finalize)는 없다. 아티팩트를 없애는 방법은 `reset_nodes()`(완전 삭제, `init`으로 복귀) 하나뿐
-- **Experimenter엔 상태 게이트가 없다** — `open`/`close`/`status` 개념 자체가 없고 `build()`/`exp()`는 언제나 호출 가능. Trial 아티팩트는 다음 `exp()` 호출까지 그대로 남아있는 게 기본값이고(`set_pipeline`이 Trial을 stale 취급 안 하는 것과 같은 이유 — "Staleness" 섹션), 지우려면 `reset_nodes()`를 명시적으로 호출
+- **Experimenter엔 상태 게이트가 없다** — `open`/`close`/`status` 개념 자체가 없고 `build()`/`exp()`는 언제나 호출 가능
+- **Trial은 아티팩트를 안 남긴다** — 위 표에서 Trial에 해당하는 Disk 칸은 항상 비어 있다. 평가받는 후보라서 남길 가치가 있는 건 모델이 아니라 결과이고, 그 결과는 `experiment_hist`(+ Collector가 모은 데이터)에 있다. 그래서 Trial엔 `built`/`init` 구분이 디스크에 없고, `reset_nodes()`가 지울 것도 없으며, 재실행 수단은 `TrialStore.remove_hist(...)` 하나뿐 ("Staleness" 섹션)
 
 ## 핵심 클래스
 
@@ -186,10 +189,14 @@ ProjectStore는 이름 목록이라 동기화가 어긋날 두 번째 진실 원
   - `load_pipeline(name, version=None)`, `list_pipeline_versions(name)` — 둘 다 `PipelineStore(pipeline_path(name), name)`를 통해 조회
   - 저장은 pkl (`v{n}.pkl`) — 형식은 `PipelineStore.save_version`/`load_version` 뒤에 숨어 있어 교체 가능
 - `trials`: `TrialStore`, `store`: `ProjectStore`, `list_experimenters()`, `list_trainers()`
+- **`remove_trial(name, collectors=None)`**: Trial 하나를 프로젝트에서 완전히 지운다 — 정의(`TrialStore.trials`) + 이력(`experiment_hist`, **모든 experimenter**) + 수집 이력(`CollectHist`) + 각 Collector가 들고 있는 데이터. Trial은 아티팩트를 안 남기는 대신 흔적이 서로 모르는 store 넷에 흩어져 있고, **그 넷을 다 보는 건 Project뿐**이라 여기 있다(단일 store 위의 편의 래퍼가 아니라, 주인 없는 교차 연산에 주인을 준 것)
+  - `collectors=`: **들고 있는 레지스트리가 있으면 그걸 넘길 것** — `collectors()`는 호출마다 새 인스턴스를 만들고 일부 Collector는 메모리 캐시에서 답하므로(`ModelAttrCollector`/`SHAPCollector`의 `_cache`), 새 인스턴스만 청소하면 내가 든 쪽은 방금 지운 걸 계속 내놓는다
+  - 특정 Experimenter만 다시 돌리고 싶은 거라면 이게 아니라 `trials.remove_hist(trial_name=, experimenter=)`
 
 ### ArtifactStore (`_store.py`, 공통 인터페이스)
 `NodeStore`/`TrialStore`가 공유하는 메소드 모양의 base class. 두 그룹:
-- **아티팩트** (`write_objs`/`write_obj`/`write_result`/`get_objs`/`get_obj`/`get_result`/`list_nodes`/`status`/`reset_node`) — **`NodeStore`만 전부 구현**. `TrialStore`는 상속만 하고 하나도 오버라이드하지 않음 — Trial의 obj/result는 (노드와 같은 디렉토리를 쓰는) 그 run의 `NodeStore`가 갖고, `TrialStore`는 정의+이력만 가지므로 쌓을 obj/result 자체가 없음. 상속해두는 이유는 base가 `NotImplementedError`를 던져서, `TrialStore`에서 호출하면 `AttributeError` 대신 의도가 분명한 에러가 나기 때문
+- **아티팩트** (`write_objs`/`write_obj`/`write_result`/`get_objs`/`get_obj`/`get_result`/`list_nodes`/`status`/`reset_node`) — **`NodeStore`만 전부 구현**. `TrialStore`는 상속만 하고 하나도 오버라이드하지 않음 — Trial은 아무 데도 아티팩트를 안 남기므로 서빙할 obj/result 자체가 없음. 상속해두는 이유는 base가 `NotImplementedError`를 던져서, `TrialStore`에서 호출하면 `AttributeError` 대신 의도가 분명한 에러가 나기 때문
+- **`stores_artifacts`**(클래스 속성, base `False` / `NodeStore` `True`): 위 두 그룹 중 어느 쪽을 실제로 구현하는지를 코드가 읽을 수 있는 형태로 만든 것. 덕분에 호출부는 executor에 "그 job 종류의 기록을 소유한 store"를 그냥 넘기고, 저장할 게 있는지는 executor가 store에 물어본다
 - **히스토리** (`record`/`get_hist`/`get_status`/`get_info`/`remove_hist`) — 둘 다 각자 자기 테이블에 대해 구현. `TrialStore`가 (이미 한 run에 스코프된 `NodeStore`엔 없는) experimenter 이름을 키로 하나 더 쓰기 때문에 override 시그니처가 서로 달라, base에선 `*args, **kwargs`로만 선언
 
 ### TrialStore (`_trial_store.py`)
@@ -199,10 +206,11 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
                 pipeline_version, status)
 ```
 - **인조식별자도 content hash도 없다.** 두 테이블 다 **이름이 PK**(`trials`는 trial 이름, 이력은 trial 이름 + experimenter 이름). `pipeline_version`은 해시가 아니라 **정수**로, 그 실행의 `Experimenter.pipeline_version`을 그대로 기록
-- 이름으로 키잉하는 이유: 아티팩트가 이미 이름으로 키잉돼 있음(`{exp}/__folds/{o}/{i}/{trial_name}/`). 맞춰두면 조인 없이 읽히고, **정의를 바꿔 재실행 = 아티팩트 덮어쓰기 = 행 덮어쓰기**가 두 테이블 모두 일관됨(`register`는 `INSERT OR REPLACE`)
+- 이름으로 키잉하는 이유: Experimenter가 이미 이름으로 키잉돼 있어(`{project}/exp/{name}`) 조인 없이 읽히고, **이름을 재정의하면 행을 덮어쓴다**가 두 테이블 모두 일관됨(`register`는 `INSERT OR REPLACE`)
 - 정의 일치 여부는 값 비교 하나로 충분해서(`has()`) 해시 컬럼을 두지 않는다. `experiment_hist`는 실행 로그일 뿐 정의의 출처가 아니므로, 이름이 재정의되면 예전 정의를 복원하는 기능은 없다
-- **아티팩트 rebuild 필요 여부는 `experiment_hist`가 판정한다** — `Experimenter._make_jobs`는 `NodeStore`를 아예 들여다보지 않고 `experiment_hist`의 fold별 `status`만 본다: `'built'`면 스킵, `'error'`거나 기록이 없으면 job 생성. 즉 trial을 재정의해도 이미 `'built'`인 fold는 자동 재실행되지 않으며, 돌리려면 `reset_nodes`로 명시적으로 지워야 함
+- **재실행 여부는 `experiment_hist`가 판정한다** — `Experimenter._make_jobs`는 `experiment_hist`의 fold별 `status`만 본다: `'built'`면 스킵, `'error'`거나 기록이 없으면 job 생성. **디스크에 이와 어긋날 것이 애초에 없어서**(Trial은 아티팩트를 안 남김) 이게 유일하게 가능한 판정이고, 다시 돌리려면 `remove_hist(trial_name=, experimenter=)` 하나면 된다. trial을 재정의해도 이미 `'built'`인 fold는 자동 재실행되지 않음
 - `register(trial)`/`register_all(trials)`: 이름 기준 upsert. `has(trial)`: 그 이름에 저장된 게 **지금** 이 정의와 같은지 필드별 비교. `get_by_name(name)`, `list_trials()`
+- `remove(name)`: **정의만** 삭제 — `experiment_hist`는 그대로 두어 "정의가 사라진 뒤에도 무엇이 돌았는지는 읽힌다". 프로젝트에서 통째로 걷어내는 건 store 넷에 걸친 일이라 `Project.remove_trial(name)`
 - `record(trial_name, experimenter, outer_idx, inner_idx, pipeline_version, status)`, `get_hist(...)`, `get_status(...)`, `remove_hist(...)`
 
 ### Experimenter (`_experimenter.py`)
@@ -228,6 +236,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - `n_jobs`는 실제 작업 수로 상한 처리 (`min(n_jobs, len(jobs))`) — 유휴 워커/progress bar 방지
   - `get_node_info()`: 노드 요약 Markdown
 - **pipeline 불필요** (디스크 상태만으로 동작): `get_status(node_name)`, `reset_nodes(nodes)`, `show_error_nodes(nodes=None, traceback=False, trial_store=None)`(trial_store 없으면 노드 에러만 보고), `get_objs(node_name, outer_idx=0, inner_idx=0)`
+  - **셋 다 Pipeline 노드 전용**(`show_error_nodes`만 예외 — `trial_store`를 주면 Trial 에러도 같이 본다). Trial은 디스크에 아무것도 안 남기므로 `get_status`는 몇 번을 돌렸든 `None`, `reset_nodes`는 지울 게 없고, `get_objs`는 `FileNotFoundError`. Trial 쪽 대응물은 `trial_store.get_status(name, exp.name)` / `remove_hist(...)` / (모델 대신) Collector가 모은 결과
 - **OS log capture** (`open_os_log`/`close_os_log`/`os_log`):
   - `open_os_log(log_path=None)`: 이 프로세스의 OS-level stdout/stderr(fd 1/2)를 `{path}/__worker_logs/master.log`(기본값)로 dup2 리다이렉트 — `self._os_log_state`에 원본 fd/`sys.stdout`·`stderr` 백업 보관. 이미 open이면 에러
   - `close_os_log()`: 리다이렉트 원복. open 안 된 상태에서 호출하면 no-op
@@ -264,13 +273,13 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 ### DataFlow / TrainDataFlow (`_flow.py`)
 - **DataFlow**: 생성자가 `NodeStore` 인스턴스(`self.store`, run 전체가 공유) + 이 fold의 `outer_idx`/`inner_idx`를 받음. `status`/`get_obj`/`get_objs`/`get_result`/`list_nodes`/`node_path`는 `self.store.X(name, self.outer_idx, self.inner_idx)`로 위임하는 얇은 메소드. `reset_node`만 위임 + `node_objs`/`_node_edges`에서도 같이 지우는 조합 동작
   - `node_objs`: `{name: (obj, result)}`, `_node_edges`: `{name: edges}`
-  - **`load()`가 `self.store.get_fold_info(...)`를 한 번 조회**해서 `edges`까지 복원한 뒤 `load_objs(name, edges=...)`. history에 행이 없는 노드는 로드 안 함(안전한 기본값) — Trial도 이 규칙으로 자연히 걸러진다(Trial 결과는 `TrialStore.experiment_hist`에만 기록되고 이 run의 `node_hist`엔 안 들어가서, 학습된 모델이 메모리로 딸려 들어오지 않음)
+  - **`load()`가 `self.store.get_fold_info(...)`를 한 번 조회**해서 `edges`까지 복원한 뒤 `load_objs(name, edges=...)`. history에 행이 없는 노드는 로드 안 함(안전한 기본값). 여기 올라오는 건 Pipeline 노드뿐이다 — Trial은 애초에 아무것도 안 남기고 Trainer의 Predictor는 자기 store에 있어서, 둘 다 이 store에 아티팩트를 두지 않는다(학습된 모델이 메모리로 딸려 들어오지 않음)
   - `get_data(source_data, edges)` → `{key: data}`
 - **TrainDataFlow** (DataFlow 상속): 노드 빌드 기능 추가. `store`를 그대로 받아 `super().__init__(store, outer_idx=, inner_idx=)`로 넘김 — fold별로 자기 NodeStore를 새로 만들지 않음
   - `data_source`: DataWrapperProvider (train/valid/**test** 제공 — `test_idx` 보유)
   - `outer_idx`/`inner_idx`는 NodeStore 키(아티팩트 경로, history row) 전용 — DataCache 키에는 안 들어감(`self.scope`가 대신함). **Trainer도 자연스러운 `(split_idx, 0)`을 그대로 쓴다**
   - `get_train(edges)`, `get_valid(edges)`, `get_test(edges)` — flow 하나로 job의 모든 입력을 만들 수 있어야 `Job`이 자족적이 됨
-  - `set_objs(name, obj, result, info)`: 현재 fit의 즉석 info에서 `edges`만 추출 — 디스크/history를 안 거침
+  - `set_objs(name, obj, result, info)`: 현재 fit의 즉석 info에서 `edges`만 추출 — 디스크/history를 안 거침. **`chained` 실행(=노드 빌드)에서만 호출**된다 — leaf(Trial/Predictor)를 여기 올리면 아무도 안 읽는 모델이 flow 메모리에 남는다
 
 ### Trainer (`_trainer.py`)
 - **Project 의존성 없음. 주입받는 건 `cache` 하나**(Experimenter와 동형) — 생성자: `Trainer(path, name, data, splitter=None, splitter_params=None, aug_data=None, cache=None)`. store(`TrainerStore(self.path)`)는 자기가 만들고, Pipeline은 `set_pipeline()`으로만
@@ -295,7 +304,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - `predictors=None`이면 이미 등록된 것들을 그대로 이어서 학습(중단된 학습 재개)
   - `Trial`을 넘기면 `TypeError` — `Predictor.from_trial(trial, experimenter=)`로 명시 승격해야 출처가 기록됨
   - 학습 대상 노드는 **넘긴 predictors 기준**(`_nodes_for(predictors)`)이지 등록된 전체가 아님
-  - `Job.flow`는 Predictor에도 **노드 flow**가 들어감(입력을 만드는 건 노드 그래프) — 아티팩트만 다른 store로 감
+  - `Job.flow`는 Predictor에도 **노드 flow**가 들어감(입력을 만드는 건 노드 그래프) — 아티팩트는 `predictor_store`로 가고, **flow에는 게시되지 않는다**(`chained=False`). Predictor는 leaf라 아무도 안 읽는데 flow에 올리면 모델만 메모리에 남기 때문. 나중에 필요한 쪽(`process()`/`to_inferencer()`)이 `predictor_store`에서 직접 꺼낸다
 - `get_status(node_name)` / `get_node_error(node_name)`: `_store_for(name)`으로 두 store 중 하나를 골라 조회 — Predictor 에러도 기록됨
 - `process(data, v=None)`: generator, split마다 Predictor output을 `v`(DSL 문자열)로 필터 후 concat하여 yield. Predictor 모델은 `flow.load()`가 안 집어오므로(이력이 다른 store에 있음 — 그게 메모리에 안 딸려오게 하는 장치) `predictor_store`에서 on-demand로 꺼내고, **edges는 정의에서 채운다** — 아티팩트에도 이 flow의 이력에도 없기 때문(안 채우면 `_resolve`가 전부 None을 반환해 조용히 아무것도 yield 안 함)
 - `to_inferencer(v=None)`: 학습된 Processor를 추출하여 Inferencer 생성
@@ -492,7 +501,7 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 4. old에는 있는데 지금 없는 이름 → stale (아티팩트 청소용)
 5. DataSource schema/targets가 바뀌면 → 전부 stale
 
-- **Trial은 캐스케이드하지 않는다**: Trial은 Pipeline 밖이라 diff가 이름을 모르고, stale 노드를 읽은 Trial도 건드리지 않는다 — `Experimenter.set_pipeline`은 stale 노드만 `reset_nodes`로 지우고 끝. Trial 아티팩트가 어떤 pipeline 버전에서 만들어졌는지는 `TrialStore.experiment_hist`가 기록하므로 historical record로 남고, 다시 돌리려면 명시적으로 재실행해야 함
+- **Trial은 캐스케이드하지 않는다**: Trial은 Pipeline 밖이라 diff가 이름을 모르고, stale 노드를 읽은 Trial도 건드리지 않는다 — `Experimenter.set_pipeline`은 stale 노드만 `reset_nodes`로 지우고 끝. Trial의 결과가 어떤 pipeline 버전에 대한 것인지는 `TrialStore.experiment_hist`가 `pipeline_version`으로 기록하므로 그 버전에 대한 기록으로 남고(버전을 올릴 의도가 없으면 Pipeline이 바뀔 이유도 없다), 다시 돌리려면 `remove_hist`로 명시적으로 재실행해야 함
 - **Trial 자신의 재정의도 감지하지 않는다**: `Experimenter._make_jobs`는 오직 `experiment_hist`의 fold별 status만 본다 — 재정의된 trial이 이미 `'built'`면 조용히 스킵되므로, 다시 돌리려면 `reset_nodes([trial_name])`을 직접 호출
 - **Predictor는 반대로 캐스케이드한다**: Trainer엔 보존할 "과거 실행" 개념이 없으므로, 바뀐 노드를 읽는 Predictor는 그냥 stale이다. `Trainer.reset_nodes`가 `predictor.node_names() & 리셋된_노드` 교집합으로 같이 지운다. Trial/Predictor를 별도 클래스로 둔 판단이 실제로 갈라지는 지점
 
@@ -589,21 +598,25 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 
 ### Job
 `Job(name, spec, outer_idx, inner_idx, flow, need_gpu=False)` — 노드와 Trial/Predictor 공용 job 단위.
-`spec`은 `Pipeline.get_node_spec()`/`Trial.get_spec()`/`Predictor.get_spec()`이 준 `ProcessorSpec`을 job 생성 시점에 1회 계산해 박아 넣은 것(따로 `node`/`trial` 객체를 들고 있지 않음). `flow`(`TrainDataFlow`) 하나로 `get_train`/`get_valid`/`get_test(edges)`를 다 만들 수 있어 job이 자족적이다. `node_path()`는 `flow.node_path(name)`에 위임.
+`spec`은 `Pipeline.get_node_spec()`/`Trial.get_spec()`/`Predictor.get_spec()`이 준 `ProcessorSpec`을 job 생성 시점에 1회 계산해 박아 넣은 것(따로 `node`/`trial` 객체를 들고 있지 않음). `flow`(`TrainDataFlow`) 하나로 `get_train`/`get_valid`/`get_test(edges)`를 다 만들 수 있어 job이 자족적이다. 결과가 **어디로 가는지는 job이 아니라 executor의 `store`**가 정한다 — job의 flow가 읽는 store와 같으란 법이 없다.
 
-### `_execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None)`
-단일 프로세스로 `Job` 리스트를 실행. 노드/Trial 차이는 `collectors` 하나뿐:
-- **`collectors=None`이 노드/build 경로** — 입력 준비가 `ext_data` 없이 `_job_data(job)`로 끝나고 매치/실행도 스킵
-- `collectors=[]`(Trainer의 Predictor 경로)는 리스트와 같은 코드 경로를 타되 매치될 게 없을 뿐 — `None`은 그 스킵만큼만 다름
-- 의존성 순서 `while True: ready = [...]` 루프(노드끼리 서로 참조 가능해서 필요)는 Trial에도 적용되지만, 그 안의 `get_missing_nodes` 게이트는 **노드 전용**(`collectors is None`일 때만 검사). Trial까지 이 게이트에 걸리게 하면 참조 노드가 끝내 안 빌드된 경우 그 Trial job이 에러 하나 없이 조용히 사라진다 — `_job_inputs`가 `KeyError`를 내고 prep error로 기록되는 게 올바른 동작
-- `job.flow.set_objs`는 노드/Trial 구분 없이 완료된 job마다 호출 — 안 하면 그 job이 `ready`에서 빠지지 않아 루프가 영원히 재실행
-- `store`(그 run의 `NodeStore`)를 명시적으로 받아 `store.write_objs(name, outer_idx, inner_idx, obj, result)` 호출
+### `_execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None, chained=False)`
+단일 프로세스로 `Job` 리스트를 실행. 세 종류가 전부 같은 `_process`를 타고, 호출부가 바꾸는 건 **결과가 어디로 가느냐**뿐이다.
+
+- **`store`는 그 job 종류의 기록을 소유한 store** — 노드/Predictor는 `NodeStore`, Trial은 `TrialStore`. 아티팩트 기록은 `store.stores_artifacts`가 True일 때만(Trial은 False라 아무것도 안 남는다)
+- **`chained`는 "이 job들이 flow를 통해 서로 먹이는가"** — Pipeline 노드에서만 True. 두 가지가 같이 켜진다: 완료된 obj/result를 `set_objs`로 flow에 게시(뒤 job이 읽으라고), 그리고 edges가 참조하는 게 다 빌드될 때까지 대기(`get_missing_nodes`). leaf(Trial/Predictor)는 둘 다 안 함
+  - 대기 게이트를 leaf에 걸면 안 되는 이유: 참조 노드가 끝내 안 빌드되면 그 job이 에러 하나 없이 조용히 사라진다 — `_job_inputs`가 `KeyError`를 내고 prep error로 기록되는 게 올바른 동작
+  - `set_objs`를 leaf에 하면 안 되는 이유: 아무도 안 읽는데 학습된 모델만 flow 메모리에 실행 내내 붙어 있게 된다
+- **완료 표시는 `done` 집합**(`(outer_idx, inner_idx, name)`) — 예전엔 `flow.node_objs` 등록 여부가 겸했는데, 그러면 flow에 안 올리는 leaf가 영원히 `ready`로 남는다
+- **`collectors`는 별개**로 Collector 얘기만 한다: `None`이면 `ext_data` 준비와 매칭을 통째로 스킵(노드엔 Collector가 안 붙음), 리스트면 실행(`[]`는 매치될 게 없는 리스트일 뿐)
 - **반환값은 job 종류와 무관하게 항상 `{(outer_idx, inner_idx, name): error_info}`** — 실패한 job이 ready-루프에서 영원히 재시도되지 않으려면 키가 fold까지 포함한 job 신원이어야 하고, 반환도 그 신원 그대로여야 한다(축약하면 같은 outer fold의 다른 inner fold 실패가 사라지고, 호출부의 `len(jobs) - len(errors)` 집계도 틀어짐). 호출부는 이름만 필요할 때 `{n for _, _, n in errors}`로 뽑는다
 
-### `_execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, tracker=None, ...)`
-워커 풀 실행. `collectors` 분기와 반환 모양은 `_execute_single`과 동일.
-- **완료 결과는 `job.flow`가 아니라 인자로 받은 `store`에서 되읽는다** — 워커는 이 호출이 지정한 store에 쓰므로. (Trainer가 Predictor를 노드 flow로 먹이면서 별도 store에 저장하기 때문에 둘이 다를 수 있다) `store.get_objs(...)` → `flow.set_objs(...)`
-- **ready-job 계산은 매 dispatch 사이클마다 처음부터 다시 스캔**(`_collect_ready()`) — 노드는 형제 노드가 끝나야 readiness가 바뀌므로 목록을 한 번만 만들어두는 방식이 안 맞는다. Trial에도 그대로 맞음(Trial끼리는 서로 의존 안 하니 한 번 ready면 계속 ready)
+**호출부별 조합**: `build()` = `node_store` + `chained=True` / `exp()` = `trial_store`(저장 없음) + collectors / `train()` 노드 = `node_store` + `chained=True` / `train()` Predictor = `predictor_store` + `collectors=[]`
+
+### `_execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, tracker=None, ..., chained=False)`
+워커 풀 실행. `store`/`chained`/`collectors`의 의미와 반환 모양은 `_execute_single`과 동일.
+- **`chained`일 때만 완료 결과를 되읽어 flow에 올린다** — 되읽기는 `job.flow`가 아니라 인자로 받은 `store`에서. 워커는 이 호출이 지정한 store에 쓰기 때문이고, chained면 둘이 어차피 같지만(노드의 flow는 자기가 쓴 store를 읽는다) 그 전제를 코드가 기대는 대신 말하게 둔 것
+- **ready-job 계산은 매 dispatch 사이클마다 처음부터 다시 스캔**(`_collect_ready()`) — 노드는 형제 노드가 끝나야 readiness가 바뀌므로 목록을 한 번만 만들어두는 방식이 안 맞는다. leaf에도 그대로 맞음(서로 의존 안 하니 한 번 ready면 계속 ready)
 - **워커 배정 fallback**: "내 타입" job이 아직 남아있으면 그 타입 몫 worker를 다른 타입에 안 뺏긴다(`elif free_cpu and not cpu_ready and gpu_fallback_cpu`). ready 목록을 매 사이클 재계산하는 탓에 같은 `_try_dispatch()` 호출 안에서 GPU pass가 막 dispatch한 job이 CPU pass의 판정엔 반영 안 되지만(다음 'done'/'error' 이벤트에서 바로잡힘) 무시할 수준
 - `ProcessWorker(conn, collectors or [], store, ...)`로 store를 그대로 넘김 — 워커 메시지 튜플은 `spec, outer_idx, inner_idx, train_data, valid_data, test_data, ext_data`(워커가 `store.write_objs(spec.name, ...)`로 직접 쓰므로 경로를 미리 조립해 보낼 필요 없음)
 - `ProcessWorker`(spawn): job 경계에서 `del` + `gc.collect()`로 이전 job의 데이터·모델을 놓아줌(안 하면 피크 = 이전 데이터 + 모델 + 새 데이터). 워커 로그 fd는 dup2 직후 close
@@ -661,11 +674,10 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
     __folds/{outer_idx}/{inner_idx}/{name}/
       obj.pkl                       # processor 객체
       result.pkl                    # fit_transform/fit_predict 출력
-      # info 파일은 없다 — status/definition/edges 등은 전부
-      # __node_hist.db(노드) / trials.db의 experiment_hist(Trial)에.
-      # Experimenter 쪽은 노드와 Trial이 이 디렉토리를 같이 쓰고,
-      # 종류를 나타내는 필드가 없으므로 구분이 필요하면 그 두 history
-      # 중 어디에 기록됐는지로 안다 (NodeStore 자신은 obj.pkl 존재만 앎)
+      # 여기 있는 건 Pipeline 노드뿐이다 — Trial은 아무것도 안 남긴다.
+      # info 파일도 없다: status/definition/edges 등은 전부
+      # __node_hist.db(노드) / trials.db의 experiment_hist(Trial)에
+      # 있고, NodeStore 자신은 obj.pkl 존재만 안다
 
   trainers/{name}/
     __trainer.db                    # TrainerStore — 이 Trainer 전용.

--- a/mllabs/_executor.py
+++ b/mllabs/_executor.py
@@ -292,7 +292,8 @@ class ProcessWorker(_mp_ctx.Process):
                     self.conn.send(('error', {**info, 'fold': (outer_idx, inner_idx)}))
                     continue
 
-                self.store.write_objs(node_name, outer_idx, inner_idx, obj, result)
+                if self.store.stores_artifacts:
+                    self.store.write_objs(node_name, outer_idx, inner_idx, obj, result)
 
                 def _send_collect(collector, node_name, outer_idx, inner_idx, res):
                     self.conn.send(('collect', collector.name, node_name, outer_idx, inner_idx, res))
@@ -337,22 +338,25 @@ class _TrackerRouter(ProgressMonitor):
 class Job:
     """One unit of build/experiment work, fully resolved before dispatch.
 
-    A node build and a Trial fit dispatch the same way once name/spec/fold/
-    flow/need_gpu are known, so both are this one class. The caller builds
-    the list and settles what's already done (``_make_node_jobs`` for nodes,
-    ``_make_jobs``/``_make_trial_jobs`` for Trials); the executor never walks
-    ``outer_folds``/``pipeline`` or decides what to skip. Nodes still need the
-    executor to order dispatch (via ``flow.get_missing_nodes``, since nodes
-    can feed each other) — Trials are leaves and don't.
+    A node build, a Trial fit and a Predictor fit dispatch the same way once
+    name/spec/fold/flow/need_gpu are known, so all three are this one class.
+    The caller builds the list and settles what's already done
+    (``_make_node_jobs`` for nodes, ``Experimenter._make_jobs`` for Trials,
+    ``Trainer._make_predictor_jobs`` for Predictors); the executor never
+    walks ``outer_folds``/``pipeline`` or decides what to skip. Nodes still
+    need the executor to order dispatch (via ``flow.get_missing_nodes``,
+    since nodes can feed each other) — Trials and Predictors are leaves and
+    don't, which is what the executor's ``chained`` argument says.
 
     Attributes:
-        name (str): Node/Trial name — also its artifact directory.
+        name (str): Node/Trial/Predictor name.
         spec (ProcessorSpec): What to build and what to feed it — the same
-            shape whether a node or a Trial produced it.
-        outer_idx, inner_idx (int): Fold coordinates — also the
-            NodeStore/DataCache key.
-        flow (TrainDataFlow): Supplies train/valid/test inputs and owns the
-            artifact directory for this fold.
+            shape whichever of the three produced it.
+        outer_idx, inner_idx (int): Fold coordinates — also the key under
+            which a persisted artifact is stored.
+        flow (TrainDataFlow): Supplies train/valid/test inputs. Where the
+            outcome goes, if anywhere, is the executor's *store* — not
+            necessarily this flow's own.
         need_gpu (bool): Whether this job's adapter wants a GPU.
     """
 
@@ -365,9 +369,6 @@ class Job:
         self.inner_idx = inner_idx
         self.flow = flow
         self.need_gpu = need_gpu
-
-    def node_path(self):
-        return self.flow.node_path(self.name)
 
     def __repr__(self):
         return f"<Job {self.name!r} fold=({self.outer_idx}, {self.inner_idx}) gpu={self.need_gpu}>"
@@ -386,30 +387,34 @@ def _job_data(job):
     return train_data, valid_data, test_data
 
 
-def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None):
+def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None,
+                    chained=False):
     """Run *jobs* to completion, single-process.
 
-    Nodes and Trials dispatch identically — both go through ``_process`` and
-    persist the same way — so *collectors* is what tells the two apart:
+    Every kind of job dispatches identically through ``_process``; what the
+    caller varies is where the outcome goes.
 
-    - ``None`` is the node/build case. Input prep skips ``ext_data``, nothing
-      is matched or run, and the dependency gate below applies.
-    - A list (empty is fine — a Trainer has no Collectors) is the Trial case.
-      ``[]`` and ``None`` differ only in those three things, so a Trial path
-      with no Collectors must still pass ``[]``.
+    *store* is whichever store owns this kind of job's record — a
+    ``NodeStore`` for nodes and Predictors, the ``TrialStore`` for Trials.
+    Fitted obj/result are written only if that store keeps artifacts at all
+    (``ArtifactStore.stores_artifacts``); a Trial leaves none, so its store
+    says so and nothing is persisted.
 
-    Jobs are dispatched in dependency order by a ``while True: ready = [...]``
-    loop, needed because nodes can feed each other. The ``get_missing_nodes``
-    gate inside it is node-only: a Trial's edges only ever reference
-    already-built nodes, and gating Trials on it would make one whose node
-    never built vanish silently — never dispatched, never an error — instead
-    of raising a ``KeyError`` from ``TrainDataFlow._resolve_typ`` that gets
-    caught and recorded as a prep error. ``job.flow.set_objs`` runs for every
-    completed job regardless of kind; nothing else marks a job done, so
-    without it the job would stay in ``ready`` and be redispatched forever.
+    *chained* says these jobs feed each other through ``job.flow`` — true
+    only for Pipeline nodes. It turns on both halves of that: completed
+    obj/result are published into the flow (``set_objs``) for later jobs to
+    read, and a job waits until everything its edges reference is built
+    (``get_missing_nodes``). Leaf jobs (Trials, Predictors) get neither.
+    Gating the wait matters: a leaf whose node never built must raise a
+    ``KeyError`` from ``TrainDataFlow._resolve_typ``, caught and recorded as
+    a prep error — under the gate it would instead vanish silently, never
+    dispatched and never an error. Skipping ``set_objs`` matters too: a leaf
+    is read by no one, so publishing it would only pin its fitted model in
+    flow memory for the rest of the run.
 
-    *store* is the run's ``NodeStore``, shared by every job's ``flow`` in a
-    single call, and is where fitted obj/result are written.
+    *collectors* is separate, and only about Collectors: ``None`` skips
+    ``ext_data`` prep and matching entirely (nodes never have Collectors), a
+    list runs them (``[]`` is a list with nothing to match).
 
     Returns ``{(outer_idx, inner_idx, name): error_info}`` for every kind of
     job — the key is a job identity, which the ready-loop needs to keep a
@@ -417,14 +422,15 @@ def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None
     """
     gpu_id_list = gpu_id_list or []
     errors = {}  # {(outer_idx, inner_idx, name): error_info}
+    done = set()  # {(outer_idx, inner_idx, name)} — completed, don't redispatch
     router = _TrackerRouter(0, tracker)
 
     while True:
         ready = [
             job for job in jobs
-            if job.name not in job.flow.node_objs
+            if (job.outer_idx, job.inner_idx, job.name) not in done
             and (job.outer_idx, job.inner_idx, job.name) not in errors
-            and (collectors is not None or not job.flow.get_missing_nodes(job.spec.edges))
+            and (not chained or not job.flow.get_missing_nodes(job.spec.edges))
         ]
         if not ready:
             break
@@ -463,8 +469,11 @@ def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None
                     c.abort_node(node_name)
                 continue
 
-            store.write_objs(node_name, outer_idx, inner_idx, obj, result)
-            job.flow.set_objs(node_name, obj, result, info)
+            if store.stores_artifacts:
+                store.write_objs(node_name, outer_idx, inner_idx, obj, result)
+            if chained:
+                job.flow.set_objs(node_name, obj, result, info)
+            done.add((outer_idx, inner_idx, node_name))
             if tracker:
                 tracker.done(0, node_name, outer_idx, inner_idx, info)
 
@@ -483,22 +492,22 @@ def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None
 
 
 def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, tracker=None,
-                   gpu_fallback_cpu=True, cpu_fallback_gpu=True, log_dir=None):
+                   gpu_fallback_cpu=True, cpu_fallback_gpu=True, log_dir=None,
+                   chained=False):
     """Run *jobs* to completion with a worker pool.
 
-    *collectors* splits node from Trial exactly as in ``_execute_single``:
-    ``None`` is the node/build case (workers get an empty collectors list,
-    input prep skips ``ext_data``, nothing is matched, and the dependency
-    gate applies); a list — empty is fine, a Trainer has no Collectors — is
-    the Trial case.
+    *store*, *chained* and *collectors* mean exactly what they do in
+    ``_execute_single``: the store that owns this kind of job's record
+    (written to only if it keeps artifacts), whether these jobs feed each
+    other through ``job.flow``, and whether Collectors run.
 
     Readiness is recomputed from scratch every dispatch cycle
     (``_collect_ready``) rather than tracked in mutable lists, because a
     node's readiness changes as the nodes it reads complete. The dependency
-    check itself (``flow.get_missing_nodes``) is node-only for the same
-    reason as in ``_execute_single``: gating Trials on it would make one
-    whose node never built vanish silently instead of being recorded as a
-    prep error.
+    check itself (``flow.get_missing_nodes``) applies only when *chained*,
+    for the same reason as in ``_execute_single``: gating a leaf job on it
+    would make one whose node never built vanish silently instead of being
+    recorded as a prep error.
 
     Worker assignment prefers matching type: a free worker of the "wrong"
     type is handed to a ready job only when nothing of its own type is
@@ -550,6 +559,7 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
     free_cpu = list(range(n_gpu, n_jobs))
     busy = {}         # conn -> Job
     errors = {}       # {(outer_idx, inner_idx, name): error_info}
+    done = set()      # {(outer_idx, inner_idx, name)} — completed, don't redispatch
     push_errors = {}  # {(collector, node, outer_idx, inner_idx): outcome}
     router = _TrackerRouter(0, tracker)
     all_conns = [conn for _, conn in workers]
@@ -594,9 +604,9 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
         gpu_ready, cpu_ready = [], []
         for job in jobs:
             key = (job.outer_idx, job.inner_idx, job.name)
-            if job.name in job.flow.node_objs or key in errors or key in in_flight:
+            if key in done or key in errors or key in in_flight:
                 continue
-            if collectors is None and job.flow.get_missing_nodes(job.spec.edges):
+            if chained and job.flow.get_missing_nodes(job.spec.edges):
                 continue
             (gpu_ready if job.need_gpu else cpu_ready).append(job)
         return gpu_ready, cpu_ready
@@ -674,12 +684,16 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
 
                 if msg_type == 'done':
                     info = data[0]
-                    # Read back through *store*, not job.flow's own: the worker
-                    # wrote where this call was told to write, and a caller can
-                    # aim the two elsewhere (a Trainer feeds Predictors from the
-                    # node flow while storing them separately).
-                    obj, result = store.get_objs(node_name, outer_idx, inner_idx)
-                    job.flow.set_objs(node_name, obj, result, {'edges': job.spec.edges})
+                    if chained:
+                        # Read back through *store*, not job.flow's own: the
+                        # worker wrote where this call was told to write. The
+                        # two coincide here (a chained job is a node, whose
+                        # flow reads the very store it was written to), but
+                        # naming the store keeps that an assumption this line
+                        # states rather than one it relies on.
+                        obj, result = store.get_objs(node_name, outer_idx, inner_idx)
+                        job.flow.set_objs(node_name, obj, result, {'edges': job.spec.edges})
+                    done.add((outer_idx, inner_idx, node_name))
                     del busy[conn]
                     (free_gpu if worker_idx < n_gpu else free_cpu).append(worker_idx)
                     if tracker:

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -406,13 +406,16 @@ class Experimenter():
         ]
 
     def get_status(self, node_name):
-        """Return the disk status of a node across all folds.
+        """Return the disk status of a Pipeline node across all folds.
 
-        One :class:`NodeStore` covers this whole run — Stages and Trials
-        always shared its directory, and every fold now shares the same
-        store instance too (told apart by ``outer_idx``/``inner_idx``).
-        Returns the common status if all folds agree, or ``'inconsistent'``
-        if they differ.
+        One :class:`NodeStore` covers this whole run, every fold sharing the
+        same instance (told apart by ``outer_idx``/``inner_idx``). Returns
+        the common status if all folds agree, or ``'inconsistent'`` if they
+        differ.
+
+        Nodes only. A Trial persists nothing, so it is always ``None`` here
+        no matter how many times it has run — its per-fold status lives in
+        ``TrialStore.get_status(trial_name, experimenter)``.
 
         Returns:
             ``'built'``, ``'error'``, ``None`` (init), or ``'inconsistent'``.
@@ -424,9 +427,13 @@ class Experimenter():
         )
 
     def reset_nodes(self, nodes):
-        """Reset nodes to ``init`` state.
+        """Reset Pipeline nodes to ``init`` state.
 
         Removes node objects and clears cache entries for the affected nodes.
+
+        Pipeline nodes only — the artifacts a build produced. A Trial has
+        none to remove, and rerunning one is
+        ``TrialStore.remove_hist(trial_name=, experimenter=)`` instead.
 
         Args:
             nodes (list[str]): Node names to reset.
@@ -519,9 +526,10 @@ class Experimenter():
             if n_jobs > 1:
                 log_dir = self.path / '__worker_logs' if self._os_log_state is not None else None
                 errors = _execute_multi(jobs, n_jobs, self.node_store, gpu_id_list=gpu_id_list,
-                                        tracker=tracker, log_dir=log_dir)
+                                        tracker=tracker, log_dir=log_dir, chained=True)
             else:
-                errors = _execute_single(jobs, self.node_store, gpu_id_list=gpu_id_list, tracker=tracker)
+                errors = _execute_single(jobs, self.node_store, gpu_id_list=gpu_id_list,
+                                         tracker=tracker, chained=True)
         finally:
             tracker.close()
 
@@ -616,11 +624,11 @@ class Experimenter():
         try:
             if n_jobs > 1:
                 log_dir = self.path / '__worker_logs' if self._os_log_state is not None else None
-                errors = _execute_multi(jobs, n_jobs, self.node_store, gpu_id_list=gpu_id_list,
+                errors = _execute_multi(jobs, n_jobs, trial_store, gpu_id_list=gpu_id_list,
                                         collectors=collectors, tracker=tracker,
                                         log_dir=log_dir)
             else:
-                errors = _execute_single(jobs, self.node_store, gpu_id_list=gpu_id_list,
+                errors = _execute_single(jobs, trial_store, gpu_id_list=gpu_id_list,
                                          collectors=collectors, tracker=tracker)
         finally:
             tracker.close()
@@ -640,13 +648,10 @@ class Experimenter():
         it recorded as ``'built'`` — a fold recorded as ``'error'``, or with
         no history row at all, gets a job. Whether the Trial's definition
         changed since that history was recorded is not checked here; history
-        is the sole source of truth for what still needs to run.
-
-        A fold that does get a job has its NodeStore entry reset first — the
-        write on rerun would overwrite the on-disk artifact regardless, but
-        without this, a flow's in-memory info cache (populated by an earlier
-        ``get_info``/``get_status`` call in this same process) would keep
-        returning the stale pre-rerun info even after the new write lands.
+        is the sole source of truth for what still needs to run, and it can
+        be, since a Trial leaves nothing on disk that could disagree with it.
+        Rerunning one is therefore ``TrialStore.remove_hist(...)`` and
+        nothing else.
         """
         from ._executor import Job
         from .adapter import resolve_node_adapter
@@ -663,7 +668,6 @@ class Experimenter():
                 hist_cache[trial.name] = trial_store.get_status(trial.name, self.name)
             if hist_cache[trial.name].get((outer_idx, inner_idx)) == 'built':
                 continue
-            flow.reset_node(trial.name)
 
             if trial.name not in gpu_cache:
                 adapter = resolve_node_adapter(spec.processor, spec.adapter)
@@ -709,6 +713,12 @@ class Experimenter():
         return "\n".join(lines)
 
     def get_objs(self, node_name, outer_idx = 0, inner_idx = 0):
+        """``(obj, result)`` for one built Pipeline node in one fold.
+
+        Nodes only — a Trial's fitted model is never written anywhere, so
+        naming one here raises ``FileNotFoundError``. What a Trial produced
+        is whatever its Collectors kept.
+        """
         return self.outer_folds[outer_idx].train_data_flows[inner_idx].get_objs(node_name)
 
     def get_worker_logs(self, worker=None):

--- a/mllabs/_flow.py
+++ b/mllabs/_flow.py
@@ -49,12 +49,12 @@ class DataFlow:
         (obj.pkl/result.pkl) carries neither anymore.
 
         A node with no matching history row is left unloaded rather than
-        guessed at either way. That is also what keeps fitted models out of
-        memory here without this having to ask what kind of node it is
-        looking at: a Trial's outcome is only ever recorded in
-        ``TrialStore.experiment_hist``, and a Trainer's Predictors have a
-        store of their own, so neither has a row in the store this flow
-        reads.
+        guessed at either way.
+
+        Only Pipeline nodes are ever here to load. A Trial persists nothing
+        at all, and a Trainer's Predictors go to a store of their own — so
+        neither leaves an artifact in the store this flow reads, and no
+        fitted model comes into memory from either.
         """
         fold_info = self.store.get_fold_info(self.outer_idx, self.inner_idx)
         for name in self.store.list_nodes(self.outer_idx, self.inner_idx):

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -167,6 +167,41 @@ class Project:
         """Names of every Trainer created through this project."""
         return self.store.list_trainers()
 
+    def remove_trial(self, name, collectors=None):
+        """Drop *name* from the project — definition, history and collected data.
+
+        A Trial leaves no artifact, so everything it produced is spread across
+        stores that deliberately don't know about each other: its definition
+        and per-fold history in ``TrialStore``, the per-fold collect outcomes
+        in ``CollectHist``, and the collected data itself inside each
+        Collector. Project is the only thing that sees all three, so removing
+        a Trial belongs here rather than in any one of them.
+
+        Every Experimenter is covered — history and collect outcomes are
+        deleted for all of them, and a Collector's data is keyed by node name
+        with no experimenter in it at all. There is no per-Experimenter
+        removal; to make one Experimenter run a Trial again, delete just its
+        history with ``project.trials.remove_hist(trial_name=, experimenter=)``.
+
+        Args:
+            name (str): Trial name. Removing one that was never registered is
+                a no-op, not an error.
+            collectors (Collectors, optional): The registry to clean. Pass the
+                one you are holding: :meth:`collectors` builds a fresh
+                registry on every call, and a Collector may answer from an
+                in-memory cache (``ModelAttrCollector``/``SHAPCollector``
+                keep one), so cleaning a fresh instance leaves yours still
+                serving what was just deleted. Defaults to a fresh registry,
+                which is enough when nothing is holding one.
+        """
+        self.trials.remove(name)
+        self.trials.remove_hist(trial_name=name)
+        collectors = self.collectors() if collectors is None else collectors
+        if collectors.hist is not None:
+            collectors.hist.remove_hist(node_name=name)
+        for collector in collectors:
+            collector.reset_nodes([name])
+
     # ------------------------------------------------------------------
     # pipeline versions
     # ------------------------------------------------------------------

--- a/mllabs/_store.py
+++ b/mllabs/_store.py
@@ -27,11 +27,10 @@ class ArtifactStore:
       ``get_objs``/``get_obj``/``get_result``/``list_nodes``/``status``/
       ``reset_node``) — ``NodeStore`` is the only one that overrides these,
       because it's the only one that actually persists obj/result files.
-      ``TrialStore`` inherits them unoverridden: Trial artifacts live in the
-      run's own ``NodeStore`` (Stage and Trial share that on-disk layout),
-      not in ``TrialStore``, which has no obj/result to serve. Calling one
-      of these on a ``TrialStore`` raises ``NotImplementedError`` rather
-      than the ``AttributeError`` it would raise without this base class.
+      ``TrialStore`` inherits them unoverridden: a Trial leaves no artifact
+      anywhere, so there is no obj/result for it to serve. Calling one of
+      these on a ``TrialStore`` raises ``NotImplementedError`` rather than
+      the ``AttributeError`` it would raise without this base class.
     - **History** methods (``record``/``get_hist``/``get_status``/
       ``get_info``/``remove_hist``) — both override these for real, each
       against its own table. Declared here only so the shape is documented
@@ -39,7 +38,14 @@ class ArtifactStore:
       an extra experimenter name that ``NodeStore`` (already scoped to one
       run) doesn't need, so the signatures aren't identical across
       overrides.
+
+    ``stores_artifacts`` states which half a given store actually implements,
+    so a caller can hand the executor whichever store owns that kind of job's
+    record and let it work out whether there is anything to persist. It is
+    the same split the two groups above describe, in a form code can read.
     """
+
+    stores_artifacts = False
 
     # -- artifact --------------------------------------------------------
 
@@ -119,6 +125,8 @@ class NodeStore(ArtifactStore):
     Args:
         path: This run's base path.
     """
+
+    stores_artifacts = True
 
     def __init__(self, path):
         self.path = Path(path)

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -508,18 +508,20 @@ class Trainer:
                 if n_jobs > 1:
                     node_errors = _execute_multi(
                         node_jobs, n_jobs, self.node_store, gpu_id_list=gpu_id_list, tracker=node_tracker,
-                        log_dir=self.path / '__worker_logs')
+                        log_dir=self.path / '__worker_logs', chained=True)
                 else:
                     node_errors = _execute_single(
-                        node_jobs, self.node_store, gpu_id_list=gpu_id_list, tracker=node_tracker)
+                        node_jobs, self.node_store, gpu_id_list=gpu_id_list, tracker=node_tracker,
+                        chained=True)
                 error_nodes.update(n for _, _, n in node_errors)
 
             if predictor_jobs:
-                # No Collectors here (a Trainer isn't an Experimenter) — pass
-                # [] rather than the default None, which the executor reads as
-                # the node/build path and would gate these on
-                # flow.get_missing_nodes, silently dropping a Predictor whose
-                # node never built instead of recording a prep error.
+                # A Predictor is a leaf: it reads the node flow but nothing
+                # reads it, so these run unchained — no dependency gate (a
+                # Predictor whose node never built must surface as a prep
+                # error, not vanish) and no set_objs (its model belongs in
+                # predictor_store, not pinned in the node flow's memory).
+                # No Collectors either, a Trainer isn't an Experimenter.
                 if n_jobs > 1:
                     predictor_errors = _execute_multi(
                         predictor_jobs, n_jobs, self.predictor_store, gpu_id_list=gpu_id_list,

--- a/mllabs/_trial_store.py
+++ b/mllabs/_trial_store.py
@@ -11,11 +11,9 @@ Two tables:
     One row per (trial name, experimenter name, outer fold, inner fold) — what
     ran, against which Pipeline, and whether it succeeded.
 
-Both tables key on names, matching what is on disk: a trial's artifacts live
-at ``{exp}/__folds/{outer}/{inner}/{trial_name}/`` and an Experimenter's at
-``{project}/exp/{name}``. Keeping the keys aligned with the layout means a
-hist row is readable on its own, and that redefining a name overwrites its
-row exactly as it overwrites the artifact — true in both tables.
+Both tables key on names, matching what an Experimenter is keyed by on disk
+(``{project}/exp/{name}``). A hist row is therefore readable on its own, and
+redefining a name overwrites its row in both tables.
 
 Neither table stores a content hash. Whether a stored definition still
 matches a given Trial is a plain value comparison (``has``) — a hash would
@@ -23,24 +21,25 @@ only restate what that already compares directly. ``experiment_hist`` is a
 run log, not the source of truth for a definition: it does not attempt to
 recover what a name's definition used to be before it was redefined.
 
-Whether a fold needs rebuilding is decided purely from ``experiment_hist``
-now (see ``Experimenter._make_jobs``): a fold recorded ``'built'`` is
-skipped, anything else (``'error'`` or no row) gets a job — the Trial's own
-definition is not compared against its on-disk artifact for this anymore, so
-redefining a Trial does not by itself force a rerun of folds already marked
-``'built'``. ``Trainer._make_trial_jobs`` still compares against the
-artifact's own ``info['definition']`` instead, since a Trainer has no
-``experiment_hist`` to consult.
+**A Trial leaves no artifact.** It is a candidate being measured, so what is
+worth keeping is its outcome, not the model that produced it: the executor
+persists nothing for a Trial job, and its collected results live in whatever
+Collectors were attached. These two tables are therefore the whole record,
+which makes ``experiment_hist`` the only possible answer to whether a fold
+still needs running (see ``Experimenter._make_jobs``): a fold recorded
+``'built'`` is skipped, anything else (``'error'`` or no row) gets a job.
+Nothing on disk can disagree with that, and rerunning a fold is
+``remove_hist(...)`` and nothing else. Redefining a Trial does not by itself
+force a rerun.
 
-``experiment_hist`` also carries an ``info`` column (2026-08-01) — everything
-``_process()``/``_write_prep_error`` produced besides ``status`` (``build_id``,
-``definition``, ``fit_time``, ``edges``, ``train_shape``,
-``warnings``, and, on failure, ``error``), JSON-encoded. This is what used to
-live only in the per-fold ``info.pkl`` NodeStore wrote on disk; recording it
-here instead, via ``TrialHistTracker``, means it survives a ``reset_nodes()``
-that wipes the artifact, and is queryable across folds/experimenters without
-walking directories. See ``NodeInfoStore`` (``_node_info_store.py``) for the
-Stage-side equivalent.
+``experiment_hist`` also carries an ``info`` column — everything
+``_process()``/``_prep_error_info`` produced besides ``status``
+(``build_id``, ``definition``, ``fit_time``, ``edges``, ``train_shape``,
+``warnings``, and, on failure, ``error``), JSON-encoded, recorded by
+``TrialHistTracker``. It is a Trial's only post-mortem, and is queryable
+across folds and Experimenters without walking directories. See
+``NodeStore.node_hist`` (``_store.py``) for the node-side equivalent, which
+sits beside artifacts rather than standing in for them.
 """
 import json
 import sqlite3
@@ -81,6 +80,11 @@ class TrialStore(ArtifactStore):
     not override any of it — it never persists obj/result artifacts, only
     definitions (``trials``) and run history (``experiment_hist``). See
     ``ArtifactStore`` for why the interface is shared anyway.
+
+    ``stores_artifacts`` is left at the base class's ``False``, which is what
+    lets ``Experimenter.exp()`` hand this store to the executor the same way
+    ``build()`` hands it a ``NodeStore``: the executor asks the store whether
+    there is anything to persist, and this one says no.
     """
 
     def __init__(self, path, name='trials'):
@@ -116,6 +120,18 @@ class TrialStore(ArtifactStore):
         """Register every Trial in *trials*."""
         for t in trials:
             self.register(t)
+
+    def remove(self, name):
+        """Delete the definition stored under *name*.
+
+        The definition only — ``experiment_hist`` is left alone, so what ran
+        stays readable after the definition it ran is gone. Dropping a Trial
+        from the project entirely spans this store, ``CollectHist`` and the
+        Collectors' own data, which no single store can see: that is
+        ``Project.remove_trial(name)``.
+        """
+        with sqlite3.connect(str(self.db_path)) as conn:
+            conn.execute("DELETE FROM trials WHERE name = ?", (name,))
 
     def has(self, trial):
         """Whether *trial*'s exact definition is the one stored under its name."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -131,6 +131,18 @@ def _trial_errored(trial_store, trial_name, exp):
     return any(s == 'error' for s in trial_store.get_status(trial_name, exp.name).values())
 
 
+def _trial_built(trial_store, trial_name, exp):
+    """Whether every fold of *exp* recorded *trial_name* as clean.
+
+    A Trial leaves no artifact, so ``Experimenter.get_status``/
+    ``NodeStore.status`` (both disk) can never answer this —
+    ``experiment_hist`` is the whole record."""
+    expected = {(o, i) for o in range(exp.get_n_splits())
+                for i in range(exp.get_n_splits_inner())}
+    status = trial_store.get_status(trial_name, exp.name)
+    return set(status) == expected and set(status.values()) == {'built'}
+
+
 class TestBuildFlowMulti:
     """Exercise _build_flow_multi's worker-pool dispatch (ProcessWorker, n_jobs>1)."""
 
@@ -190,7 +202,7 @@ class TestNJobsCap:
         worker_sessions = [s for s in logger.created if s != 0]
         assert worker_sessions == [1, 2]
         assert sorted(logger.created) == sorted(logger.removed)
-        assert exp.get_status('dt') == 'built'
+        assert _trial_built(trial_store, 'dt', exp)
 
 
 class TestWorkerLogCapture:
@@ -369,7 +381,7 @@ class TestDataPrepErrors:
         exp.build(n_jobs=1)
         exp.exp(_folds(_bad_edges(), exp), trial_store, n_jobs=1)
 
-        assert exp.get_status('dt') == 'built'
+        assert _trial_built(trial_store, 'dt', exp)
         assert _trial_errored(trial_store, 'bad_dt', exp)
 
     def test_exp_multi_reports_error_and_continues(self, exp, pipeline, trial_store):
@@ -378,11 +390,8 @@ class TestDataPrepErrors:
         exp.build(n_jobs=2)
         exp.exp(_folds(_bad_edges(), exp), trial_store, n_jobs=2)
 
-        assert exp.get_status('dt') == 'built'
+        assert _trial_built(trial_store, 'dt', exp)
         assert _trial_errored(trial_store, 'bad_dt', exp)
-        for outer_fold in exp.outer_folds:
-            for store in outer_fold.train_data_flows:
-                assert store.status('dt') == 'built'
 
 
 class TestErrorKeyShape:
@@ -435,11 +444,8 @@ class TestExperimentMulti:
         exp.build(n_jobs=2)
         exp.exp(_folds(_bad_edges(), exp), trial_store, n_jobs=2)
 
-        assert exp.get_status('dt') == 'built'
+        assert _trial_built(trial_store, 'dt', exp)
         assert _trial_errored(trial_store, 'bad_dt', exp)
-        for outer_fold in exp.outer_folds:
-            for store in outer_fold.train_data_flows:
-                assert store.status('dt') == 'built'
 
 
 class TestTrainerMulti:

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -98,6 +98,18 @@ def _flow(exp, outer=0, inner=0):
     return exp.outer_folds[outer].train_data_flows[inner]
 
 
+def _trial_built(trial_store, trial_name, exp):
+    """Whether every fold of *exp* recorded *trial_name* as clean.
+
+    A Trial leaves no artifact, so ``Experimenter.get_status``/
+    ``NodeStore.status`` (both disk) can never answer this —
+    ``experiment_hist`` is the whole record."""
+    expected = {(o, i) for o in range(exp.get_n_splits())
+                for i in range(exp.get_n_splits_inner())}
+    status = trial_store.get_status(trial_name, exp.name)
+    return set(status) == expected and set(status.values()) == {'built'}
+
+
 def _stage_errored(exp, node_name):
     """Whether *node_name* (a Stage) has an 'error' row in this run's own
     NodeStore history — NodeStore.status()/Experimenter.get_status() can only
@@ -247,7 +259,7 @@ class TestExp:
     def test_exp_head(self, exp, pipeline, project):
         trial = _dt()
         exp.exp(_folds(trial, exp), project.trials)
-        assert exp.get_status('dt') == 'built'
+        assert _trial_built(project.trials, 'dt', exp)
 
     def test_exp_skips_built(self, exp, pipeline, project):
         trial = _dt()
@@ -340,6 +352,80 @@ class TestResetNodes:
     # Experimenter.
 
 
+class TestTrialLeavesNoArtifact:
+    """A Trial is a candidate being measured, so only its outcome is kept:
+    experiment_hist plus whatever its Collectors collected. Nothing is
+    written to the run's NodeStore and nothing is pinned in the flow."""
+
+    def test_nothing_on_disk_and_nothing_in_the_flow(self, exp, project):
+        trial = _dt()
+        exp.exp(_folds(trial, exp), project.trials)
+        flow = _flow(exp)
+        assert not flow.node_path('dt').exists()
+        assert 'dt' not in flow.list_nodes()
+        assert 'dt' not in flow.node_objs
+        assert flow.status('dt') is None
+        assert exp.get_status('dt') is None
+        assert exp.node_store.get_hist(node_name='dt') == []
+
+    def test_the_outcome_is_still_recorded(self, exp, project):
+        trial = _dt()
+        exp.exp(_folds(trial, exp), project.trials)
+        status = project.trials.get_status('dt', exp.name)
+        assert status
+        assert set(status.values()) == {'built'}
+
+    def test_nodes_are_unaffected(self, exp, pipeline, project):
+        _setup_stage(pipeline, exp)
+        exp.build()
+        exp.exp(_folds(_dt(), exp), project.trials)
+        flow = _flow(exp)
+        assert flow.status('scaler') == 'built'
+        assert 'scaler' in flow.node_objs
+
+    def test_a_trial_reads_nodes_built_in_the_same_process(self, exp, pipeline, project):
+        """Nodes are published into the flow by build(); a Trial reading one
+        through a namespace segment has to find it there."""
+        _setup_stage(pipeline, exp)
+        exp.build()
+        trial = _dt(edges={'X': 'scaler:(*)', 'y': '{target}'})
+        exp.exp(_folds(trial, exp), project.trials)
+        assert set(project.trials.get_status('dt', exp.name).values()) == {'built'}
+
+    def test_rerun_needs_only_remove_hist(self, exp, project):
+        trial = _dt()
+        exp.exp(_folds(trial, exp), project.trials)
+        project.trials.remove_hist(trial_name='dt', experimenter=exp.name)
+        exp.exp(_folds(trial, exp), project.trials)
+        assert set(project.trials.get_status('dt', exp.name).values()) == {'built'}
+
+    def test_a_failed_trial_records_the_error_and_leaves_nothing(self, exp, project):
+        bad = Trial('dt', 'mock.BadPredictor', DT_EDGES)
+        exp.exp(_folds(bad, exp), project.trials)
+        flow = _flow(exp)
+        assert not flow.node_path('dt').exists()
+        info = project.trials.get_info('dt', exp.name)[(0, 0)]
+        assert set(project.trials.get_status('dt', exp.name).values()) == {'error'}
+        assert info['error']['type'] == 'RuntimeError'
+        assert 'traceback' in info['error']
+
+    def test_a_failed_fold_is_retried_on_the_next_exp(self, exp, project):
+        """'error' is not 'built', so the fold gets a job again — no reset
+        needed, and nothing stale can be left behind to confuse it."""
+        exp.exp(_folds(Trial('dt', 'mock.BadPredictor', DT_EDGES), exp), project.trials)
+        assert set(project.trials.get_status('dt', exp.name).values()) == {'error'}
+        exp.exp(_folds(_dt(), exp), project.trials)
+        assert _trial_built(project.trials, 'dt', exp)
+
+    def test_reset_nodes_on_a_trial_name_is_inert(self, exp, project):
+        """It has nothing to remove, so it cannot leave history asserting a
+        result whose artifact is gone (#127)."""
+        trial = _dt()
+        exp.exp(_folds(trial, exp), project.trials)
+        exp.reset_nodes(['dt'])
+        assert set(project.trials.get_status('dt', exp.name).values()) == {'built'}
+
+
 class TestRebuild:
     def test_build_with_rebuild_true(self, exp, pipeline):
         _setup_stage(pipeline, exp)
@@ -365,18 +451,15 @@ class TestRebuild:
         assert new_obj is not old_obj
         assert _flow(exp).status('scaler') == 'built'
 
-    def test_exp_rebuilds_non_built_node(self, exp, pipeline, project):
-        """Resetting a Trial requires clearing both NodeStore (artifact) and
-        TrialStore.experiment_hist (skip decision) — _make_jobs skips purely
-        on hist status, so reset_nodes() alone would leave the fold skipped."""
+    def test_exp_skips_folds_already_recorded_built(self, exp, pipeline, project):
+        """experiment_hist is the whole skip decision — a Trial persists
+        nothing that could disagree with it."""
         trial = _dt()
         exp.exp(_folds(trial, exp), project.trials)
-        assert exp.get_status('dt') == 'built'
-        exp.reset_nodes(['dt'])
-        assert exp.get_status('dt') is None
-        project.trials.remove_hist(trial_name='dt', experimenter=exp.name)
+        first = project.trials.get_hist(trial_name='dt', experimenter=exp.name)
         exp.exp(_folds(trial, exp), project.trials)
-        assert exp.get_status('dt') == 'built'
+        second = project.trials.get_hist(trial_name='dt', experimenter=exp.name)
+        assert [r['info']['build_id'] for r in first] == [r['info']['build_id'] for r in second]
 
 
 class TestSetPipeline:
@@ -451,7 +534,7 @@ class TestSaveLoad:
         flow = loaded.outer_folds[0].train_data_flows[0]
         assert 'scaler' in flow.node_objs
         assert flow.status('scaler') == 'built'
-        assert loaded.get_status('dt') == 'built'
+        assert _trial_built(project.trials, 'dt', loaded)
 
     def test_load_restores_pipeline(self, project, exp, pipeline, sample_data):
         _setup_stage(pipeline, exp)
@@ -462,7 +545,7 @@ class TestSaveLoad:
         assert 'scaler' in loaded.pipeline.nodes
         trial = _dt()
         loaded.exp(_folds(trial, loaded), project.trials)  # uses restored pipeline, no set_pipeline needed
-        assert loaded.get_status('dt') == 'built'
+        assert _trial_built(project.trials, 'dt', loaded)
 
     def test_load_data_key_mismatch(self, project, sample_data):
         project.experimenter('dk', sample_data, data_key='key_a')
@@ -496,13 +579,22 @@ class TestSaveLoad:
 
 
 class TestGetStatus:
-    def test_get_status_none_before_exp(self, exp, pipeline, project):
-        assert exp.get_status('dt') is None
+    def test_get_status_none_before_build(self, exp, pipeline, project):
+        _setup_stage(pipeline, exp)
+        assert exp.get_status('scaler') is None
 
-    def test_get_status_built_after_exp(self, exp, pipeline, project):
+    def test_get_status_built_after_build(self, exp, pipeline, project):
+        _setup_stage(pipeline, exp)
+        exp.build()
+        assert exp.get_status('scaler') == 'built'
+
+    def test_get_status_is_nodes_only(self, exp, pipeline, project):
+        """A Trial persists nothing, so it never shows here however often it
+        has run — its status is TrialStore's to answer."""
         trial = _dt()
         exp.exp(_folds(trial, exp), project.trials)
-        assert exp.get_status('dt') == 'built'
+        assert exp.get_status('dt') is None
+        assert _trial_built(project.trials, 'dt', exp)
 
     def test_get_status_error(self, exp, pipeline, project):
         bad_trial = Trial('bad_dt', 'mock.BadPredictor', {'X': '{f1}', 'y': '{target}'})

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,8 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import ShuffleSplit
 
-from mllabs import Project, TrialStore, Trial, Predictor, PipelineBuilder, make_trials
+from mllabs import (Project, TrialStore, Trial, Predictor, PipelineBuilder, make_trials,
+                    Connector, MetricCollector)
 
 
 TREE = 'sklearn.tree.DecisionTreeClassifier'
@@ -32,6 +33,10 @@ def store(tmp_path):
 
 def _trial(name='dt', params=None):
     return Trial(name, TREE, EDGES, params=params or {'max_depth': 3})
+
+
+def dummy_metric(y, pred):
+    return 0.5
 
 
 class TestProjectLayout:
@@ -446,7 +451,6 @@ class TestExperimenterUnderProject:
         trial = make_trials('dt', processor=TREE, edges=EDGES,
                              params={'max_depth': 3, 'random_state': 0})[0]
         e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials)
-        assert e.get_status('dt') == 'built'
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
 
         # history is keyed by the two names, matching the layout on disk
@@ -508,9 +512,84 @@ class TestExperimenterUnderProject:
         trial = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0})
         bad_trial = Trial('bad', 'mock.BadPredictor', EDGES)
         e.exp([(trial, 0, 0), (trial, 1, 0), (bad_trial, 0, 0)], project.trials, n_jobs=2)
-        assert e.get_status('dt') == 'built'
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
         assert project.trials.get_status('bad', 'run_a')[(0, 0)] == 'error'
+
+
+class TestRemoveTrial:
+    """A Trial leaves no artifact, so everything it produced sits in stores
+    that don't know about each other — TrialStore (definition + history),
+    CollectHist (per-fold collect outcomes) and each Collector's own data.
+    Project is the only thing that sees all three."""
+
+    def _run(self, project, builder, sample_data):
+        version = project.build_pipeline(builder).version
+        e = project.experimenter(
+            'run_a', sample_data,
+            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=0),
+            pipeline_name='main', pipeline_version=version,
+        )
+        e.build()
+        collectors = project.collectors()
+        collectors.set_collector('acc', MetricCollector, Connector(),
+                                 params={'output_var': None, 'metric_func': dummy_metric})
+        trial = _trial()
+        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials, collectors=collectors)
+        return e, collectors
+
+    def test_store_remove_drops_the_definition_only(self, store):
+        store.register(_trial())
+        store.record('dt', 'exp-1', 0, 0, status='built')
+        store.remove('dt')
+        assert store.get_by_name('dt') is None
+        assert store.list_trials() == []
+        assert store.get_hist(trial_name='dt')  # what ran stays readable
+
+    def test_removing_an_unregistered_name_is_a_no_op(self, project):
+        project.remove_trial('never_registered')
+
+    def test_removes_definition_history_and_collected_data(self, project, builder, sample_data):
+        e, collectors = self._run(project, builder, sample_data)
+        assert project.trials.get_by_name('dt') is not None
+        assert project.trials.get_status('dt', 'run_a')
+        assert collectors.hist.get_hist(node_name='dt')
+        assert collectors.get_collector('acc').get_metric('dt') is not None
+
+        project.remove_trial('dt')
+
+        assert project.trials.get_by_name('dt') is None
+        assert project.trials.get_status('dt', 'run_a') == {}
+        assert collectors.hist.get_hist(node_name='dt') == []
+        assert project.collectors().get_collector('acc').get_metric('dt') is None
+
+    def test_leaves_other_trials_alone(self, project, builder, sample_data):
+        e, collectors = self._run(project, builder, sample_data)
+        other = _trial('dt2')
+        e.exp([(other, 0, 0), (other, 1, 0)], project.trials, collectors=collectors)
+
+        project.remove_trial('dt')
+
+        assert project.trials.get_by_name('dt2') is not None
+        assert project.trials.get_status('dt2', 'run_a')
+        assert collectors.hist.get_hist(node_name='dt2')
+        assert project.collectors().get_collector('acc').get_metric('dt2') is not None
+
+    def test_cleans_the_registry_it_is_given(self, project, builder, sample_data):
+        """collectors() builds a fresh registry each call, and a Collector may
+        answer from an in-memory cache — so the caller's own registry has to be
+        cleanable, not just whatever Project happens to construct."""
+        e, collectors = self._run(project, builder, sample_data)
+        acc = collectors.get_collector('acc')
+        assert acc.has_node('dt')
+        project.remove_trial('dt', collectors=collectors)
+        assert not acc.has_node('dt')
+
+    def test_a_removed_trial_runs_again_from_scratch(self, project, builder, sample_data):
+        e, collectors = self._run(project, builder, sample_data)
+        project.remove_trial('dt')
+        trial = _trial()
+        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials, collectors=collectors)
+        assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
 
 
 class TestTrainerUnderProject:


### PR DESCRIPTION
Closes #127.

## The bug

`reset_nodes()` on a Trial deleted the artifact but left the fold recorded as `'built'` in `experiment_hist`, so the next `exp()` skipped it — the result gone for good, no error, no warning. The two skip gates read different sources (a node's is disk, a Trial's is history) and they live in different stores, so one call could not clear both.

## The fix

Rather than teach `reset_nodes` about a project-wide store, this removes what the two gates could disagree about: **a Trial no longer persists anything.**

A Trial is a candidate being measured, so what is worth keeping is its outcome, not the model that produced it — `experiment_hist` plus whatever its Collectors kept. That makes history the only possible answer to what still needs running, and rerunning a fold `remove_hist()` and nothing else. `reset_nodes()` stays what it always meant: the artifacts a build produced.

`_make_jobs`' per-fold `flow.reset_node(trial.name)` goes away with it.

## How the executor tells jobs apart

It no longer infers the kind. Two arguments say it directly:

| | `store` | `chained` | `collectors` |
|---|---|---|---|
| `build()` | `node_store` | `True` | — |
| `exp()` | `trial_store` | `False` | list |
| `train()` nodes | `node_store` | `True` | — |
| `train()` Predictors | `predictor_store` | `False` | `[]` |

- **`store`** is whichever store owns that job's record. obj/result are written only if it keeps artifacts at all, which `ArtifactStore.stores_artifacts` now states (base `False`, `NodeStore` `True`) — the same artifact/history split the class docstring already described, in a form code can read.
- **`chained`** says these jobs feed each other through `job.flow`. It gates both halves of that: publishing completed obj/result into the flow (`set_objs`) and waiting on `get_missing_nodes`. Leaf jobs get neither.

This replaces `collectors is None` as the stand-in for "is this a node", which never fit Predictors — they pass `[]` and do persist. `collectors` is now only about Collectors.

**Predictors are cleaned up too** (asked for in review): still stored in `predictor_store`, but no longer published into the node flow, so a fitted model is not pinned in flow memory for the rest of the run. `process()`/`to_inferencer()` already read them from `predictor_store` on demand.

Job completion is now an explicit `done` set of `(outer, inner, name)`. `flow.node_objs` was doing that as a side effect, and a leaf never lands there.

## Removing a Trial

There was no way to delete one — `TrialStore` had no `DELETE` outside `remove_hist`, while `PredictorStore` has both `remove` and `replace_all`.

- **`TrialStore.remove(name)`** — the definition only. History stays readable on its own.
- **`Project.remove_trial(name, collectors=None)`** — the whole thing: definition, `experiment_hist` for every Experimenter, `CollectHist`, and each Collector's own data. Those four stores deliberately do not know about each other and Project is the only thing that sees them all, so the operation belongs there rather than in any one of them.
  - Pass the registry you are holding: `collectors()` builds a fresh one per call and `ModelAttrCollector`/`SHAPCollector` answer from an in-memory cache, so cleaning a fresh instance leaves yours serving what was just deleted.

## Tests

New `TestTrialLeavesNoArtifact` (8) — nothing on disk or in the flow, the outcome is still recorded, nodes unaffected, a Trial reads nodes built earlier in the same process, `remove_hist` alone reruns, `reset_nodes` on a Trial name is inert (#127), a failed Trial records its error and leaves nothing, an `'error'` fold is retried automatically.

New `TestRemoveTrial` (6) — store-level removal is definition-only, unknown name is a no-op, definition/history/collected data all go (verified through a *fresh* registry so it is the disk being checked), other Trials untouched, a passed registry is cleaned in memory too, a removed Trial runs again from scratch.

Updated: assertions that used `Experimenter.get_status(trial)` as "did it run" now read `experiment_hist`; `TestGetStatus` became a check that `get_status` is nodes-only.

Full suite green.
