### PR TITLE
refactor(Collectors): one registry per Experimenter, not per Project (#135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,19 +27,20 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 ```
 Project(path, cache_maxsize)          경로·캐시 소유. 프로젝트 전역인 것만
   ├─ PipelineBuilder ──build()──► Pipeline    가변 정의 → 불변 노드 그래프
-  ├─ Collectors ──CollectorStore──► Collector 정의(entity 행 + params pkl) → 재조립
   ├─ TrialStore                     Trial 정의 + 실행 이력 (프로젝트 전역 — 결과 비교가 목적)
   ├─ ProjectStore                   run 이름 목록만 (experimenters / trainers)
   ├─ Experimenter(name)             CV 실험 (exp/{name}/) — Trial을 평가
-  │    └─ ExperimenterStore         meta + splitter + pipeline.pkl (이 run만)
+  │    ├─ ExperimenterStore         meta + splitter + pipeline.pkl (이 run만)
+  │    └─ Collectors ──CollectorStore──► Collector 정의(entity 행 + params pkl) → 재조립
+  │         └─ CollectHist          수집 이력 (이 run만)
   └─ Trainer(name)                  전체 데이터 학습 (trainers/{name}/) — Predictor를 학습
        ├─ TrainerStore              meta + splits + pipeline.pkl (이 Trainer만)
        ├─ PredictorStore            Predictor 정의 (이 Trainer만 — 비교할 일이 없어서)
        └─ to_inferencer() ──► Inferencer
 ```
-**경계**: run 하나에 대한 것(splitter, 채택한 Pipeline, 아티팩트/이력, 학습할 Predictor)은 전부 그 run
-디렉토리 안. Project는 "이 프로젝트에 뭐가 있나"만 답한다 → **어떤 run이든 Project 없이 열 수 있다**
-(`Experimenter.load_experimenter(path, data)` / `Trainer.load_trainer(path, data)`).
+**경계**: run 하나에 대한 것(splitter, 채택한 Pipeline, 아티팩트/이력, Collector, 학습할 Predictor)은
+전부 그 run 디렉토리 안. Project는 "이 프로젝트에 뭐가 있나"만 답한다 → **어떤 run이든 Project 없이
+열 수 있다** (`Experimenter.load_experimenter(path, data)` / `Trainer.load_trainer(path, data)`).
 
 - **Project** (`_project.py`): 디렉토리 레이아웃 + `TrialStore`/`ProjectStore`/`cache`. 프로젝트 전역인 것만 소유하고, Pipeline 버전조차 색인하지 않는다(각 pipeline이 자기 db에서 관리)
 - **PipelineBuilder / Pipeline** (`_pipeline.py`): 가변 빌더 + `build()`가 만드는 불변 **노드 전용** 그래프
@@ -182,16 +183,18 @@ Project는 순수 "조각을 짜맞춰주는 팩토리"일 뿐 필수 의존성�
 ProjectStore는 이름 목록이라 동기화가 어긋날 두 번째 진실 원본이 되지 않는다.
 
 - `Project(path, cache_maxsize=4GB)` — `DataCache`를 소유하고 모든 Experimenter/Trainer가 공유
-- 경로: `pipeline_path(name)`, `exp_path(name)`, `trainer_path(name)`, `inferencer_path(name)`, `collectors_path()`
-- 팩토리: `pipeline_builder(name)`, `collectors()`, `experimenter(name, data, pipeline_name=, pipeline_version=, **kw)`, `load_experimenter(name, data, data_key=, aug_data=)`, `trainer(name, data, pipeline_name=, pipeline_version=, **kw)`, `load_trainer(name, data, aug_data=)`
+- 경로: `pipeline_path(name)`, `exp_path(name)`, `trainer_path(name)`, `inferencer_path(name)` — **collector 경로 없음**(레지스트리는 run 소유)
+- 팩토리: `pipeline_builder(name)`, `experimenter(name, data, pipeline_name=, pipeline_version=, **kw)`, `load_experimenter(name, data, data_key=, aug_data=)`, `trainer(name, data, pipeline_name=, pipeline_version=, **kw)`, `load_trainer(name, data, aug_data=)`
 - **Pipeline 버전**: `build_pipeline(builder)` → `builder.build()` 후 결과를 다음 버전(1부터, `max+1`)으로 저장하고 `pipeline.version`에 세팅해 반환. **content dedup 없음** — 내용이 같아도 호출할 때마다 새 버전(`builder`에 path가 없으면 `ValueError`)
   - 카운터/버전 파일은 **각 pipeline 자신의 db**(`pipelines/{name}/{name}.db`)가 소유 — `build_pipeline`은 `builder._store.save_version()`에 위임할 뿐, 프로젝트 전역 색인이 없음
   - `load_pipeline(name, version=None)`, `list_pipeline_versions(name)` — 둘 다 `PipelineStore(pipeline_path(name), name)`를 통해 조회
   - 저장은 pkl (`v{n}.pkl`) — 형식은 `PipelineStore.save_version`/`load_version` 뒤에 숨어 있어 교체 가능
 - `trials`: `TrialStore`, `store`: `ProjectStore`, `list_experimenters()`, `list_trainers()`
-- **`remove_trial(name, collectors=None)`**: Trial 하나를 프로젝트에서 완전히 지운다 — 정의(`TrialStore.trials`) + 이력(`experiment_hist`, **모든 experimenter**) + 수집 이력(`CollectHist`) + 각 Collector가 들고 있는 데이터. Trial은 아티팩트를 안 남기는 대신 흔적이 서로 모르는 store 넷에 흩어져 있고, **그 넷을 다 보는 건 Project뿐**이라 여기 있다(단일 store 위의 편의 래퍼가 아니라, 주인 없는 교차 연산에 주인을 준 것)
-  - `collectors=`: **들고 있는 레지스트리가 있으면 그걸 넘길 것** — `collectors()`는 호출마다 새 인스턴스를 만들고 일부 Collector는 메모리 캐시에서 답하므로(`ModelAttrCollector`/`SHAPCollector`의 `_cache`), 새 인스턴스만 청소하면 내가 든 쪽은 방금 지운 걸 계속 내놓는다
-  - 특정 Experimenter만 다시 돌리고 싶은 거라면 이게 아니라 `trials.remove_hist(trial_name=, experimenter=)`
+- **`remove_trial(name, experimenters=None)`**: Trial 하나를 프로젝트에서 완전히 지운다 — 정의(`TrialStore.trials`) + 이력(`experiment_hist`, **모든 experimenter**) + 각 run이 수집한 데이터와 그 `CollectHist`. Trial은 아티팩트를 안 남기는 대신 흔적이 서로 모르는 store들에 흩어져 있고, **그걸 다 보는 건 Project뿐**이라 여기 있다(단일 store 위의 편의 래퍼가 아니라, 주인 없는 교차 연산에 주인을 준 것)
+  - 프로젝트 전역 절반(정의 + 전 experimenter 이력)은 각각 SQL 한 문장이고, run별 절반은 `list_experimenters()` 순회 → `Experimenter.remove_trial_result(name)` 위임
+  - **run을 열지 않는다** — `Collectors({exp_path}/collectors)`로 레지스트리만 경로에서 연다(db 두 개뿐, 데이터셋 불필요). Experimenter를 만들면 `DataFlow.__init__`이 그 fold의 아티팩트를 전부 적재하므로 trial 하나 지우자고 치를 비용이 아님
+  - `experimenters=`: **이미 열어둔 run이 있으면 그걸 넘길 것** — 경로로 새로 연 레지스트리는 내가 든 인스턴스가 아니고, 일부 Collector는 메모리 캐시에서 답한다(`ModelAttrCollector`/`SHAPCollector`의 `_cache`)
+  - 특정 Experimenter만 다시 돌리고 싶은 거라면 이게 아니라 `e.remove_trial_result(name, trial_store)`
 
 ### ArtifactStore (`_store.py`, 공통 인터페이스)
 `NodeStore`/`TrialStore`가 공유하는 메소드 모양의 base class. 두 그룹:
@@ -224,13 +227,15 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - 채택한 Pipeline은 **실험 디렉토리의 `pipeline.pkl`로 저장되고 `load_experimenter()`가 그걸 다시 읽는다**(`_experimenter.py:284`) — Project 없이도 마지막에 채택한 Pipeline이 복원됨. **생성자는 안 읽는다** — `self.pipeline = None`으로 두고 `_save()`가 meta의 `pipeline_name`/`pipeline_version`까지 기본값으로 덮어쓰므로, 기존 디렉토리에 대고 생성자를 부르면 provenance가 사라진다(GitHub #128)
   - 버전 전환 시 `pipeline.diff_from(self.pipeline)`으로 stale 판정 → `reset_nodes()`로 해당 노드 아티팩트만 제거. Trial은 건드리지 않음("Staleness" 섹션)
 - `cache`(`DataCache`, optional) — `None`이면 캐시 없이 동작. store는 optional이 아니라(자기가 만듦) standalone Experimenter도 meta/splitter/Pipeline이 전부 저장됨
+- **`collectors`**: `Collectors({path}/collectors)` — 생성자에서 만들고(생성자가 곧 복원) `node_store`와 같은 자리. Collector가 쓰는 건 전부 노드 이름만으로 키잉되므로 **경로가 두 run을 가르는 유일한 수단**이다 — 프로젝트 전역 레지스트리였다면 이름이 겹치는 Trial마다 서로의 결과를 덮어썼다(무증상, 그리고 하필 비교가 필요한 바로 그 경우에). 대가는 교차 run 비교가 store N개에 대한 읽기가 되는 것(#130)
+- **`remove_trial_result(name, trial_store=None)`**: 이 run이 가진 Trial *결과*를 지운다 — `self.collectors.remove_results(name)`(수집 데이터 + `CollectHist` 행). `trial_store`를 주면 이 run의 `experiment_hist` 행도 삭제 → **다음 `exp()`가 그 Trial을 다시 돌린다**(fold 스킵의 유일한 근거가 이력이므로). 다른 run의 기록은 안 건드림
 - **pipeline 필요** (`_require_pipeline()`로 미설정 시 에러):
   - `build(nodes=None, rebuild=False, n_jobs=1, gpu_id_list=None, logger=None)` — 노드 빌드
-  - **`exp(trials, trial_store, collectors=None, collect_hist=None, n_jobs=1, gpu_id_list=None, logger=None)`**
+  - **`exp(trials, trial_store, collectors=None, n_jobs=1, gpu_id_list=None, logger=None)`**
     - `trials`: **`[(Trial, outer_idx, inner_idx), ...]`** 튜플 리스트. fold 전개를 여기서 하므로 executor는 목록을 그대로 실행
     - `trial_store`(`TrialStore`): 필수 — Trial 정의 등록/fold 스킵 판정/이력 기록 전부 여기로 함(보통 `project.trials`)
-    - `collectors`: `Collectors` 레지스트리 / Collector 인스턴스 리스트 / `None`
-    - `collect_hist`(`CollectHist`, optional): 수집 이력. 안 주면 **레지스트리를 넘겼을 때만** 그 `collectors.hist`가 쓰임 — 맨 리스트는 쓸 프로젝트 전역 자리가 없어서 기록 안 됨(`_resolve_collectors`가 `(instances, hist)` 반환)
+    - `collectors`: **이 run의 `self.collectors`에 등록된 이름 리스트**. `None`=전부, `[]`=수집 안 함. 인스턴스를 넘기면 `TypeError`(`_resolve_collectors`) — 레지스트리가 모르는 Collector는 이 run에 쓸 자리가 없어서 조용히 run 밖에 결과를 떨군다. 미등록 이름은 `Collectors.resolve`가 `KeyError`
+    - 수집 이력은 항상 `self.collectors.hist` — 한 호출의 선택이 아니라 run에 속하므로 인자가 없다
     - `_make_jobs(trials, trial_store)`가 `Job(name, spec, outer_idx, inner_idx, flow, need_gpu)` 리스트를 만듦. skip 판정은 `trial_store.get_status(name, self.name)`의 fold별 status로만 함. GPU 판정도 여기서 하고, adapter resolve는 **trial 이름당 1회**
     - Trial 정의를 *trial_store*에 등록하고, `TrialHistTracker`가 fold별 done/error를 이력에 기록
   - `n_jobs`는 실제 작업 수로 상한 처리 (`min(n_jobs, len(jobs))`) — 유휴 워커/progress bar 방지
@@ -347,25 +352,28 @@ predictors(name PK, desc, processor, method, adapter, params, edges, tag,
   - edges: `{key: dsl_string}` — 각 key에 대해 노드의 resolved `edges[key]` 문자열과 **정확히 일치**해야 함 (contain 기반 아님)
 
 ### Collector (`collector/` 패키지)
-- **Collectors** (`_registry.py`): Collector 인스턴스를 소유하는 레지스트리. `Project.collectors()`로 얻음
+- **Collectors** (`_registry.py`): Collector 인스턴스를 소유하는 레지스트리. **Experimenter 하나당 하나** — `e.collectors`(`{exp path}/collectors`)
   - `Collectors(path=None)` — path 있으면 등록 시 `{path}/{name}`이 기본 저장 위치. **생성자가 곧 복원** — 그 path의 `CollectorStore`에서 등록돼 있던 걸 전부 되살림(별도 `load()` 없음)
+  - **왜 run 소유인가**: Collector가 쓰는 건 전부 노드 이름만으로 키잉된다(`MetricCollector` PK `(node, idx, inner_idx, split)`, 파일 기반은 `{path}/{node}...`). 그래서 두 run을 가르는 건 **경로뿐**이고, 레지스트리를 공유하면 이름이 겹치는 Trial마다 서로의 결과를 덮어쓴다 — 무증상으로, 그리고 하필 비교가 필요한 바로 그 경우에. `NodeStore`와 같은 배치이고, 덕분에 standalone run이 collector까지 자족한다
   - `set_collector(name, collector, connector, path=None, params=None, exist='skip')` — 부품에서 조립. `collector`는 클래스 또는 `"module.ClassName"`, `connector`는 인스턴스 또는 `{__ref__}`, `params`엔 `resolve_ref_values` 적용
   - **등록 즉시 영속화** — `set_collector`가 store에 write-through. `Collectors.save()`는 없다. path 없는 레지스트리는 메모리 전용
   - `get_collector`/`remove_collector`(store 행+params 파일까지 삭제)/`names()`/`in`/`len`/`iter`
-  - **`resolve(names)`**: 미등록 이름이면 `KeyError` — 조용히 넘어가면 "아무것도 수집 안 됨"과 구분이 안 되기 때문
+  - **`resolve(names)`**: 미등록 이름이면 `KeyError` — 조용히 넘어가면 "아무것도 수집 안 됨"과 구분이 안 되기 때문. `None`이면 전부
+  - **`remove_results(node_name)`**: 그 노드로 수집된 것 전부 삭제 — `hist` 행 + 각 Collector의 `reset_nodes([name])`. 두 절반을 다 보는 게 레지스트리뿐이라 여기 있다(정의는 안 건드림). `Experimenter.remove_trial_result`/`Project.remove_trial`이 이걸로 수렴
   - `match(spec, names=None)`
-  - **`hist`**: 같은 path의 `CollectHist`. path 없으면 `None`. 레지스트리가 프로젝트 전역이라 이력도 여기 붙는다 — 메트릭이 한곳에 모여야 비교 가능한 것과 같은 이유
+  - **`hist`**: 같은 path의 `CollectHist`. path 없으면 `None`
 
 - **CollectHist** (`collector/_collect_hist.py`): 수집 이력
   ```sql
-  collect_hist(collector_name, experimenter, node_name, outer_idx, inner_idx,  -- PK
+  collect_hist(collector_name, node_name, outer_idx, inner_idx,  -- PK
                pipeline_version, status, collect_date, elapsed, info)
   ```
+  - **`experimenter` 컬럼이 없는 이유**: 레지스트리가 이미 run 하나에 스코프돼 있어 어느 run인지는 **db가 어디 있느냐**로 답한다 — `node_hist`에 `run_name`이 없는 것과 같다
   - **키가 fold 단위인 이유**: Collector가 자기 상태를 다루는 단위는 노드(`has_node`/`abort_node`/`reset_nodes`/`_save_node`)지만, 실패는 fold 하나에서 나고 그게 어느 fold였는지가 분석의 시작점. 노드로 접으면 그 정보가 사라짐
   - `status`: `'collected'`(결과 반환) / `'empty'`(예외 없이 `None`) / `'error'`. **`empty`를 따로 가르는 게 핵심** — 실패와 "수집할 게 없음"이 둘 다 `None`이면 구분이 안 된다(보통 `output_var` 설정 실수)
   - `info`(에러 시 JSON): `{phase, type, message, traceback}`. `phase`는 `'output'`(공용 `obj.process` 준비) / `'ext'`(ProcessCollector의 `output_ext`) / `'collect'` / `'push'`
   - `elapsed`는 **`collect()` 호출 시간만** — 단일/멀티 워커에서 같은 의미가 되도록(멀티에선 push가 부모에서 돎)
-  - `record`/`record_all`/`get_hist(collector_name=, experimenter=, node_name=, status=, pipeline_version=)`/`get_status`/`get_info`/`get_errors`/`remove_hist`
+  - `record`/`record_all`/`get_hist(collector_name=, node_name=, status=, pipeline_version=)`/`get_status(collector_name, node_name=)`/`get_info`/`get_errors(collector_name=)`/`remove_hist(collector_name=, node_name=)`
   - `get_status`/`get_info`의 키는 `(node_name, outer_idx, inner_idx)`
   - **게이트가 아니라 로그** — `experiment_hist`와 달리 이걸 보고 뭘 스킵하지 않는다. 다만 "`'built'`로 스킵된 fold엔 수집 기록이 없다"가 조회로 드러나서, 이미 다 돌린 실험에 collector를 새로 붙여 `exp()`를 다시 불렀을 때 아무것도 수집 안 되는 상황이 무증상으로 지나가지 않는다
 
@@ -637,7 +645,7 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 - `ExecuteTracker` 기반. `LoggerExecuteTracker` — 워커 이벤트→logger, `typ`에 따라 `logger.info`/`warning` 라우팅
 - `NodeInfoTracker` — 노드/Predictor 실행 이력을 그 run의 `NodeStore.node_hist`에 기록
 - **`TrialHistTracker(tracker, store, experimenter, pipeline_version, collect_hist=None)`** — 로깅 tracker를 감싸 `done`/`error` 시점에 `TrialStore`에 이력 기록. 이벤트 시점이라 멀티워커도 그대로 커버되고, 사후에 디스크를 다시 읽지 않아도 된다
-  - `collect_hist`를 주면 `collect(node_name, outer_idx, inner_idx, outcomes)` 이벤트에서 `CollectHist`에도 기록. 별도 wrapper 클래스를 두지 않은 이유: 수집 이력의 키/스탬프가 이 클래스가 이미 들고 있는 `experimenter`/`pipeline_version` 그대로고, 부모 프로세스 이벤트 스트림을 타야 하는 이유도 같다
+  - `collect_hist`(실행 중인 Experimenter의 `collectors.hist`)를 주면 `collect(node_name, outer_idx, inner_idx, outcomes)` 이벤트에서 `CollectHist`에도 기록. 별도 wrapper 클래스를 두지 않은 이유: 스탬프가 이 클래스가 이미 들고 있는 `pipeline_version` 그대로고, 부모 프로세스 이벤트 스트림을 타야 하는 이유도 같다. `experimenter`는 안 넘어간다 — 그 hist가 이미 그 run의 것
   - `ExecuteTracker.collect(...)`는 base에 no-op — 노드/Predictor 경로엔 매칭될 Collector가 없어 실제로 호출되지 않음
 
 ## 저장 구조
@@ -652,23 +660,24 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
     {name}.db                       # PipelineBuilder 노드/그룹 정의 + versions(version PK, path)
     v{n}.pkl                        # 버전별 빌드 결과 Pipeline
 
-  collectors/
-    collectors.db                   # CollectorStore — collectors(name PK, collector,
-                                    #   connector, path). 정의의 평문 절반
-    __params/{name}.pkl             #   정의의 나머지 절반 — 생성자 params (산 객체가
-                                    #   들어올 수 있어 pickle). 이 둘로 재조립
-    collect_hist.db                 # CollectHist — 정의(위)와 별도 파일로,
-                                    #   CollectorStore는 정의만 갖는다는 경계 유지
-    {name}/                         # Collector가 소유하는 저장 위치 — 데이터만
-      metrics.db                    # MetricCollector (node, idx, inner_idx, split, value)
-      {node}.pkl                    # StackingCollector — {'folds': [[inner 결과...], ...]}
-      {node}/{idx}_{inner_idx}.pkl  # OutputCollector
-
   exp/{name}/                       # Experimenter — 이름이 곧 식별자, 디렉토리 하나로 자족
     __exp.db                        # ExperimenterStore — 이 run 전용.
                                     #   experimenter(name PK, data_key, title,
                                     #                pipeline_name, pipeline_version, splitters BLOB)
     pipeline.pkl                    # 이 run이 채택한 Pipeline 사본
+    collectors/                     # 이 run의 Collectors — 프로젝트 전역 레지스트리는 없다.
+                                    #   Collector 데이터가 노드 이름만으로 키잉되므로
+                                    #   경로가 run을 가르는 유일한 수단
+      collectors.db                 #   CollectorStore — collectors(name PK, collector,
+                                    #     connector, path). 정의의 평문 절반
+      __params/{name}.pkl           #   정의의 나머지 절반 — 생성자 params (산 객체가
+                                    #     들어올 수 있어 pickle). 이 둘로 재조립
+      collect_hist.db               #   CollectHist — 정의(위)와 별도 파일로,
+                                    #     CollectorStore는 정의만 갖는다는 경계 유지
+      {name}/                       #   Collector가 소유하는 저장 위치 — 데이터만
+        metrics.db                  #     MetricCollector (node, idx, inner_idx, split, value)
+        {node}.pkl                  #     StackingCollector — {'folds': [[inner 결과...], ...]}
+        {node}/{idx}_{inner_idx}.pkl  #   OutputCollector
     __worker_logs/worker_{i}.log    # 멀티워커가 캡처한 네이티브 출력 (+ master.log)
     __folds/__node_hist.db          # 이 run의 NodeStore가 소유
     __folds/{outer_idx}/{inner_idx}/{name}/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ e = project.experimenter('cv', df, pipeline_name='main',
                          pipeline_version=project.build_pipeline(p).version)
 e.build()
 
-collectors = project.collectors()
+collectors = e.collectors
 collectors.set_collector(
     'acc', 'mllabs.collector.MetricCollector',
     {'__ref__': 'mllabs.Connector', '__params__': {'edges': {'y': '{target}'}}},
@@ -83,7 +83,7 @@ trials = [Trial(f'lr_{c}', 'sklearn.linear_model.LogisticRegression',
                 params={'C': c})
           for c in (0.1, 1.0)]
 
-e.exp([(t, 0, 0) for t in trials], project.trials, collectors=collectors)
+e.exp([(t, 0, 0) for t in trials], project.trials)
 
 print(collectors.get_collector('acc').get_metrics_agg(None)[0])
 ```

--- a/docs/guide/collectors.md
+++ b/docs/guide/collectors.md
@@ -4,10 +4,10 @@ A Collector captures what happens while Trials run — metrics, model attributes
 
 ## The registry
 
-Collectors are registered in a `Collectors` registry, which the `Project` owns. Registration builds the instance from its parts and **persists it immediately** — there is no `save()`.
+Collectors are registered in a `Collectors` registry, which belongs to an Experimenter — `e.collectors`, stored under `{exp path}/collectors`. Registration builds the instance from its parts and **persists it immediately** — there is no `save()`.
 
 ```python
-collectors = project.collectors()
+collectors = e.collectors
 
 collectors.set_collector(
     'acc',
@@ -20,7 +20,7 @@ collectors.set_collector(
 
 The three positional arguments are the name, the Collector class (as a string or a class), and the Connector (as an instance or a ref spec). Everything else goes in `params`.
 
-Constructing the registry *is* restoring it — `project.collectors()` in a fresh session hands back everything registered before.
+Constructing the registry *is* restoring it, and the Experimenter constructs one — reopening a run with `load_experimenter` hands back everything registered on it before.
 
 ```python
 collectors.names()
@@ -29,10 +29,10 @@ collectors.remove_collector('acc')      # deletes the row and its params file
 'acc' in collectors
 ```
 
-A registry is project-wide on purpose: when several runs share one, their metrics land in the same place and stay comparable.
+A registry belongs to one run on purpose. Everything a Collector writes is keyed by node name and nothing more — `MetricCollector`'s primary key is `(node, idx, inner_idx, split)`, and the file-based ones use `{path}/{node}...` — so the path is the only thing keeping two runs apart. Sharing one registry would have them overwrite each other on every Trial name they had in common, silently, and precisely when the results were worth comparing. Comparing across runs is a read over each run's own store.
 
 !!! note "Registration writes through"
-    `project.collectors()` returns a registry bound to the project directory, so `project.collectors().set_collector(...)` on a throwaway registry still persists. A registry created without a path is memory-only and keeps nothing.
+    `e.collectors` is bound to the run's directory, so `set_collector(...)` persists as it is called. A registry created without a path (`Collectors()`) is memory-only and keeps nothing.
 
 ### How they persist
 
@@ -62,22 +62,21 @@ Connector(edges={'y': '{target}'})                 # exact per-key edge match
 ## Running with Collectors
 
 ```python
-e.exp(folds, project.trials, collectors=collectors)          # the whole registry
-e.exp(folds, project.trials,
-      collectors=collectors.resolve(['acc', 'shap']),        # a subset
-      collect_hist=collectors.hist)
+e.exp(folds, project.trials)                                 # every Collector on this run
+e.exp(folds, project.trials, collectors=['acc', 'shap'])     # a subset, by name
+e.exp(folds, project.trials, collectors=[])                  # collect nothing
 ```
 
-Passing the registry brings its history along automatically. A bare list has no project-wide place to record to, so name one with `collect_hist=` if you want the history.
+`collectors=` takes **names** out of the run's own registry, the same way `processor` and `adapter` are string refs. An instance is rejected: a Collector this registry does not know has no place in this run to write to, and would quietly deposit its results outside it. An unregistered name raises `KeyError` — silently skipping would be indistinguishable from "collected nothing".
 
-`resolve()` raises `KeyError` on an unregistered name — silently skipping would be indistinguishable from "collected nothing".
+Outcomes always go to that run's `collectors.hist`, whichever selection a call makes. The history belongs to the run, not to one call's choice.
 
 !!! note "Collectors only see Trials that actually run"
     Collection is a side effect of running a Trial. A fold already recorded `'built'` is skipped, so attaching a Collector *after* an experiment and re-running `exp()` collects nothing. Clear the fold history first — see [State Model](../concepts/state-model.md).
 
 ## CollectHist — what each Collector did
 
-`collectors.hist` holds one row per `(collector, experimenter, node, outer_idx, inner_idx)`.
+`collectors.hist` holds one row per `(collector, node, outer_idx, inner_idx)`. There is no experimenter key — the hist sits in one run's registry, so which run a row came from is answered by where the db is, the same way `node_hist` needs no `run_name`.
 
 ```python
 hist = collectors.hist

--- a/docs/guide/experimenter-trials.md
+++ b/docs/guide/experimenter-trials.md
@@ -89,11 +89,10 @@ folds = [(t, o, i)
          for o in range(e.get_n_splits())
          for i in range(e.get_n_splits_inner())]
 
-e.exp(folds, project.trials, collectors=project.collectors(),
-      n_jobs=2, gpu_id_list=[0], logger=logger)
+e.exp(folds, project.trials, n_jobs=2, gpu_id_list=[0], logger=logger)
 ```
 
-`trial_store` is required — it is where definitions are registered, where per-fold outcomes are recorded, and what decides which folds are skipped as already `'built'`.
+`trial_store` is required — it is where definitions are registered, where per-fold outcomes are recorded, and what decides which folds are skipped as already `'built'`. Every Collector registered on the run takes part unless `collectors=` narrows it by name — see [Collectors](collectors.md).
 
 !!! note "Redefining a Trial does not re-run it"
     A fold recorded as `'built'` is skipped silently. To force it:

--- a/docs/guide/project-pipeline.md
+++ b/docs/guide/project-pipeline.md
@@ -14,10 +14,11 @@ Everything else is reached from it:
 
 ```python
 project.pipeline_builder('main')       # a PipelineBuilder under pipelines/main/
-project.collectors()                   # the Collector registry
 project.trials                         # the project-wide TrialStore
 project.list_experimenters()           # names only
 ```
+
+Collectors are not among them — a registry belongs to the run that writes into it, as `e.collectors`. See [Collectors](collectors.md).
 
 A project can hold several pipelines, each keyed by name with its own version counter. `'pipeline'` is the default name.
 

--- a/examples/kaggle_s6e6/2. Second Phase.ipynb
+++ b/examples/kaggle_s6e6/2. Second Phase.ipynb
@@ -16,10 +16,10 @@
     "| 모델을 `set_node(grp='xgb')`로 선언 | 모델은 **`Trial`** — Pipeline 밖, `exp()`에 직접 전달 |\n",
     "| `p.build()` | `project.build_pipeline(p)` → 버전 부여 후 `e.set_pipeline(...)` |\n",
     "| `Experimenter(df, sp=, path=)` | `project.experimenter(name, df, ...)` / `project.load_experimenter(name, df)` |\n",
-    "| `e.set_collector(...)` / `e.get_collector(...)` | `project.collectors()` 레지스트리 (프로젝트 전역, 등록 즉시 영속화) |\n",
-    "| `e.exp(nodes='xgb1')` | `e.exp([(trial, outer, inner), ...], project.trials, collectors=...)` |\n",
+    "| `e.set_collector(...)` / `e.get_collector(...)` | `e.collectors` 레지스트리 (run 소유, 등록 즉시 영속화) |\n",
+    "| `e.exp(nodes='xgb1')` | `e.exp([(trial, outer, inner), ...], project.trials, collectors=[이름, ...])` |\n",
     "| `e.exp(finalize=True)` | `finalize` 개념 없음 |\n",
-    "| 수집 실패는 `collector.warnings` (메모리) | `collectors.hist` — **`CollectHist`** (fold 단위 이력) |\n",
+    "| 수집 실패는 `collector.warnings` (메모리) | `e.collectors.hist` — **`CollectHist`** (fold 단위 이력) |\n",
     "\n",
     "grp 상속이 모델에 적용되지 않으므로, 그 자리는 아래 `MODELS` dict + `trial()` 헬퍼가 대신한다."
    ]
@@ -257,9 +257,9 @@
    "source": [
     "## Project 구성\n",
     "\n",
-    "`Project`가 디렉토리 레이아웃과 프로젝트 전역인 것들(pipelines / collectors / TrialStore / cache)을 소유한다.\n",
-    "run 하나(Experimenter)에 관한 것 — splitter, 채택한 Pipeline, 노드 아티팩트 — 은 전부 `exp/phase2/` 안에 있어서\n",
-    "Project 없이도 열 수 있다."
+    "`Project`가 디렉토리 레이아웃과 프로젝트 전역인 것들(pipelines / TrialStore / cache)을 소유한다.\n",
+    "run 하나(Experimenter)에 관한 것 — splitter, 채택한 Pipeline, 노드 아티팩트, Collector — 은 전부\n",
+    "`exp/phase2/` 안에 있어서 Project 없이도 열 수 있다."
    ]
   },
   {
@@ -441,6 +441,45 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
+   "id": "experimenter",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def adopt():\n",
+    "    \"\"\"현재 builder 상태를 새 버전으로 빌드해 이 run에 채택시킨다.\n",
+    "    바뀐 노드만 stale 처리되어 아티팩트가 지워진다 (Pipeline.diff_from).\"\"\"\n",
+    "    e.set_pipeline(project.build_pipeline(p), 'phase2_pipeline')\n",
+    "    return e.pipeline_version\n",
+    "\n",
+    "\n",
+    "if 'phase2' in project.list_experimenters():\n",
+    "    e = project.load_experimenter('phase2', df_train)\n",
+    "else:\n",
+    "    e = project.experimenter(\n",
+    "        'phase2', df_train,\n",
+    "        sp=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.8),\n",
+    "        sp_v=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.9),\n",
+    "        splitter_params={'y': y},\n",
+    "        pipeline_name='phase2_pipeline',\n",
+    "        pipeline_version=project.build_pipeline(p).version,\n",
+    "    )\n",
+    "e.pipeline_version"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 14,
    "id": "collectors",
    "metadata": {},
@@ -482,7 +521,7 @@
     }
    ],
    "source": [
-    "collectors = project.collectors()\n",
+    "collectors = e.collectors\n",
     "\n",
     "\n",
     "def conn(**kw):\n",
@@ -514,50 +553,16 @@
    "id": "collectors-md",
    "metadata": {},
    "source": [
-    "`set_collector`는 **등록 즉시 영속화**된다(`collectors/collectors.db` + `__params/{name}.pkl`).\n",
-    "`Collectors.save()`는 없어졌고, 다음 세션에서는 `project.collectors()` 호출 자체가 복원이다.\n",
+    "`set_collector`는 **등록 즉시 영속화**된다(`exp/phase2/collectors/collectors.db` + `__params/{name}.pkl`).\n",
+    "`Collectors.save()`는 없고, 다음 세션에서는 `e.collectors` 접근 자체가 복원이다 —\n",
+    "레지스트리는 이 run의 것이라 `load_experimenter('phase2', ...)`가 Collector 정의·데이터·이력을 같이 되살린다.\n",
+    "\n",
+    "레지스트리가 run 소유인 이유: Collector가 쓰는 건 전부 노드 이름만으로 키잉된다\n",
+    "(`MetricCollector` PK `(node, idx, inner_idx, split)`, 파일 기반은 `{path}/{node}...`).\n",
+    "프로젝트 전역이었다면 이름이 겹치는 Trial마다 두 run이 서로의 결과를 덮어썼다.\n",
     "\n",
     "`Connector(role='head')`의 `role`도 없어졌다 — Collector는 애초에 Trial job에만 붙고 노드 job엔 안 붙어서\n",
     "걸러야 할 대상이 없었다."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "experimenter",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "17"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def adopt():\n",
-    "    \"\"\"현재 builder 상태를 새 버전으로 빌드해 이 run에 채택시킨다.\n",
-    "    바뀐 노드만 stale 처리되어 아티팩트가 지워진다 (Pipeline.diff_from).\"\"\"\n",
-    "    e.set_pipeline(project.build_pipeline(p), 'phase2_pipeline')\n",
-    "    return e.pipeline_version\n",
-    "\n",
-    "\n",
-    "if 'phase2' in project.list_experimenters():\n",
-    "    e = project.load_experimenter('phase2', df_train)\n",
-    "else:\n",
-    "    e = project.experimenter(\n",
-    "        'phase2', df_train,\n",
-    "        sp=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.8),\n",
-    "        sp_v=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.9),\n",
-    "        splitter_params={'y': y},\n",
-    "        pipeline_name='phase2_pipeline',\n",
-    "        pipeline_version=project.build_pipeline(p).version,\n",
-    "    )\n",
-    "e.pipeline_version"
    ]
   },
   {
@@ -574,9 +579,10 @@
     "\n",
     "\n",
     "def run(trials, **kw):\n",
-    "    \"\"\"collectors를 레지스트리째 넘기면 수집 이력도 collectors.hist에 자동으로 남는다.\"\"\"\n",
+    "    \"\"\"collectors 인자를 안 주면 이 run에 등록된 Collector 전부가 붙고,\n",
+    "    수집 이력도 e.collectors.hist에 남는다.\"\"\"\n",
     "    kw = {'n_jobs': 2, 'gpu_id_list': [0], 'logger': logger, **kw}\n",
-    "    e.exp(folds(trials), project.trials, collectors=collectors, **kw)"
+    "    e.exp(folds(trials), project.trials, **kw)"
    ]
   },
   {
@@ -1610,7 +1616,9 @@
    "source": [
     "## 수집 이력 — `CollectHist`\n",
     "\n",
-    "`collectors.hist`는 `(collector, experimenter, node, outer_idx, inner_idx)`마다 한 행을 남긴다.\n",
+    "`collectors.hist`는 `(collector, node, outer_idx, inner_idx)`마다 한 행을 남긴다.\n",
+    "`experimenter` 키는 없다 — hist가 이 run의 레지스트리 안에 있어서, 어느 run이냐는 db가 어디\n",
+    "있느냐로 답한다(`node_hist`에 `run_name`이 없는 것과 같다).\n",
     "\n",
     "- `status`: `'collected'` / `'empty'`(예외 없이 `None` 반환 — 보통 `output_var` 설정 실수) / `'error'`\n",
     "- `info`: 에러일 때 `{phase, type, message, traceback}`. `phase`는 `'output'`/`'ext'`/`'collect'`/`'push'`\n",
@@ -3434,11 +3442,14 @@
     "Connector에 `edges=y_edges`를 주는 건 매칭용만이 아니다. `get_dataset(include_target=True)`이\n",
     "`connector.edges['y']`를 읽어 target 컬럼을 붙이므로, 이게 없으면 피처만 나온다.\n",
     "\n",
-    "레지스트리를 통째로 넘기지 않고 `resolve(['stack_oof'])`로 하나만 넘기는 이유: `bAcc`는\n",
-    "`output_var='-1:'` + `balanced_accuracy_score` 조합이라 `method='predict'` 출력(라벨 한 열)을\n",
-    "전제한다. predict_proba 출력에 그대로 걸리면 확률을 라벨로 채점하려다 에러가 난다. 대신\n",
-    "`collect_hist=`를 명시해 수집 이력은 남긴다 — 맨 리스트는 기록될 프로젝트 전역 자리가 없어\n",
-    "기본적으로 아무것도 안 남긴다.\n",
+    "`stack_oof`는 `e_stk`의 레지스트리에 등록한다 — 레지스트리는 run 소유라 `e`의 것과 별개이고,\n",
+    "그래서 같은 이름의 Trial을 두 run이 돌려도 결과가 서로 덮이지 않는다.\n",
+    "\n",
+    "`collectors=['stack_oof']`로 이름을 하나만 주는 건 이 run에 다른 Collector가 붙는 걸 막기\n",
+    "위해서가 아니라(여긴 이것뿐이다) 의도를 명시하기 위해서다. 참고로 `bAcc`를 여기 등록했다면\n",
+    "걸렸을 것이다 — `output_var='-1:'` + `balanced_accuracy_score` 조합이라 `method='predict'`\n",
+    "출력(라벨 한 열)을 전제하는데, predict_proba 출력에 걸리면 확률을 라벨로 채점하려다 에러가 난다.\n",
+    "수집 이력은 선택과 무관하게 언제나 그 run의 `collectors.hist`에 남는다.\n",
     "\n",
     "한 가지 주의: `StackingCollector`는 outer fold 결과를 메모리(`_outer_buf`)에 모았다가 5개가 다\n",
     "차면 그때서야 `{node}.pkl`로 쓴다. 즉 **5 fold가 한 번의 `exp()` 호출에서 다 돌아야** 저장된다 —\n",
@@ -3462,7 +3473,7 @@
     }
    ],
    "source": [
-    "collectors.set_collector(\n",
+    "e_stk.collectors.set_collector(\n",
     "    'stack_oof', 'mllabs.collector.StackingCollector',\n",
     "    conn(node_query=[t.name for t in stk_trials], edges=y_edges),\n",
     "    params={'output_var': '1:', 'method': 'mean'}, exist='replace')\n",
@@ -3473,8 +3484,7 @@
     "\n",
     "with e_stk.os_log():\n",
     "    e_stk.exp(folds_stk, project.trials,\n",
-    "              collectors=collectors.resolve(['stack_oof']),\n",
-    "              collect_hist=collectors.hist,\n",
+    "              collectors=['stack_oof'],\n",
     "              n_jobs=2, gpu_id_list=[0], logger=logger)\n"
    ]
   },
@@ -3525,7 +3535,7 @@
     }
    ],
    "source": [
-    "ds = collectors.get_collector('stack_oof').get_dataset(e_stk)\n",
+    "ds = e_stk.collectors.get_collector('stack_oof').get_dataset(e_stk)\n",
     "print(ds.shape, ds.columns)\n",
     "ds.head()\n"
    ]

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -13,6 +13,7 @@ from ._store import NodeStore
 from ._experimenter_store import ExperimenterStore, DB_NAME as _EXP_DB
 from ._describer import desc_spec
 from ._logger import resolve_logger
+from .collector import Collectors
 
 
 def _start_native_redirect(log_path):
@@ -67,19 +68,6 @@ def _stop_native_redirect(state):
 from ._run_common import resolve_common_status, require_built_pipeline
 
 
-def _resolve_collectors(collectors):
-    """``(instances, CollectHist | None)`` from a registry, a list, or None.
-
-    A registry brings its own history — it owns the project-global path both
-    the Collectors and their history live under. A bare list has no such
-    place, so its outcomes go unrecorded unless ``exp(collect_hist=...)``
-    names one.
-    """
-    if collectors is None:
-        return [], None
-    if hasattr(collectors, 'resolve'):
-        return collectors.resolve(None), getattr(collectors, 'hist', None)
-    return list(collectors), None
 
 
 class OuterFold:
@@ -160,6 +148,14 @@ class Experimenter():
 
     Attributes:
         cache (DataCache): Shared LRU cache, or ``None``.
+        collectors (Collectors): This run's own Collector registry, over
+            ``{path}/collectors`` — definitions, collected data and
+            :class:`~mllabs.CollectHist` alike. It belongs to the run rather
+            than the project because what a Collector writes is keyed by node
+            name and nothing else, so two runs sharing a registry would
+            overwrite each other on any Trial name they have in common.
+            Constructing the Experimenter restores it, so reopening a run
+            brings back its Collectors with it.
         pipeline (Pipeline): The adopted Pipeline, kept as this run's own
             ``pipeline.pkl``. The ``(pipeline_name, pipeline_version)``
             pointer is recorded too, but only as provenance — it names the
@@ -213,6 +209,7 @@ class Experimenter():
 
         self.cache = cache
         self.node_store = NodeStore(self.path / '__folds')
+        self.collectors = Collectors(self.path / 'collectors')
 
         self.outer_folds = [
             OuterFold(
@@ -432,8 +429,7 @@ class Experimenter():
         Removes node objects and clears cache entries for the affected nodes.
 
         Pipeline nodes only — the artifacts a build produced. A Trial has
-        none to remove, and rerunning one is
-        ``TrialStore.remove_hist(trial_name=, experimenter=)`` instead.
+        none to remove; :meth:`remove_trial_result` is its counterpart.
 
         Args:
             nodes (list[str]): Node names to reset.
@@ -444,6 +440,31 @@ class Experimenter():
 
         if self.cache is not None:
             self.cache.clear_nodes(nodes)
+
+    def remove_trial_result(self, name, trial_store=None):
+        """Drop what this run has of Trial *name*.
+
+        A Trial leaves no artifact, so its result is whatever its Collectors
+        kept — held in this run's own registry, which
+        :meth:`Collectors.remove_results` clears along with the matching
+        ``CollectHist`` rows.
+
+        Pass *trial_store* to drop this run's ``experiment_hist`` rows as well.
+        That is what makes the next ``exp()`` run the Trial again: folds are
+        skipped on the strength of a recorded ``'built'`` status and nothing
+        else, so the history is the only thing holding one back. Only this
+        Experimenter's rows go — another run's record of the same Trial is its
+        own. To remove the Trial from the project entirely, definition
+        included, use ``Project.remove_trial``.
+
+        Args:
+            name (str): Trial name.
+            trial_store (TrialStore, optional): Where this run's Trial history
+                lives. Omitted, the history stays and the folds stay skipped.
+        """
+        self.collectors.remove_results(name)
+        if trial_store is not None:
+            trial_store.remove_hist(trial_name=name, experimenter=self.name)
 
     def show_error_nodes(self, nodes=None, traceback=False, trial_store=None):
         """Print nodes in ``error`` state.
@@ -569,7 +590,7 @@ class Experimenter():
                     jobs.append(Job(name, spec, outer_idx, inner_idx, flow, need_gpu=need_gpu))
         return jobs
 
-    def exp(self, trials, trial_store, collectors=None, collect_hist=None,
+    def exp(self, trials, trial_store, collectors=None,
             n_jobs=1, gpu_id_list=None, logger=None):
         """Run *trials* against the Stage graph and invoke matching Collectors.
 
@@ -581,12 +602,11 @@ class Experimenter():
             trial_store (TrialStore): Where Trial definitions are registered
                 and fold outcomes are recorded — also what decides which
                 folds are skipped as already built (see :meth:`_make_jobs`).
-            collectors: :class:`~mllabs.Collectors` registry, a list of
-                Collector instances, or ``None`` to collect nothing.
-            collect_hist (CollectHist, optional): Where each Collector's
-                per-fold outcome is recorded. Defaults to the registry's own
-                ``hist`` when *collectors* is a registry; a bare list has none
-                unless one is named here.
+            collectors (list[str], optional): Names to collect with, out of
+                this run's own :attr:`collectors` registry. ``None`` (default)
+                uses every Collector registered there; ``[]`` collects nothing.
+                Outcomes go to that registry's ``hist`` — the history belongs
+                to the run, not to the selection made for one call.
             n_jobs (int): Number of parallel workers. Default 1 (sequential).
             gpu_id_list (list, optional): GPU IDs to use for GPU-enabled trials.
             logger: Logger instance. Default: shared ``DefaultLogger.get_instance()``.
@@ -602,8 +622,7 @@ class Experimenter():
         pipeline = self._require_pipeline()
         pipeline.check_data_compatibility(self.data)
 
-        collectors, registry_hist = _resolve_collectors(collectors)
-        collect_hist = collect_hist if collect_hist is not None else registry_hist
+        collectors = self._resolve_collectors(collectors)
         jobs = self._make_jobs(trials, trial_store)
         if not jobs:
             logger.info("No trials to run")
@@ -618,7 +637,7 @@ class Experimenter():
         tracker = TrialHistTracker(
             LoggerExecuteTracker(len(jobs), n_jobs, logger),
             trial_store, self.name, self.pipeline_version,
-            collect_hist=collect_hist,
+            collect_hist=self.collectors.hist,
         )
 
         try:
@@ -640,6 +659,27 @@ class Experimenter():
                         f"{len(errors)} error(s): {error_names}")
         else:
             logger.info(f"Exp complete: {len(jobs)} job(s)")
+
+    def _resolve_collectors(self, names):
+        """Collector instances for *names*, out of this run's own registry.
+
+        Names rather than instances, for the same reason ``processor`` and
+        ``adapter`` are string refs: a Collector this registry does not know
+        has no place in this run to write to, and would quietly deposit its
+        results outside the run — which is exactly what a per-run registry
+        exists to prevent. ``Collectors.resolve`` raises on an unknown name,
+        so a typo is not a silent "collected nothing" either.
+        """
+        if names is not None:
+            bad = [n for n in names if not isinstance(n, str)]
+            if bad:
+                raise TypeError(
+                    f"exp(collectors=): expected Collector names registered on "
+                    f"this Experimenter, got {[type(b).__name__ for b in bad]}. "
+                    f"Register with e.collectors.set_collector(name, ...) and "
+                    f"pass the name."
+                )
+        return self.collectors.resolve(names)
 
     def _make_jobs(self, trials, trial_store):
         """Expand ``(Trial, outer, inner)`` entries into runnable Jobs.

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -27,17 +27,16 @@ class Project:
           trials.db           TrialStore (definitions + run history)
           pipelines/{name}/   PipelineBuilder db (incl. its own version counter),
                                and v{n}.pkl per built version
-          collectors/         Collectors registry
-          exp/{name}/         Experimenter — its own store, Pipeline copy and
-                               NodeStore, all self-contained
+          exp/{name}/         Experimenter — its own store, Pipeline copy,
+                               NodeStore and Collectors, all self-contained
           trainers/{name}/    Trainer (same, own NodeStore)
           inferencers/{name}/ saved Inferencers
 
     Project holds only what is genuinely project-wide: the pipelines, the
-    Collectors, the TrialStore, the shared cache, and the index of run names.
-    Everything about an individual run — its splitters, its data key, the
-    Pipeline it adopted, its node artifacts and history — belongs to that
-    run's own directory, so it can be reopened without a Project at all.
+    TrialStore, the shared cache, and the index of run names. Everything about
+    an individual run — its splitters, its data key, the Pipeline it adopted,
+    its node artifacts and history, its Collectors — belongs to that run's own
+    directory, so it can be reopened without a Project at all.
 
     Args:
         path (str | Path): Project root. Created if missing.
@@ -69,11 +68,6 @@ class Project:
     def inferencer_path(self, name):
         return self._sub('inferencers', name)
 
-    def collectors_path(self):
-        p = self.path / 'collectors'
-        p.mkdir(parents=True, exist_ok=True)
-        return p
-
     def _sub(self, kind, name):
         p = self.path / kind / name
         p.mkdir(parents=True, exist_ok=True)
@@ -87,10 +81,6 @@ class Project:
         """A :class:`~mllabs.PipelineBuilder` stored under this project."""
         from ._pipeline import PipelineBuilder
         return PipelineBuilder(path=self.pipeline_path(name), name=name)
-
-    def collectors(self):
-        """The project's :class:`~mllabs.Collectors` registry, restored if saved."""
-        return Collectors(self.collectors_path())
 
     def experimenter(self, name, data, pipeline_name='pipeline', pipeline_version=None, **kwargs):
         """Create an Experimenter named *name* under ``{project}/exp/{name}``.
@@ -167,40 +157,43 @@ class Project:
         """Names of every Trainer created through this project."""
         return self.store.list_trainers()
 
-    def remove_trial(self, name, collectors=None):
+    def remove_trial(self, name, experimenters=None):
         """Drop *name* from the project — definition, history and collected data.
 
         A Trial leaves no artifact, so everything it produced is spread across
         stores that deliberately don't know about each other: its definition
-        and per-fold history in ``TrialStore``, the per-fold collect outcomes
-        in ``CollectHist``, and the collected data itself inside each
-        Collector. Project is the only thing that sees all three, so removing
-        a Trial belongs here rather than in any one of them.
+        and per-fold history in the project's ``TrialStore``, and — inside
+        every Experimenter that ran it — the collected data and the
+        ``CollectHist`` rows describing it. Project is the only thing that
+        sees all of them, so removing a Trial belongs here.
 
-        Every Experimenter is covered — history and collect outcomes are
-        deleted for all of them, and a Collector's data is keyed by node name
-        with no experimenter in it at all. There is no per-Experimenter
-        removal; to make one Experimenter run a Trial again, delete just its
-        history with ``project.trials.remove_hist(trial_name=, experimenter=)``.
+        The definition and the whole of its history go in one statement each;
+        the per-run half is a pass over :meth:`list_experimenters`, delegating
+        to :meth:`Experimenter.remove_trial_result`. Opening a run's registry
+        costs only its two db files — no Experimenter is constructed and no
+        dataset is needed — but a registry opened here is not the one you may
+        already be holding, and some Collectors answer from an in-memory cache
+        (``ModelAttrCollector``/``SHAPCollector``). Pass those runs as
+        *experimenters* so their own registries are the ones cleaned.
 
         Args:
             name (str): Trial name. Removing one that was never registered is
                 a no-op, not an error.
-            collectors (Collectors, optional): The registry to clean. Pass the
-                one you are holding: :meth:`collectors` builds a fresh
-                registry on every call, and a Collector may answer from an
-                in-memory cache (``ModelAttrCollector``/``SHAPCollector``
-                keep one), so cleaning a fresh instance leaves yours still
-                serving what was just deleted. Defaults to a fresh registry,
-                which is enough when nothing is holding one.
+            experimenters (list[Experimenter], optional): Open Experimenters to
+                clean through, matched by name. Any run not listed is handled
+                by opening its registry from disk.
         """
         self.trials.remove(name)
         self.trials.remove_hist(trial_name=name)
-        collectors = self.collectors() if collectors is None else collectors
-        if collectors.hist is not None:
-            collectors.hist.remove_hist(node_name=name)
-        for collector in collectors:
-            collector.reset_nodes([name])
+        held = {e.name: e for e in (experimenters or ())}
+        for exp_name in self.list_experimenters():
+            exp = held.get(exp_name)
+            if exp is not None:
+                exp.remove_trial_result(name)
+                continue
+            path = self.exp_path(exp_name) / 'collectors'
+            if path.exists():
+                Collectors(path).remove_results(name)
 
     # ------------------------------------------------------------------
     # pipeline versions

--- a/mllabs/_tracker.py
+++ b/mllabs/_tracker.py
@@ -145,10 +145,10 @@ class TrialHistTracker(ExecuteTracker):
     already built, and duplicates work the tracker has done anyway.
 
     Collect outcomes ride along here rather than in a third wrapper: they are
-    keyed by the same ``experimenter`` and stamped with the same
-    ``pipeline_version`` this class already holds, and they arrive on the same
-    parent-process event stream for the same reason (``_run_collectors`` runs
-    in the worker, so only the parent sees every fold's outcome).
+    stamped with the same ``pipeline_version`` this class already holds, and
+    they arrive on the same parent-process event stream for the same reason
+    (``_run_collectors`` runs in the worker, so only the parent sees every
+    fold's outcome).
 
     Args:
         tracker (ExecuteTracker): The display/logging tracker to delegate to.
@@ -156,8 +156,8 @@ class TrialHistTracker(ExecuteTracker):
         experimenter (str): Experimenter name — half of the history key.
         pipeline_version (int): The Experimenter's ``pipeline_version`` for the run.
         collect_hist (CollectHist, optional): Where Collector outcomes are
-            written. ``None`` records nothing — a Collector list passed without
-            a registry has nowhere project-global to write.
+            written — the running Experimenter's own. ``None`` records nothing,
+            which is what a registry with no path (memory-only) leaves.
     """
 
     def __init__(self, tracker, store, experimenter, pipeline_version, collect_hist=None):
@@ -202,8 +202,7 @@ class TrialHistTracker(ExecuteTracker):
         if self._collect_hist is not None:
             for outcome in outcomes:
                 self._collect_hist.record(
-                    outcome['collector'], self._experimenter, node_name,
-                    outer_idx, inner_idx,
+                    outcome['collector'], node_name, outer_idx, inner_idx,
                     pipeline_version=self._pipeline_version,
                     status=outcome['status'], elapsed=outcome.get('elapsed'),
                     info=outcome.get('info'),

--- a/mllabs/collector/_collect_hist.py
+++ b/mllabs/collector/_collect_hist.py
@@ -6,7 +6,6 @@ from pathlib import Path
 _SCHEMA_SQL = """
     CREATE TABLE IF NOT EXISTS collect_hist (
         collector_name   TEXT NOT NULL,
-        experimenter     TEXT NOT NULL,
         node_name        TEXT NOT NULL,
         outer_idx        INTEGER NOT NULL,
         inner_idx        INTEGER NOT NULL,
@@ -15,13 +14,11 @@ _SCHEMA_SQL = """
         collect_date     TEXT,
         elapsed          REAL,
         info             TEXT,
-        PRIMARY KEY (collector_name, experimenter, node_name, outer_idx, inner_idx)
+        PRIMARY KEY (collector_name, node_name, outer_idx, inner_idx)
     );
-    CREATE INDEX IF NOT EXISTS idx_collect_hist_experimenter
-        ON collect_hist (experimenter);
 """
 
-_KEY_COLUMNS = ('collector_name', 'experimenter', 'node_name', 'outer_idx', 'inner_idx')
+_KEY_COLUMNS = ('collector_name', 'node_name', 'outer_idx', 'inner_idx')
 
 
 def utc_now():
@@ -29,22 +26,36 @@ def utc_now():
 
 
 class CollectHist:
+    """Per-fold outcome of every collect call, for one run's registry.
+
+    Lives beside the :class:`~mllabs.Collectors` registry that owns it, which
+    is one Experimenter's — so a row is identified by
+    ``(collector_name, node_name, outer_idx, inner_idx)`` alone and nothing
+    here needs an ``experimenter`` column, the same way ``node_hist`` needs no
+    ``run_name``.
+
+    It is a log, not a gate: nothing is skipped on the strength of a row here.
+    What it does make visible is a fold recorded 'built' before a Collector
+    was attached — that fold is skipped without dispatch, so it collects
+    nothing, and the absence of a row is the only trace of it.
+    """
+
     def __init__(self, path, name='collect_hist'):
         self.db_path = Path(path) / f'{name}.db'
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(str(self.db_path)) as conn:
             conn.executescript(_SCHEMA_SQL)
 
-    def record(self, collector_name, experimenter, node_name, outer_idx, inner_idx,
+    def record(self, collector_name, node_name, outer_idx, inner_idx,
                pipeline_version=None, status=None, collect_date=None,
                elapsed=None, info=None):
         with sqlite3.connect(str(self.db_path)) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO collect_hist "
-                "(collector_name, experimenter, node_name, outer_idx, inner_idx, "
+                "(collector_name, node_name, outer_idx, inner_idx, "
                 "pipeline_version, status, collect_date, elapsed, info) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (collector_name, experimenter, node_name, outer_idx, inner_idx,
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (collector_name, node_name, outer_idx, inner_idx,
                  pipeline_version, status, collect_date or utc_now(), elapsed,
                  json.dumps(info) if info is not None else None),
             )
@@ -53,11 +64,10 @@ class CollectHist:
         for row in rows:
             self.record(**row)
 
-    def get_hist(self, collector_name=None, experimenter=None, node_name=None,
+    def get_hist(self, collector_name=None, node_name=None,
                  status=None, pipeline_version=None):
         where, params = [], []
         for column, value in (('collector_name', collector_name),
-                              ('experimenter', experimenter),
                               ('node_name', node_name),
                               ('status', status),
                               ('pipeline_version', pipeline_version)):
@@ -67,7 +77,7 @@ class CollectHist:
         sql = "SELECT * FROM collect_hist"
         if where:
             sql += " WHERE " + " AND ".join(where)
-        sql += " ORDER BY collector_name, experimenter, node_name, outer_idx, inner_idx"
+        sql += " ORDER BY collector_name, node_name, outer_idx, inner_idx"
         with sqlite3.connect(str(self.db_path)) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(sql, params).fetchall()
@@ -78,28 +88,24 @@ class CollectHist:
             result.append(row)
         return result
 
-    def get_status(self, collector_name, experimenter, node_name=None):
+    def get_status(self, collector_name, node_name=None):
         return {
             (r['node_name'], r['outer_idx'], r['inner_idx']): r['status']
-            for r in self.get_hist(collector_name=collector_name,
-                                   experimenter=experimenter, node_name=node_name)
+            for r in self.get_hist(collector_name=collector_name, node_name=node_name)
         }
 
-    def get_info(self, collector_name, experimenter, node_name=None):
+    def get_info(self, collector_name, node_name=None):
         return {
             (r['node_name'], r['outer_idx'], r['inner_idx']): r['info']
-            for r in self.get_hist(collector_name=collector_name,
-                                   experimenter=experimenter, node_name=node_name)
+            for r in self.get_hist(collector_name=collector_name, node_name=node_name)
         }
 
-    def get_errors(self, experimenter=None, collector_name=None):
-        return self.get_hist(collector_name=collector_name, experimenter=experimenter,
-                             status='error')
+    def get_errors(self, collector_name=None):
+        return self.get_hist(collector_name=collector_name, status='error')
 
-    def remove_hist(self, collector_name=None, experimenter=None, node_name=None):
+    def remove_hist(self, collector_name=None, node_name=None):
         where, params = [], []
         for column, value in (('collector_name', collector_name),
-                              ('experimenter', experimenter),
                               ('node_name', node_name)):
             if value is not None:
                 where.append(f"{column} = ?")

--- a/mllabs/collector/_registry.py
+++ b/mllabs/collector/_registry.py
@@ -7,9 +7,14 @@ from ._store import CollectorEntity, CollectorStore, build_collector
 class Collectors:
     """Registry that owns Collector instances and their storage.
 
-    Collector instances live here rather than being rebuilt per run, so several
-    runs can share one registry and their metrics land in the same place, where
-    they stay comparable.
+    One registry belongs to one run — an Experimenter builds its own over
+    ``{exp path}/collectors`` and hands it out as ``Experimenter.collectors``.
+    Everything a Collector writes is keyed by node name and nothing more
+    (``MetricCollector``'s PK is ``(node, idx, inner_idx, split)``; the
+    file-based ones use ``{path}/{node}...``), so the path is what keeps two
+    runs apart. Sharing one registry between runs would have them overwrite
+    each other's results for every Trial whose name they have in common —
+    silently, and precisely when the results were worth comparing.
 
     Registration persists immediately when the registry has a path: a
     :class:`CollectorEntity` row goes into ``{path}/collectors.db`` and the
@@ -18,10 +23,9 @@ class Collectors:
     those two halves — the instance itself is never stored.
 
     ``hist`` is the :class:`~mllabs.CollectHist` over the same path — one row
-    per (collector, experimenter, node, fold) describing what that collect
-    call did. It sits with the registry, not with a run, because a registry is
-    project-global and its history has to stay comparable across runs for the
-    same reason its metrics do.
+    per (collector, node, fold) describing what that collect call did. It has
+    no ``experimenter`` column because the registry holding it already is one
+    run's.
 
     Args:
         path (str | Path, optional): Base directory. A Collector registered
@@ -92,6 +96,22 @@ class Collectors:
 
     def names(self):
         return list(self.collectors)
+
+    def remove_results(self, node_name):
+        """Drop everything collected for *node_name* — data and history both.
+
+        The registry is the only thing that sees both halves: ``hist`` records
+        what each collect call did, while the result itself is inside whichever
+        Collector produced it. Removing one without the other leaves a history
+        row pointing at data that is gone, or data no history accounts for.
+
+        Definitions are untouched — this removes what a node produced, not the
+        Collectors that were watching for it.
+        """
+        if self.hist is not None:
+            self.hist.remove_hist(node_name=node_name)
+        for collector in self.collectors.values():
+            collector.reset_nodes([node_name])
 
     def __contains__(self, name):
         return name in self.collectors

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -55,8 +55,12 @@ def _all_folds(trial, e):
     return [(trial, o, i) for o in range(e.get_n_splits()) for i in range(e.get_n_splits_inner())]
 
 
-def _run(built, *trials, collectors=None, collect_hist=None, n_jobs=1):
-    """Runs every fold of the given trials (default: the fixture's own) with *collectors*.
+def _run(built, *trials, collectors=None, n_jobs=1):
+    """Runs every fold of the given trials (default: the fixture's own).
+
+    *collectors* is a list of names out of the run's own registry, or None for
+    every one registered on it — which is what most tests want, since each
+    registers exactly the Collector it is testing into a fresh fixture.
 
     Collection happens during exp() dispatch only — a fold already recorded
     'built' in TrialStore.experiment_hist is skipped without dispatch, so a
@@ -66,8 +70,7 @@ def _run(built, *trials, collectors=None, collect_hist=None, n_jobs=1):
     """
     trials = trials or (built.trial,)
     folds = [f for t in trials for f in _all_folds(t, built.e)]
-    built.e.exp(folds, built.project.trials, collectors=collectors,
-                collect_hist=collect_hist, n_jobs=n_jobs)
+    built.e.exp(folds, built.project.trials, collectors=collectors, n_jobs=n_jobs)
 
 
 @pytest.fixture
@@ -166,15 +169,15 @@ class TestConnector:
 
 class TestMetricCollector:
     def test_collect_basic(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         assert mc.has_node('dt')
 
     def test_get_metric(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         result = mc.get_metric('dt')
         assert isinstance(result, pd.Series)
         assert result.name == 'dt'
@@ -182,102 +185,102 @@ class TestMetricCollector:
         assert all(0 <= v <= 1 for v in result.values)
 
     def test_get_metrics(self, multi_head_exp):
-        mc = multi_head_exp.project.collectors().set_collector(
+        mc = multi_head_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc.name])
         result = mc.get_metrics()
         assert isinstance(result, pd.DataFrame)
         assert 'dt1' in result.index.get_level_values(0)
         assert 'dt2' in result.index.get_level_values(0)
 
     def test_get_metrics_with_node_filter(self, multi_head_exp):
-        mc = multi_head_exp.project.collectors().set_collector(
+        mc = multi_head_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc.name])
         result = mc.get_metrics(nodes=['dt1'])
         assert 'dt1' in result.index.get_level_values(0)
         assert 'dt2' not in result.index.get_level_values(0)
 
     def test_get_metrics_regex(self, multi_head_exp):
-        mc = multi_head_exp.project.collectors().set_collector(
+        mc = multi_head_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc.name])
         result = mc.get_metrics(nodes='dt1')
         assert len(result) > 0
 
     def test_get_metrics_agg(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         mean, std = mc.get_metrics_agg()
         assert isinstance(mean, pd.DataFrame)
         assert std is None
 
     def test_get_metrics_agg_with_std(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         mean, std = mc.get_metrics_agg(include_std=True)
         assert isinstance(mean, pd.DataFrame)
         assert isinstance(std, pd.DataFrame)
 
     def test_get_metrics_agg_inner_only(self, built_exp_inner):
-        mc = built_exp_inner.project.collectors().set_collector(
+        mc = built_exp_inner.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp_inner, collectors=[mc])
+        _run(built_exp_inner, collectors=[mc.name])
         mean, std = mc.get_metrics_agg(inner_fold=True, outer_fold=False)
         assert isinstance(mean, pd.DataFrame)
 
     def test_get_metrics_agg_no_fold(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         result = mc.get_metrics_agg(inner_fold=False, outer_fold=False)
         assert isinstance(result, pd.DataFrame)
 
     def test_get_metrics_agg_invalid(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         with pytest.raises(ValueError):
             mc.get_metrics_agg(inner_fold=False, outer_fold=True)
 
     def test_include_train(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc_train', MetricCollector, Connector(),
             params={'output_var': None, 'metric_func': accuracy_metric, 'include_train': True})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         result = mc.get_metric('dt')
         assert 'train' in result.index.get_level_values(-1)
 
     def test_inner_split_metrics(self, built_exp_inner):
-        mc = built_exp_inner.project.collectors().set_collector(
+        mc = built_exp_inner.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp_inner, collectors=[mc])
+        _run(built_exp_inner, collectors=[mc.name])
         result = mc.get_metric('dt')
         assert len(result) > 2
 
     def test_connector_filter(self, multi_head_exp):
-        mc = multi_head_exp.project.collectors().set_collector(
+        mc = multi_head_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(node_query=['dt1']),
             params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mc.name])
         assert mc.has_node('dt1')
         assert not mc.has_node('dt2')
 
     def test_reset_nodes(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         assert mc.has_node('dt')
         mc.reset_nodes(['dt'])
         assert not mc.has_node('dt')
 
     def test_save_load(self, built_exp):
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
-        loaded = built_exp.project.collectors().get_collector('acc')
+        _run(built_exp, collectors=[mc.name])
+        loaded = built_exp.e.collectors.get_collector('acc')
         assert loaded.has_node('dt')
         result_orig = mc.get_metric('dt')
         result_loaded = loaded.get_metric('dt')
@@ -291,16 +294,16 @@ class TestMetricCollector:
         touches NodeStore/cache) is not enough to force a rerun by itself —
         the hist row also has to go; ``_make_jobs`` then resets the NodeStore
         entry itself once it decides a job is needed."""
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         mc = collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         assert mc.has_node('dt')
 
         mc2 = collectors.set_collector(
             'acc2', MetricCollector, Connector(), params={'output_var': None, 'metric_func': dummy_metric})
         built_exp.project.trials.remove_hist(trial_name='dt', experimenter=built_exp.e.name)
-        _run(built_exp, collectors=[mc2])
+        _run(built_exp, collectors=[mc2.name])
         assert mc2.has_node('dt')
         result = mc2.get_metric('dt')
         assert all(v == 0.5 for v in result.values)
@@ -339,67 +342,67 @@ class TestProbToLabel:
 
 class TestStackingCollector:
     def test_collect_basic(self, built_exp):
-        sc = built_exp.project.collectors().set_collector('stk', StackingCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[sc])
+        sc = built_exp.e.collectors.set_collector('stk', StackingCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[sc.name])
         assert sc.has_node('dt')
 
     def test_get_dataset(self, built_exp):
-        sc = built_exp.project.collectors().set_collector(
+        sc = built_exp.e.collectors.set_collector(
             'stk', StackingCollector, Connector(edges={'y': '{target}'}), params={'output_var': None})
-        _run(built_exp, collectors=[sc])
+        _run(built_exp, collectors=[sc.name])
         ds = sc.get_dataset(built_exp.e)
         assert isinstance(ds, pd.DataFrame)
         assert len(ds) == int(len(built_exp.e.data.data) * 0.2) * 2  # ShuffleSplit, n_splits = 2, test_size = 0.2
         assert 'target' in ds.columns
 
     def test_get_dataset_no_target(self, built_exp):
-        sc = built_exp.project.collectors().set_collector('stk', StackingCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[sc])
+        sc = built_exp.e.collectors.set_collector('stk', StackingCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[sc.name])
         ds = sc.get_dataset(built_exp.e, include_target=False)
         assert isinstance(ds, pd.DataFrame)
         assert 'target' not in ds.columns
 
     def test_get_dataset_multi_nodes(self, multi_head_exp):
-        sc = multi_head_exp.project.collectors().set_collector(
+        sc = multi_head_exp.e.collectors.set_collector(
             'stk', StackingCollector, Connector(edges={'y': '{target}'}), params={'output_var': None})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[sc])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[sc.name])
         ds = sc.get_dataset(multi_head_exp.e)
         assert ds.shape[1] > 2
 
     def test_get_dataset_node_filter(self, multi_head_exp):
-        sc = multi_head_exp.project.collectors().set_collector(
+        sc = multi_head_exp.e.collectors.set_collector(
             'stk', StackingCollector, Connector(edges={'y': '{target}'}), params={'output_var': None})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[sc])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[sc.name])
         ds = sc.get_dataset(multi_head_exp.e, nodes=['dt1'])
         assert isinstance(ds, pd.DataFrame)
 
     def test_method_mean(self, built_exp_inner):
-        sc = built_exp_inner.project.collectors().set_collector(
+        sc = built_exp_inner.e.collectors.set_collector(
             'stk_mean', StackingCollector, Connector(edges={'y': '{target}'}), params={'output_var': None, 'method': 'mean'})
-        _run(built_exp_inner, collectors=[sc])
+        _run(built_exp_inner, collectors=[sc.name])
         assert sc.has_node('dt')
 
     def test_reset_nodes(self, built_exp):
-        sc = built_exp.project.collectors().set_collector('stk', StackingCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[sc])
+        sc = built_exp.e.collectors.set_collector('stk', StackingCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[sc.name])
         assert sc.has_node('dt')
         sc.reset_nodes(['dt'])
         assert not sc.has_node('dt')
 
     def test_save_load(self, built_exp):
-        sc = built_exp.project.collectors().set_collector(
+        sc = built_exp.e.collectors.set_collector(
             'stk', StackingCollector, Connector(edges={'y': '{target}'}), params={'output_var': None})
-        _run(built_exp, collectors=[sc])
-        loaded = built_exp.project.collectors().get_collector('stk')
+        _run(built_exp, collectors=[sc.name])
+        loaded = built_exp.e.collectors.get_collector('stk')
         assert loaded.has_node('dt')
         ds_orig = sc.get_dataset(built_exp.e)
         ds_loaded = loaded.get_dataset(built_exp.e)
         pd.testing.assert_frame_equal(ds_orig, ds_loaded)
 
     def test_index_preserved(self, built_exp):
-        sc = built_exp.project.collectors().set_collector(
+        sc = built_exp.e.collectors.set_collector(
             'stk', StackingCollector, Connector(edges={'y': '{target}'}), params={'output_var': None})
-        _run(built_exp, collectors=[sc])
+        _run(built_exp, collectors=[sc.name])
         ds = sc.get_dataset(built_exp.e)
         all_valid_idx = np.concatenate([
             built_exp.e.outer_folds[i].test_idx
@@ -412,93 +415,93 @@ class TestStackingCollector:
 class TestModelAttrCollector:
     def test_collect_basic(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         assert mac.has_node('dt')
 
     def test_get_attr(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         result = mac.get_attr('dt')
         assert isinstance(result, list)
         assert len(result) == 2
 
     def test_get_attr_idx(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         result = mac.get_attr('dt', idx=0)
         assert isinstance(result, list)
 
     def test_get_attrs(self, multi_head_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = multi_head_exp.project.collectors().set_collector(
+        mac = multi_head_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mac])
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[mac.name])
         result = mac.get_attrs()
         assert 'dt1' in result
         assert 'dt2' in result
 
     def test_get_attrs_agg(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         result = mac.get_attrs_agg('dt')
         assert isinstance(result, pd.Series)
 
     def test_get_attrs_agg_inner_only(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         result = mac.get_attrs_agg('dt', agg_inner=True, agg_outer=False)
         assert isinstance(result, pd.DataFrame)
 
     def test_get_attrs_agg_invalid(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         with pytest.raises(ValueError):
             mac.get_attrs_agg('dt', agg_inner=False, agg_outer=True)
 
     def test_not_mergeable(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'tree', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'tree', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         with pytest.raises(ValueError, match='not mergeable'):
             mac.get_attrs_agg('dt')
 
     def test_reset_nodes(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
+        _run(built_exp, collectors=[mac.name])
         mac.reset_nodes(['dt'])
         assert not mac.has_node('dt')
 
     def test_save_load(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        mac = built_exp.project.collectors().set_collector(
+        mac = built_exp.e.collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mac])
-        loaded = built_exp.project.collectors().get_collector('fi')
+        _run(built_exp, collectors=[mac.name])
+        loaded = built_exp.e.collectors.get_collector('fi')
         assert loaded.has_node('dt')
 
     def test_auto_adapter(self):
@@ -514,29 +517,29 @@ class TestModelAttrCollector:
 
 class TestOutputCollector:
     def test_collect_basic(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         assert oc.has_node('dt')
 
     def test_get_output(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         result = oc.get_output('dt', 0, 0)
         assert 'output_test' in result
         assert 'output_train' in result
         assert 'columns' in result
 
     def test_get_output_structure(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         result = oc.get_output('dt', 0, 0)
         assert isinstance(result['output_test'], np.ndarray)
         assert result['output_train'] is None or isinstance(result['output_train'], np.ndarray)
         assert result['output_valid'] is None or isinstance(result['output_valid'], np.ndarray)
 
     def test_get_outputs(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         results = oc.get_outputs('dt')
         assert isinstance(results, dict)
         assert len(results) == built_exp.e.get_n_splits() * built_exp.e.get_n_splits_inner()
@@ -545,33 +548,33 @@ class TestOutputCollector:
             assert len(key) == 2
 
     def test_get_outputs_inner_split(self, built_exp_inner):
-        oc = built_exp_inner.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp_inner, collectors=[oc])
+        oc = built_exp_inner.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp_inner, collectors=[oc.name])
         results = oc.get_outputs('dt')
         n_expected = built_exp_inner.e.get_n_splits() * built_exp_inner.e.get_n_splits_inner()
         assert len(results) == n_expected
 
     def test_get_output_not_found(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         assert oc.get_output('dt', 99, 99) is None
 
     def test_get_outputs_node_not_found(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         assert oc.get_outputs('nonexistent') == {}
 
     def test_reset_nodes(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
         assert oc.has_node('dt')
         oc.reset_nodes(['dt'])
         assert not oc.has_node('dt')
 
     def test_save_load(self, built_exp):
-        oc = built_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(built_exp, collectors=[oc])
-        loaded = built_exp.project.collectors().get_collector('out')
+        oc = built_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(built_exp, collectors=[oc.name])
+        loaded = built_exp.e.collectors.get_collector('out')
         assert loaded.has_node('dt')
         result_orig = oc.get_output('dt', 0, 0)
         result_loaded = loaded.get_output('dt', 0, 0)
@@ -579,8 +582,8 @@ class TestOutputCollector:
                                       result_loaded['output_valid'])
 
     def test_saved_nodes(self, multi_head_exp):
-        oc = multi_head_exp.project.collectors().set_collector('out', OutputCollector, Connector(), params={'output_var': None})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[oc])
+        oc = multi_head_exp.e.collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[oc.name])
         saved = oc._get_saved_nodes()
         assert 'dt1' in saved
         assert 'dt2' in saved
@@ -592,23 +595,23 @@ class TestCollectorWithExperimenter:
         dispatch, so a second exp() call with the same collector leaves its
         result unchanged — this is exp()'s own skip logic, not a separate
         exist='skip' collect() call (which no longer exists)."""
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         metric_before = mc.get_metric('dt').copy()
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         metric_after = mc.get_metric('dt')
         pd.testing.assert_series_equal(metric_before, metric_after)
 
     def test_collectors_reload_from_the_store(self, built_exp):
         """Collector state lives in the project's Collectors registry, not the
         Experimenter. Registration writes through, so there is nothing to save."""
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         mc = collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
 
-        reloaded = built_exp.project.collectors()
+        reloaded = built_exp.e.collectors
         loaded_mc = reloaded.get_collector('acc')
         assert loaded_mc is not None
         assert loaded_mc.has_node('dt')
@@ -621,9 +624,9 @@ class TestCollectorWithExperimenter:
         project's separate Collectors registry — so Experimenter.reset_nodes
         (NodeStore + cache only) has no way to cascade into one. Clearing a
         Collector's own state is a separate, explicit reset_nodes call on it."""
-        mc = built_exp.project.collectors().set_collector(
+        mc = built_exp.e.collectors.set_collector(
             'acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=[mc])
+        _run(built_exp, collectors=[mc.name])
         assert mc.has_node('dt')
         built_exp.e.reset_nodes(['dt'])
         assert mc.has_node('dt')
@@ -632,13 +635,13 @@ class TestCollectorWithExperimenter:
 
     def test_multiple_collectors(self, built_exp):
         from mllabs.adapter import DecisionTreeAdapter
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         mc = collectors.set_collector('acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
         oc = collectors.set_collector('out', OutputCollector, Connector(), params={'output_var': None})
         mac = collectors.set_collector(
             'fi', ModelAttrCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'),
             params={'result_key': 'feature_importances', 'adapter': DecisionTreeAdapter()})
-        _run(built_exp, collectors=[mc, oc, mac])
+        _run(built_exp, collectors=[mc.name, oc.name, mac.name])
         assert mc.has_node('dt')
         assert oc.has_node('dt')
         assert mac.has_node('dt')
@@ -651,9 +654,9 @@ class TestSHAPCollector:
 
     def _make_sc(self, built):
         from mllabs import SHAPCollector
-        sc = built.project.collectors().set_collector(
+        sc = built.e.collectors.set_collector(
             'shap', SHAPCollector, Connector(processor='sklearn.tree.DecisionTreeClassifier'))
-        _run(built, collectors=[sc])
+        _run(built, collectors=[sc.name])
         return sc
 
     def test_collect_basic(self, built_exp):
@@ -713,7 +716,7 @@ class TestSHAPCollector:
 
     def test_save_load(self, built_exp):
         sc = self._make_sc(built_exp)
-        loaded = built_exp.project.collectors().get_collector('shap')
+        loaded = built_exp.e.collectors.get_collector('shap')
         assert loaded.has_node('dt')
         orig = sc.get_feature_importance_agg('dt')
         loaded_result = loaded.get_feature_importance_agg('dt')
@@ -753,9 +756,9 @@ class TestCollectorErrorHandling:
     never reaches the parent — only what the hist row carries."""
 
     def test_collect_error_is_recorded_with_its_traceback(self, built_exp):
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('broken', 'mock.BrokenCollector', Connector())
-        _run(built_exp, collectors=collectors)
+        _run(built_exp)
 
         rows = collectors.hist.get_hist(collector_name='broken')
         assert rows and all(r['status'] == 'error' for r in rows)
@@ -765,10 +768,10 @@ class TestCollectorErrorHandling:
         assert 'collect error' in info['traceback']
 
     def test_exp_continues_other_collectors_after_error(self, built_exp):
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('broken', 'mock.BrokenCollector', Connector())
         mc = collectors.set_collector('acc', MetricCollector, Connector(), params={'output_var': None, 'metric_func': accuracy_metric})
-        _run(built_exp, collectors=collectors)
+        _run(built_exp)
 
         assert mc.has_node('dt')
         assert collectors.hist.get_hist(collector_name='broken', status='error')
@@ -777,9 +780,9 @@ class TestCollectorErrorHandling:
     def test_push_failure_is_recorded_as_its_own_phase(self, built_exp):
         """A Collector whose collect() works but whose store step blows up —
         the fold that triggered the flush is the one that carries the error."""
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('badpush', 'mock.BrokenPushCollector', Connector())
-        _run(built_exp, collectors=collectors)
+        _run(built_exp)
 
         rows = collectors.hist.get_hist(collector_name='badpush')
         assert rows and all(r['status'] == 'error' for r in rows)
@@ -787,9 +790,10 @@ class TestCollectorErrorHandling:
 
 
 class TestCollectHist:
-    """One row per (collector, experimenter, node, outer, inner) — the fold
-    keys are what make an error locatable, which is the whole point of
-    recording an outcome the Collector itself no longer keeps."""
+    """One row per (collector, node, outer, inner) — the fold keys are what
+    make an error locatable, which is the whole point of recording an outcome
+    the Collector itself no longer keeps. No experimenter key: the hist
+    belongs to one run's registry, so the run is the store it is in."""
 
     @staticmethod
     def _folds(e):
@@ -797,90 +801,197 @@ class TestCollectHist:
                 for i in range(e.get_n_splits_inner())}
 
     def test_a_row_per_collector_and_fold(self, built_exp_inner):
-        collectors = built_exp_inner.project.collectors()
+        collectors = built_exp_inner.e.collectors
         collectors.set_collector('count', 'mock.CountingCollector', Connector())
-        _run(built_exp_inner, collectors=collectors)
+        _run(built_exp_inner)
 
         rows = collectors.hist.get_hist(collector_name='count')
         assert {(r['outer_idx'], r['inner_idx']) for r in rows} == self._folds(built_exp_inner.e)
         assert all(r['node_name'] == 'dt' and r['status'] == 'collected' for r in rows)
 
-    def test_row_carries_the_run_it_came_from(self, built_exp):
-        collectors = built_exp.project.collectors()
+    def test_row_carries_the_stamp_of_the_run(self, built_exp):
+        collectors = built_exp.e.collectors
         collectors.set_collector('count', 'mock.CountingCollector', Connector())
-        _run(built_exp, collectors=collectors)
+        _run(built_exp)
 
         row = collectors.hist.get_hist(collector_name='count')[0]
-        assert row['experimenter'] == built_exp.e.name
+        assert 'experimenter' not in row
         assert row['pipeline_version'] == built_exp.e.pipeline_version
         assert row['collect_date'] is not None
         assert row['elapsed'] >= 0
 
+    def test_the_hist_lives_in_the_run_directory(self, built_exp):
+        """Which run a row came from is answered by where the db is, not by a
+        column — the same way node_hist needs no run_name."""
+        assert built_exp.e.collectors.hist.db_path.parent == built_exp.e.path / 'collectors'
+
     def test_collecting_nothing_is_not_an_error(self, built_exp):
         """The base Collector returns None — that used to be indistinguishable
         from a failed collect, since both produced None."""
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('noop', 'mllabs.Collector', Connector())
-        _run(built_exp, collectors=collectors)
+        _run(built_exp)
 
         rows = collectors.hist.get_hist(collector_name='noop')
         assert rows and all(r['status'] == 'empty' and r['info'] is None for r in rows)
 
     def test_only_matched_collectors_get_rows(self, built_exp):
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('count', 'mock.CountingCollector', Connector(node_query='^dt'))
         collectors.set_collector('other', 'mock.CountingCollector', Connector(node_query='^nope'))
-        _run(built_exp, collectors=collectors)
+        _run(built_exp)
 
         assert collectors.hist.get_hist(collector_name='count')
         assert collectors.hist.get_hist(collector_name='other') == []
 
     def test_get_status_is_keyed_by_node_and_fold(self, built_exp_inner):
-        collectors = built_exp_inner.project.collectors()
+        collectors = built_exp_inner.e.collectors
         collectors.set_collector('count', 'mock.CountingCollector', Connector())
-        _run(built_exp_inner, collectors=collectors)
+        _run(built_exp_inner)
 
-        status = collectors.hist.get_status('count', built_exp_inner.e.name)
+        status = collectors.hist.get_status('count')
         assert set(status) == {('dt', o, i) for o, i in self._folds(built_exp_inner.e)}
         assert set(status.values()) == {'collected'}
 
     def test_multi_worker_records_the_same_rows(self, built_exp):
         """_run_collectors runs in the worker, so the outcome has to travel
         back over the pipe — only the parent ever writes the hist."""
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('count', 'mock.CountingCollector', Connector())
-        _run(built_exp, collectors=collectors, n_jobs=2)
+        _run(built_exp, n_jobs=2)
 
         rows = collectors.hist.get_hist(collector_name='count')
         assert {(r['outer_idx'], r['inner_idx']) for r in rows} == self._folds(built_exp.e)
         assert all(r['status'] == 'collected' for r in rows)
 
     def test_multi_worker_records_a_collect_error(self, built_exp):
-        collectors = built_exp.project.collectors()
+        collectors = built_exp.e.collectors
         collectors.set_collector('broken', 'mock.BrokenCollector', Connector())
-        _run(built_exp, collectors=collectors, n_jobs=2)
+        _run(built_exp, n_jobs=2)
 
         rows = collectors.hist.get_hist(collector_name='broken')
         assert rows and all(r['status'] == 'error' for r in rows)
         assert 'collect error' in rows[0]['info']['traceback']
 
-    def test_a_bare_list_records_nothing(self, built_exp):
-        """A list has no project-global place to write to; a registry does."""
-        collectors = built_exp.project.collectors()
+    def test_a_named_subset_is_recorded_too(self, built_exp):
+        """Narrowing to a list is a choice about this call, not about where the
+        history goes — that is the run's, whichever form is passed."""
+        collectors = built_exp.e.collectors
         c = collectors.set_collector('count', 'mock.CountingCollector', Connector())
-        _run(built_exp, collectors=[c])
+        _run(built_exp, collectors=[c.name])
 
-        assert collectors.hist.get_hist() == []
+        assert collectors.hist.get_hist(collector_name='count')
 
-    def test_collect_hist_argument_overrides_the_registry(self, built_exp, tmp_path):
-        from mllabs import CollectHist
-        hist = CollectHist(tmp_path / 'elsewhere')
-        collectors = built_exp.project.collectors()
-        collectors.set_collector('count', 'mock.CountingCollector', Connector())
-        _run(built_exp, collectors=collectors, collect_hist=hist)
 
-        assert hist.get_hist(collector_name='count')
-        assert collectors.hist.get_hist() == []
+class TestCollectorSelection:
+    """exp(collectors=) names Collectors on this run's registry — the registry
+    is the run's, so anything it does not know has no place here to write."""
+
+    def test_none_uses_every_collector_registered_on_the_run(self, built_exp):
+        c1 = built_exp.e.collectors.set_collector('c1', 'mock.CountingCollector', Connector())
+        c2 = built_exp.e.collectors.set_collector('c2', 'mock.CountingCollector', Connector())
+        _run(built_exp)
+
+        hist = built_exp.e.collectors.hist
+        assert hist.get_hist(collector_name=c1.name)
+        assert hist.get_hist(collector_name=c2.name)
+
+    def test_a_name_selects_only_that_one(self, built_exp):
+        built_exp.e.collectors.set_collector('c1', 'mock.CountingCollector', Connector())
+        built_exp.e.collectors.set_collector('c2', 'mock.CountingCollector', Connector())
+        _run(built_exp, collectors=['c1'])
+
+        hist = built_exp.e.collectors.hist
+        assert hist.get_hist(collector_name='c1')
+        assert hist.get_hist(collector_name='c2') == []
+
+    def test_empty_list_collects_nothing(self, built_exp):
+        built_exp.e.collectors.set_collector('c1', 'mock.CountingCollector', Connector())
+        _run(built_exp, collectors=[])
+
+        assert built_exp.e.collectors.hist.get_hist() == []
+
+    def test_an_unregistered_name_raises(self, built_exp):
+        """A silent miss reads exactly like 'this Collector produced nothing'."""
+        with pytest.raises(KeyError, match='nope'):
+            _run(built_exp, collectors=['nope'])
+
+    def test_an_instance_is_rejected(self, built_exp):
+        c = built_exp.e.collectors.set_collector('c1', 'mock.CountingCollector', Connector())
+        with pytest.raises(TypeError, match='names'):
+            _run(built_exp, collectors=[c])
+
+
+class TestRegistryIsPerRun:
+    """Two runs of the same Trial name must not overwrite each other's results.
+
+    Everything a Collector writes is keyed by node name and nothing more, so
+    the registry's path is the only thing keeping two runs apart — which is
+    why the registry belongs to an Experimenter and not to the Project.
+    """
+
+    @staticmethod
+    def _run_one(project, name, version, sample_data, trial):
+        e = project.experimenter(
+            name, sample_data,
+            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
+            pipeline_name='pipe', pipeline_version=version)
+        e.build()
+        mc = e.collectors.set_collector(
+            'acc', MetricCollector, Connector(),
+            params={'output_var': None, 'metric_func': accuracy_metric})
+        e.exp(_all_folds(trial, e), project.trials)
+        return e, mc
+
+    @pytest.fixture
+    def two_runs(self, tmp_path, sample_data):
+        project = Project(tmp_path / 'proj_two')
+        version = _pipeline_version(project, 'pipe')
+        trial = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 42})
+        a = self._run_one(project, 'run_a', version, sample_data, trial)
+        b = self._run_one(project, 'run_b', version, sample_data, trial)
+        return project, a, b
+
+    def test_each_run_stores_under_its_own_directory(self, two_runs):
+        _, (e_a, mc_a), (e_b, mc_b) = two_runs
+        assert mc_a.path != mc_b.path
+        assert mc_a.path.is_relative_to(e_a.path)
+        assert mc_b.path.is_relative_to(e_b.path)
+        assert e_a.collectors.hist.db_path != e_b.collectors.hist.db_path
+
+    def test_the_same_trial_name_is_collected_by_both(self, two_runs):
+        _, (_, mc_a), (_, mc_b) = two_runs
+        assert mc_a.get_metric('dt') is not None
+        assert mc_b.get_metric('dt') is not None
+        assert len(mc_a.get_metric('dt')) == len(mc_b.get_metric('dt'))
+
+    def test_each_run_records_its_own_hist(self, two_runs):
+        _, (e_a, _), (e_b, _) = two_runs
+        rows_a = e_a.collectors.hist.get_hist(collector_name='acc')
+        rows_b = e_b.collectors.hist.get_hist(collector_name='acc')
+        assert rows_a and len(rows_a) == len(rows_b)
+
+    def test_removing_from_one_run_leaves_the_other(self, two_runs):
+        """The overwrite this arrangement prevents, seen from the other end:
+        one run dropping its result must not reach into the other's."""
+        _, (e_a, mc_a), (e_b, mc_b) = two_runs
+        e_a.remove_trial_result('dt')
+
+        assert mc_a.get_metric('dt') is None
+        assert e_a.collectors.hist.get_hist(node_name='dt') == []
+        assert mc_b.get_metric('dt') is not None
+        assert e_b.collectors.hist.get_hist(node_name='dt')
+
+    def test_removing_the_result_reruns_the_trial(self, two_runs):
+        """History is the only gate on a fold, so dropping it is what makes the
+        next exp() dispatch the Trial again."""
+        project, (e_a, mc_a), _ = two_runs
+        trial = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 42})
+        e_a.remove_trial_result('dt', project.trials)
+
+        assert project.trials.get_status('dt', e_a.name) == {}
+        e_a.exp(_all_folds(trial, e_a), project.trials)
+        assert mc_a.get_metric('dt') is not None
 
 
 class TestProcessCollector:
@@ -889,113 +1000,113 @@ class TestProcessCollector:
         return sample_data.iloc[:20].reset_index(drop=True)
 
     def test_collect_basic(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         assert pc.has_node('dt')
 
     def test_get_output_shape(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         result = pc.get_output()
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 20
 
     def test_get_output_nodes_none(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         result = pc.get_output(nodes=None)
         assert isinstance(result, pd.DataFrame)
 
     def test_get_output_nodes_list(self, multi_head_exp, ext_data):
-        pc = multi_head_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc])
+        pc = multi_head_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc.name])
         result_dt1 = pc.get_output(nodes=['dt1'])
         result_all = pc.get_output(nodes=None)
         assert isinstance(result_dt1, pd.DataFrame)
         assert result_dt1.shape[1] < result_all.shape[1]
 
     def test_get_output_nodes_regex(self, multi_head_exp, ext_data):
-        pc = multi_head_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc])
+        pc = multi_head_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc.name])
         result = pc.get_output(nodes='dt1')
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 20
 
     def test_with_upstream_stage(self, built_exp, ext_data):
         # built_exp: scaler(stage) -> dt(Trial), ext_data goes through scaler first
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         result = pc.get_output()
         assert len(result) == 20
 
     def test_agg_mean(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'method': 'mean'})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'method': 'mean'})
+        _run(built_exp, collectors=[pc.name])
         result = pc.get_output(agg='mean')
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 20
 
     def test_agg_mode(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         result = pc.get_output(agg='mode')
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 20
 
     def test_agg_simple(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'method': 'simple'})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'method': 'simple'})
+        _run(built_exp, collectors=[pc.name])
         result = pc.get_output(agg='simple')
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 20
 
     def test_with_inner_splits(self, built_exp_inner, ext_data):
-        pc = built_exp_inner.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp_inner, collectors=[pc])
+        pc = built_exp_inner.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp_inner, collectors=[pc.name])
         result = pc.get_output()
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 20
 
     def test_multi_head_columns_concat(self, multi_head_exp, ext_data):
-        pc = multi_head_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc])
+        pc = multi_head_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc.name])
         result_all = pc.get_output(nodes=None)
         result_dt1 = pc.get_output(nodes=['dt1'])
         result_dt2 = pc.get_output(nodes=['dt2'])
         assert result_all.shape[1] == result_dt1.shape[1] + result_dt2.shape[1]
 
     def test_connector_filter(self, multi_head_exp, ext_data):
-        pc = multi_head_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(node_query=['dt1']), params={'ext_data': ext_data})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc])
+        pc = multi_head_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(node_query=['dt1']), params={'ext_data': ext_data})
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc.name])
         assert pc.has_node('dt1')
         assert not pc.has_node('dt2')
 
     def test_reset_nodes(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         assert pc.has_node('dt')
         pc.reset_nodes(['dt'])
         assert not pc.has_node('dt')
 
     def test_get_saved_nodes(self, multi_head_exp, ext_data):
-        pc = multi_head_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc])
+        pc = multi_head_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2, collectors=[pc.name])
         saved = pc._get_saved_nodes()
         assert 'dt1' in saved
         assert 'dt2' in saved
 
     def test_save_load(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
-        loaded = built_exp.project.collectors().get_collector('proc')
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
+        loaded = built_exp.e.collectors.get_collector('proc')
         assert loaded.has_node('dt')
         result_orig = pc.get_output()
         result_loaded = loaded.get_output()
         pd.testing.assert_frame_equal(result_orig, result_loaded)
 
     def test_invalid_agg(self, built_exp, ext_data):
-        pc = built_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
-        _run(built_exp, collectors=[pc])
+        pc = built_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data})
+        _run(built_exp, collectors=[pc.name])
         with pytest.raises(ValueError):
             pc.get_output(agg='invalid')
 
@@ -1011,21 +1122,21 @@ class TestProcessCollector:
         return Built(project=project, e=e, trial=trial)
 
     def test_output_var_none_returns_all_columns(self, proba_exp, ext_data):
-        pc = proba_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'output_var': None})
-        _run(proba_exp, collectors=[pc])
+        pc = proba_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'output_var': None})
+        _run(proba_exp, collectors=[pc.name])
         result = pc.get_output()
         assert result.shape == (20, 2)
 
     def test_output_var_list_selects_column(self, proba_exp, ext_data):
-        pc = proba_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'output_var': '{dt__target_0}'})
-        _run(proba_exp, collectors=[pc])
+        pc = proba_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'output_var': '{dt__target_0}'})
+        _run(proba_exp, collectors=[pc.name])
         result = pc.get_output()
         assert list(result.columns) == ['dt__target_0']
         assert result.shape == (20, 1)
 
     def test_output_var_regex_selects_column(self, proba_exp, ext_data):
-        pc = proba_exp.project.collectors().set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'output_var': 'dt__target_1'})
-        _run(proba_exp, collectors=[pc])
+        pc = proba_exp.e.collectors.set_collector('proc', ProcessCollector, Connector(), params={'ext_data': ext_data, 'output_var': 'dt__target_1'})
+        _run(proba_exp, collectors=[pc.name])
         result = pc.get_output()
         assert list(result.columns) == ['dt__target_1']
         assert result.shape == (20, 1)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -314,14 +314,13 @@ class TestWorkerWarningVerbosity:
         # predict/collect-time warnings (like XGBoost device mismatch) now flow
         # through the logger with the node prefix, not raw to stderr.
         from mllabs._logger import ProgressSessionLogger
-        from mllabs import Collectors, Connector, MetricCollector
+        from mllabs import Connector, MetricCollector
         exp.set_pipeline(pipeline.build())
         exp.build()
-        registry = Collectors(tmp_path / 'coll')
-        registry.set_collector('m', MetricCollector, Connector(),
-                               params={'output_var': None, 'metric_func': _const_metric})
+        exp.collectors.set_collector('m', MetricCollector, Connector(),
+                                     params={'output_var': None, 'metric_func': _const_metric})
         logger = ProgressSessionLogger(level=['info', 'progress'])  # no 'warning'
-        exp.exp(_folds(_wp(), exp), trial_store, registry, logger=logger)
+        exp.exp(_folds(_wp(), exp), trial_store, ['m'], logger=logger)
 
         assert any('PREDICT_WARN_XYZ' in w for w in logger.warning_list)
         assert any('[wp_node]' in w for w in logger.warning_list)   # node prefix present

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -275,29 +275,39 @@ class TestExp:
 
     def test_exp_with_collector(self, exp, pipeline, project):
         trial = _dt()
-        mc = project.collectors().set_collector(
+        mc = exp.collectors.set_collector(
             'acc', MetricCollector, Connector(),
             params={'output_var': None, 'metric_func': accuracy_metric},
         )
-        exp.exp(_folds(trial, exp), project.trials, collectors=[mc])
+        exp.exp(_folds(trial, exp), project.trials, collectors=['acc'])
         assert mc.has_node('dt')
 
     def test_set_collector_resolves_callable_metric(self, exp, pipeline, project):
         from sklearn.metrics import balanced_accuracy_score
         trial = _dt()
-        mc = project.collectors().set_collector(
+        mc = exp.collectors.set_collector(
             'bacc', MetricCollector, Connector(),
             params={'output_var': None,
                     'metric_func': {'__callable__': 'sklearn.metrics.balanced_accuracy_score'}},
         )
         assert mc.metric_func is balanced_accuracy_score
-        exp.exp(_folds(trial, exp), project.trials, collectors=[mc])
+        exp.exp(_folds(trial, exp), project.trials, collectors=['bacc'])
         assert mc.has_node('dt')
+
+    def test_the_run_restores_its_own_collectors(self, exp, pipeline, project, sample_data):
+        """The registry is the run's, so reopening it brings the Collectors
+        back — a standalone Experimenter is complete on its own directory."""
+        exp.collectors.set_collector(
+            'acc', MetricCollector, Connector(),
+            params={'output_var': None, 'metric_func': accuracy_metric},
+        )
+        reopened = Experimenter.load_experimenter(exp.path, sample_data)
+        assert reopened.collectors.names() == ['acc']
 
 
 class TestCollectorsRegistry:
-    """Collectors are a project-wide registry now (`mllabs.collector._registry`),
-    not owned by Experimenter (no more exp.set_collector/get_collector) — the
+    """A registry belongs to one run (`mllabs.collector._registry`); an
+    Experimenter builds its own and hands it out as `.collectors`. The
     set_collector 'skip'/'error' exist modes are tested directly against it."""
 
     def test_set_collector(self, tmp_path):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -4,7 +4,7 @@ import pandas as pd
 from sklearn.model_selection import ShuffleSplit
 
 from mllabs import (Project, TrialStore, Trial, Predictor, PipelineBuilder, make_trials,
-                    Connector, MetricCollector)
+                    Collectors, Connector, MetricCollector)
 
 
 TREE = 'sklearn.tree.DecisionTreeClassifier'
@@ -51,8 +51,7 @@ class TestProjectLayout:
 
     def test_paths_are_under_root(self, project):
         for p in (project.pipeline_path('a'), project.exp_path('b'),
-                  project.trainer_path('c'), project.inferencer_path('d'),
-                  project.collectors_path()):
+                  project.trainer_path('c'), project.inferencer_path('d')):
             assert project.path in p.parents or p.parent == project.path
 
     def test_paths_are_created(self, project):
@@ -71,8 +70,15 @@ class TestProjectLayout:
         again = project.pipeline_builder('main')
         assert 'g' in again.grps
 
-    def test_collectors_registry_rooted_in_project(self, project):
-        assert project.collectors().path == project.collectors_path()
+    def test_project_owns_no_collector_registry(self, project, sample_data):
+        """A registry belongs to the run that writes into it — Collector data is
+        keyed by node name alone, so a project-wide one would have two runs
+        overwrite each other on any Trial name they share."""
+        assert not hasattr(project, 'collectors')
+        assert not (project.path / 'collectors').exists()
+
+        e = project.experimenter('run_a', sample_data)
+        assert e.collectors.path == e.path / 'collectors'
 
 
 class TestPipelineVersions:
@@ -518,24 +524,23 @@ class TestExperimenterUnderProject:
 
 class TestRemoveTrial:
     """A Trial leaves no artifact, so everything it produced sits in stores
-    that don't know about each other — TrialStore (definition + history),
-    CollectHist (per-fold collect outcomes) and each Collector's own data.
-    Project is the only thing that sees all three."""
+    that don't know about each other — the project's TrialStore (definition +
+    history), and inside every run that ran it, the collected data and the
+    CollectHist rows for it. Project is the only thing that sees them all."""
 
-    def _run(self, project, builder, sample_data):
+    def _run(self, project, builder, sample_data, name='run_a'):
         version = project.build_pipeline(builder).version
         e = project.experimenter(
-            'run_a', sample_data,
+            name, sample_data,
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=0),
             pipeline_name='main', pipeline_version=version,
         )
         e.build()
-        collectors = project.collectors()
-        collectors.set_collector('acc', MetricCollector, Connector(),
-                                 params={'output_var': None, 'metric_func': dummy_metric})
+        e.collectors.set_collector('acc', MetricCollector, Connector(),
+                                   params={'output_var': None, 'metric_func': dummy_metric})
         trial = _trial()
-        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials, collectors=collectors)
-        return e, collectors
+        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials)
+        return e, e.collectors
 
     def test_store_remove_drops_the_definition_only(self, store):
         store.register(_trial())
@@ -560,35 +565,50 @@ class TestRemoveTrial:
         assert project.trials.get_by_name('dt') is None
         assert project.trials.get_status('dt', 'run_a') == {}
         assert collectors.hist.get_hist(node_name='dt') == []
-        assert project.collectors().get_collector('acc').get_metric('dt') is None
+        assert Collectors(e.path / 'collectors').get_collector('acc').get_metric('dt') is None
 
     def test_leaves_other_trials_alone(self, project, builder, sample_data):
         e, collectors = self._run(project, builder, sample_data)
         other = _trial('dt2')
-        e.exp([(other, 0, 0), (other, 1, 0)], project.trials, collectors=collectors)
+        e.exp([(other, 0, 0), (other, 1, 0)], project.trials)
 
         project.remove_trial('dt')
 
         assert project.trials.get_by_name('dt2') is not None
         assert project.trials.get_status('dt2', 'run_a')
         assert collectors.hist.get_hist(node_name='dt2')
-        assert project.collectors().get_collector('acc').get_metric('dt2') is not None
+        assert collectors.get_collector('acc').get_metric('dt2') is not None
 
-    def test_cleans_the_registry_it_is_given(self, project, builder, sample_data):
-        """collectors() builds a fresh registry each call, and a Collector may
-        answer from an in-memory cache — so the caller's own registry has to be
-        cleanable, not just whatever Project happens to construct."""
+    def test_reaches_every_run_that_collected_it(self, project, builder, sample_data):
+        """The registries are per-run now, so this is a pass over the runs
+        rather than one store — a run left out would keep its results."""
+        e_a, coll_a = self._run(project, builder, sample_data, name='run_a')
+        e_b, coll_b = self._run(project, builder, sample_data, name='run_b')
+        assert coll_a.get_collector('acc').has_node('dt')
+        assert coll_b.get_collector('acc').has_node('dt')
+
+        project.remove_trial('dt')
+
+        for e in (e_a, e_b):
+            reopened = Collectors(e.path / 'collectors')
+            assert reopened.get_collector('acc').get_metric('dt') is None
+            assert reopened.hist.get_hist(node_name='dt') == []
+
+    def test_cleans_the_registries_it_is_given(self, project, builder, sample_data):
+        """A registry opened from disk is not the one the caller holds, and a
+        Collector may answer from an in-memory cache — so the run itself has to
+        be cleanable, not just whatever Project reopens."""
         e, collectors = self._run(project, builder, sample_data)
         acc = collectors.get_collector('acc')
         assert acc.has_node('dt')
-        project.remove_trial('dt', collectors=collectors)
+        project.remove_trial('dt', experimenters=[e])
         assert not acc.has_node('dt')
 
     def test_a_removed_trial_runs_again_from_scratch(self, project, builder, sample_data):
         e, collectors = self._run(project, builder, sample_data)
         project.remove_trial('dt')
         trial = _trial()
-        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials, collectors=collectors)
+        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials)
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
 
 


### PR DESCRIPTION
Closes #135.

## The problem

Everything a Collector writes is keyed by node name and nothing else — `MetricCollector`'s PK is `(node, idx, inner_idx, split)`, the file-based ones use `{path}/{node}...`. The registry was the project's, so two Experimenters that ran a Trial of the same name wrote to the same row or the same file, and the second one won. No error, no warning.

`CollectHist` was the one exception, keyed with an `experimenter`. That made the pair worse than either extreme on its own: history recorded that both runs collected, while the data held only the last, so `get_hist()` reported `'collected'` for a row whose result had been overwritten.

The instance already behaved as one run's — only its lifetime said otherwise:

- `on_attach(experimenter)` re-runs `_on_attach` whenever the identity changes (`ProbToLabel` resolves label classes out of it), so alternating `exp()` between two runs flips shared state back and forth.
- `_setup(n_outer, n_inner)` writes *that run's* fold counts onto the instance, and those drive `push` → `_flush_outer` and `StackingCollector._save_node`.
- `_buf` keys a partially filled outer fold by node alone, so one run's leftovers are visible to the next.

## What changed

The registry moves to `{exp path}/collectors` and the Experimenter owns it. Separation now comes from the path rather than from adding a key to six storage formats, and `CollectHist` drops its `experimenter` column, index and filters for the same reason `node_hist` has no `run_name`: the store is already scoped to the run that owns it. A run also gets more complete — `load_experimenter` brings back its Collectors, their data and their history along with everything else.

`exp()` follows:

```python
e.exp(folds, project.trials)                              # every Collector on this run
e.exp(folds, project.trials, collectors=['acc', 'shap'])  # a subset, by name
e.exp(folds, project.trials, collectors=[])               # collect nothing
```

`collectors=` takes **names** out of the run's own registry, the way `processor` and `adapter` are string refs. An instance is rejected with a `TypeError`: one this registry does not know has no place in this run to write, and would quietly deposit results outside it — which is what a per-run registry exists to prevent. An unregistered name raises `KeyError`, since a silent miss reads exactly like "collected nothing". `collect_hist=` is gone; there was one correct value and the run holds it.

Removing a Trial splits along the same line:

- `Collectors.remove_results(node_name)` — a node's data and its hist rows together. The registry is the only thing that sees both halves.
- `Experimenter.remove_trial_result(name, trial_store=None)` — delegates to it, and with a `trial_store` also drops this run's `experiment_hist` rows, which is what makes the next `exp()` run the Trial again (folds are skipped on recorded status and nothing else).
- `Project.remove_trial(name, experimenters=None)` — keeps the project-wide half (one statement each for the definition and for every run's history) and passes over `list_experimenters()` for the rest. It opens each registry **by path** rather than constructing an Experimenter, which would load every fold's artifacts. Pass runs you already hold as `experimenters=` so their in-memory caches (`ModelAttrCollector`/`SHAPCollector`) are cleaned too.

`Project.collectors()` and `collectors_path()` are removed along with the project-root `collectors/` directory.

## What this gives up

`Collectors`' docstring named cross-run comparability as the reason the registry was project-global. That comparability was not real: landing in the same place meant overwriting, not pooling, exactly when two runs shared a trial name — the case where comparison was wanted. What is genuinely lost is that one `get_metrics()` answered for the whole project; that is now a read across runs, which is #130's subject.

## Open questions settled

- **OQ1** — the whole registry moves, definitions included, not just data and history.
- **OQ2** — `exp/{name}/collectors/{collector name}/`, leaving each collector's own layout untouched underneath.
- **OQ3** — `CollectHist` moves into the run and loses `experimenter`.
- **OQ4** — Trainer has no collectors and gains none.
- **OQ5** — `remove_trial(name, experimenters=None)`, per above.
- **OQ6** — no migration. An existing project keeps its root `collectors/` directory, untouched and unread.

## Notes

- `examples/kaggle_s6e6/2. Second Phase.ipynb` is updated in its own commit. The experimenter cell moves ahead of the collectors cell (the registry needs the run to exist), and `stack_oof` — previously registered on the project registry and handed to `e_stk` via `resolve()` — now registers on `e_stk.collectors`. That notebook was the evidence base for the issue and is where the old arrangement actually showed. Execution counts now read out of order across the moved cell; the next run renumbers them.
- Tests: 982 passed, 128 skipped. New coverage is `TestRegistryIsPerRun` (two runs of the same Trial name keep separate data and history; removing from one leaves the other; removing the result makes the Trial run again) and `TestCollectorSelection` (`None`/subset/`[]`, unregistered name, instance rejected).
