### PR TITLE
refactor(Trial): author at the project, run by name (#126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Project(path, cache_maxsize)          경로·캐시 소유. 프로젝트 전역
 - **Project** (`_project.py`): 디렉토리 레이아웃 + `TrialStore`/`ProjectStore`/`cache`. 프로젝트 전역인 것만 소유하고, Pipeline 버전조차 색인하지 않는다(각 pipeline이 자기 db에서 관리)
 - **PipelineBuilder / Pipeline** (`_pipeline.py`): 가변 빌더 + `build()`가 만드는 불변 **노드 전용** 그래프
 - **Trial / make_trials** (`_trial.py`): 평가할 구성 하나. Pipeline 밖에 있음
-- **TrialStore** (`_trial_store.py`): `trials`(정의) + `experiment_hist`(fold별 실행 이력)
+- **TrialStore** (`_trial_store.py`): `trials`(정의) + `experiment_hist`(fold별 실행 이력). 저작은 `Project.set_trial`, 실행은 `Experimenter.exp`가 **이름으로** 꺼내 씀
 - **Predictor** (`_predictor.py`): Trainer가 학습하는 끝지점 출력 노드. Trial과 같은 실행 정의 + 출처(`src_trial`/`src_experimenter`)
 - **PredictorStore** (`_predictor_store.py`): `predictors`(정의) 하나뿐 — 이력은 Trainer의 두 번째 `NodeStore`가 가짐
 - **ProjectStore** (`_project_store.py`): `experimenters`/`trainers` **이름 목록만**
@@ -162,8 +162,8 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
 - **`Trial`**: `name`, `processor`, `method`, `adapter`, `params`, `edges`, `desc`, `tag`
   - `desc`: 순수 표시용 설명 문자열 — `PipelineBuilder`의 `desc`와 같은 역할(매칭/diff/저장 식별에 전혀 관여 안 함). 안 주면 `None`
   - `get_spec()`: 노드의 `Pipeline.get_node_spec()`과 **똑같은 `ProcessorSpec`** 반환
-  - **이름이 식별자**. 디스크 아티팩트 디렉토리명이자 `TrialStore`(`trials` 테이블 PK)의 키 — 재정의하면 아티팩트도 `TrialStore` row도 덮어씀
-  - 정의를 값으로 비교하는 별도 유틸(content_key 류)은 없다 — `TrialStore.has()`가 필드별로 직접 비교
+  - **이름이 식별자**. `TrialStore`(`trials` 테이블 PK)의 키이자 `experiment_hist`가 매다는 것이고, `exp()`가 참조하는 것도 이 이름 — Trial 객체는 프로젝트에 등록될 때만 등장하고 실행 경로엔 이름만 다닌다
+  - 정의를 값으로 비교하는 별도 유틸(content_key 류)은 없다 — `TrialStore.has()`가 필드별로 직접 비교. 이 비교가 `Project.set_trial`의 문지기(변경 여부 + 성공 이력 있는 이름 동결)를 떠받침
   - `node_names()`: edges가 참조하는 노드 이름 집합
 
 - **`make_trials(name, processor, edges, method, adapter, params, param_grid, tags)`** → `list[Trial]`
@@ -190,6 +190,14 @@ ProjectStore는 이름 목록이라 동기화가 어긋날 두 번째 진실 원
   - `load_pipeline(name, version=None)`, `list_pipeline_versions(name)` — 둘 다 `PipelineStore(pipeline_path(name), name)`를 통해 조회
   - 저장은 pkl (`v{n}.pkl`) — 형식은 `PipelineStore.save_version`/`load_version` 뒤에 숨어 있어 교체 가능
 - `trials`: `TrialStore`, `store`: `ProjectStore`, `list_experimenters()`, `list_trainers()`
+- **`set_trial(trial)` / `set_trials(trials)`**: Trial 저작 진입점. **실행과 분리된 이유** — Trial은 프로젝트 소유인데 등록이 `Experimenter.exp()`의 부수효과였다. 그래서 실행하지 않고는 프로젝트에 넣을 수 없었고, 한 run이 다른 run이 이미 쓴 이름을 조용히 덮을 수 있었다
+  - 반환은 **추가·변경된 이름**(`set_trial`은 str 또는 `None`, `set_trials`는 list) — 그대로 다음 `exp()`의 작업 목록이 된다. 저장된 정의와 같으면 변경이 아님(`has()`)
+  - **성공 이력이 있는 이름은 얼린다**: `experiment_hist`에 `'built'` fold가 있는데 정의가 다르면 `ValueError`. 이력은 이름으로 키잉되고 Trial은 아티팩트를 안 남기므로, 재정의하면 옛 결과가 그걸 만든 적 없는 정의를 설명하게 된다 — 한 Trial의 기록처럼 보이는 두 개가 됨. 바꾸려면 새 이름이거나 `remove_trial`(결과까지 포기). `'error'`뿐이면 지킬 결과가 없으니 허용
+  - `set_trials`는 **전부 검사한 뒤에 쓴다** — 하나가 얼려 있으면 아무것도 안 바뀐다(절반만 등록되면 반환한 작업 목록이 거짓이 됨)
+  - 문지기 없는 저수준 경로는 `trials.register()` — 테스트가 재정의 동작을 직접 확인할 때 씀
+- **`show_error_trials(experimenter=None, traceback=False)`**: Trial 실행 에러를 fold당 한 줄로. `Experimenter.show_error_nodes`의 Trial판이고 **여기 있는 이유는 이력의 주인이 여기라서**(노드 이력은 run, Trial 이력은 프로젝트). 실패가 없으면 `None`
+- **`pending_trials(experimenter=None)`**: 등록된 Trial 중 **에러났거나 이력이 아예 없는** 이름 목록. 둘 다 "아직 돌려야 할 것"이라 한 목록으로 낸다 — 손으로 쓰면 후자만 잡아서 실패한 게 조용히 빠진다(#130이 노트북에서 지목한 실제 버그)
+  - **일부러 거칠다**: fold 일부만 돌다 끊긴 건 안 잡는다 — 그걸 판정하려면 fold 그리드와 대조해야 하는데 이 store는 그걸 모른다. 반환된 이름을 그냥 돌려도 안전하다(`exp()`가 끝난 fold를 건너뜀)
 - **`remove_trial(name, experimenters=None)`**: Trial 하나를 프로젝트에서 완전히 지운다 — 정의(`TrialStore.trials`) + 이력(`experiment_hist`, **모든 experimenter**) + 각 run이 수집한 데이터와 그 `CollectHist`. Trial은 아티팩트를 안 남기는 대신 흔적이 서로 모르는 store들에 흩어져 있고, **그걸 다 보는 건 Project뿐**이라 여기 있다(단일 store 위의 편의 래퍼가 아니라, 주인 없는 교차 연산에 주인을 준 것)
   - 프로젝트 전역 절반(정의 + 전 experimenter 이력)은 각각 SQL 한 문장이고, run별 절반은 `list_experimenters()` 순회 → `Experimenter.remove_trial_result(name)` 위임
   - **run을 열지 않는다** — `Collectors({exp_path}/collectors)`로 레지스트리만 경로에서 연다(db 두 개뿐, 데이터셋 불필요). Experimenter를 만들면 `DataFlow.__init__`이 그 fold의 아티팩트를 전부 적재하므로 trial 하나 지우자고 치를 비용이 아님
@@ -211,10 +219,12 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - **인조식별자도 content hash도 없다.** 두 테이블 다 **이름이 PK**(`trials`는 trial 이름, 이력은 trial 이름 + experimenter 이름). `pipeline_version`은 해시가 아니라 **정수**로, 그 실행의 `Experimenter.pipeline_version`을 그대로 기록
 - 이름으로 키잉하는 이유: Experimenter가 이미 이름으로 키잉돼 있어(`{project}/exp/{name}`) 조인 없이 읽히고, **이름을 재정의하면 행을 덮어쓴다**가 두 테이블 모두 일관됨(`register`는 `INSERT OR REPLACE`)
 - 정의 일치 여부는 값 비교 하나로 충분해서(`has()`) 해시 컬럼을 두지 않는다. `experiment_hist`는 실행 로그일 뿐 정의의 출처가 아니므로, 이름이 재정의되면 예전 정의를 복원하는 기능은 없다
-- **재실행 여부는 `experiment_hist`가 판정한다** — `Experimenter._make_jobs`는 `experiment_hist`의 fold별 `status`만 본다: `'built'`면 스킵, `'error'`거나 기록이 없으면 job 생성. **디스크에 이와 어긋날 것이 애초에 없어서**(Trial은 아티팩트를 안 남김) 이게 유일하게 가능한 판정이고, 다시 돌리려면 `remove_hist(trial_name=, experimenter=)` 하나면 된다. trial을 재정의해도 이미 `'built'`인 fold는 자동 재실행되지 않음
-- `register(trial)`/`register_all(trials)`: 이름 기준 upsert. `has(trial)`: 그 이름에 저장된 게 **지금** 이 정의와 같은지 필드별 비교. `get_by_name(name)`, `list_trials()`
-- `remove(name)`: **정의만** 삭제 — `experiment_hist`는 그대로 두어 "정의가 사라진 뒤에도 무엇이 돌았는지는 읽힌다". 프로젝트에서 통째로 걷어내는 건 store 넷에 걸친 일이라 `Project.remove_trial(name)`
-- `record(trial_name, experimenter, outer_idx, inner_idx, pipeline_version, status)`, `get_hist(...)`, `get_status(...)`, `remove_hist(...)`
+- **재실행 여부는 `experiment_hist`가 판정한다** — `Experimenter._make_jobs`는 `experiment_hist`의 fold별 `status`만 본다: `'built'`면 스킵, `'error'`거나 기록이 없으면 job 생성. **디스크에 이와 어긋날 것이 애초에 없어서**(Trial은 아티팩트를 안 남김) 이게 유일하게 가능한 판정이고, 다시 돌리려면 `e.remove_trial_result(name)` 하나면 된다. 재정의해도 이미 `'built'`인 fold는 자동 재실행되지 않으며, **애초에 그런 재정의가 `Project.set_trial`에서 막힌다**
+- `register(trial)`/`register_all(trials)`: 이름 기준 upsert — **문지기가 없는 저수준 API**. 성공 이력 검사를 거치는 저작 진입점은 `Project.set_trial`/`set_trials`
+- `has(trial)`: 그 이름에 저장된 게 **지금** 이 정의와 같은지 필드별 비교. 저장된 게 아예 없으면 `False`(호출부가 부재를 따로 안 봐도 되게). `desc`/`tag`는 비교 대상이 아님 — 표시·선택용이라 실행이 달라지지 않음
+- `get_by_name(name)`/`list_trials()`: **`Trial` 객체**를 반환(`PredictorStore`와 같음). `exp()`가 이름으로 받아 여기서 정의를 꺼내 실행하므로, 넣은 것과 같은 것이 나와야 함
+- `remove(name)`: **정의만** 삭제 — `experiment_hist`는 그대로 두어 "정의가 사라진 뒤에도 무엇이 돌았는지는 읽힌다". 프로젝트에서 통째로 걷어내는 건 여러 store에 걸친 일이라 `Project.remove_trial(name)`
+- `record(trial_name, experimenter, outer_idx, inner_idx, pipeline_version, status)`, `get_hist(trial_name=, experimenter=, pipeline_version=, status=)`, `get_status(...)`, `remove_hist(...)`
 
 ### Experimenter (`_experimenter.py`)
 - **Project 의존성 없음. 주입받는 건 `cache` 하나** — 생성자: `Experimenter(path, name, data, data_names=, sp=, sp_v=, splitter_params=, title=, data_key=, aug_data=, cache=)`. store는 `ExperimenterStore(self.path)`로 **자기가 만들고**, Pipeline은 `set_pipeline()`으로만 채택
@@ -228,20 +238,23 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - 버전 전환 시 `pipeline.diff_from(self.pipeline)`으로 stale 판정 → `reset_nodes()`로 해당 노드 아티팩트만 제거. Trial은 건드리지 않음("Staleness" 섹션)
 - `cache`(`DataCache`, optional) — `None`이면 캐시 없이 동작. store는 optional이 아니라(자기가 만듦) standalone Experimenter도 meta/splitter/Pipeline이 전부 저장됨
 - **`collectors`**: `Collectors({path}/collectors)` — 생성자에서 만들고(생성자가 곧 복원) `node_store`와 같은 자리. Collector가 쓰는 건 전부 노드 이름만으로 키잉되므로 **경로가 두 run을 가르는 유일한 수단**이다 — 프로젝트 전역 레지스트리였다면 이름이 겹치는 Trial마다 서로의 결과를 덮어썼다(무증상, 그리고 하필 비교가 필요한 바로 그 경우에). 대가는 교차 run 비교가 store N개에 대한 읽기가 되는 것(#130)
-- **`remove_trial_result(name, trial_store=None)`**: 이 run이 가진 Trial *결과*를 지운다 — `self.collectors.remove_results(name)`(수집 데이터 + `CollectHist` 행). `trial_store`를 주면 이 run의 `experiment_hist` 행도 삭제 → **다음 `exp()`가 그 Trial을 다시 돌린다**(fold 스킵의 유일한 근거가 이력이므로). 다른 run의 기록은 안 건드림
+- **`trial_store`**(`TrialStore`, optional): 실행할 Trial을 읽고 결과를 기록하는 곳. `cache`처럼 **생성자에서 한 번** 주입 — 프로젝트에 하나뿐이고 run 수명 동안 바뀌지 않는다. **영속화 안 함**: 프로젝트 레벨 객체라 자기 디렉토리만 아는 run이 찾아낼 방법이 없고, 상위 레이아웃을 추측하는 건 이 구조가 피해온 암묵 결합. 없으면 `_require_trial_store()`가 두 공급 경로를 안내하며 `RuntimeError`
+- **`remove_trial_result(name)`**: 이 run이 가진 Trial *결과*를 지운다 — `self.collectors.remove_results(name)`(수집 데이터 + `CollectHist` 행) + 이 run의 `experiment_hist` 행 → **다음 `exp()`가 그 Trial을 다시 돌린다**(fold 스킵의 유일한 근거가 이력이므로). 다른 run의 기록도, 정의(프로젝트 소유)도 안 건드림. `trial_store`가 없으면 이력 절반은 건너뜀
 - **pipeline 필요** (`_require_pipeline()`로 미설정 시 에러):
   - `build(nodes=None, rebuild=False, n_jobs=1, gpu_id_list=None, logger=None)` — 노드 빌드
-  - **`exp(trials, trial_store, collectors=None, n_jobs=1, gpu_id_list=None, logger=None)`**
-    - `trials`: **`[(Trial, outer_idx, inner_idx), ...]`** 튜플 리스트. fold 전개를 여기서 하므로 executor는 목록을 그대로 실행
-    - `trial_store`(`TrialStore`): 필수 — Trial 정의 등록/fold 스킵 판정/이력 기록 전부 여기로 함(보통 `project.trials`)
+  - **`exp(trials, collectors=None, n_jobs=1, gpu_id_list=None, logger=None)`**
+    - `trials`: **Trial 이름 리스트**. 이름 하나가 이 run의 fold 전 조합을 뜻하며, fold 지정은 호출부의 몫이 아니다
+    - **이름이지 인스턴스가 아니다** — 정의는 주입된 `self.trial_store`에서 꺼낸다. Trial은 프로젝트 소유인데 예전엔 등록이 `exp()`의 부수효과라, 실행하지 않고는 프로젝트에 넣을 수 없었고 한 run이 다른 run이 쓰던 이름을 조용히 재정의할 수 있었다. 저작은 `Project.set_trial`, 여기는 실행만
+    - 미등록 이름은 `KeyError`, 이름 자리에 `Trial`을 넘기면 `TypeError`(안 잡으면 sqlite 바인딩 에러로 새어나가 원인이 안 보임)
     - `collectors`: **이 run의 `self.collectors`에 등록된 이름 리스트**. `None`=전부, `[]`=수집 안 함. 인스턴스를 넘기면 `TypeError`(`_resolve_collectors`) — 레지스트리가 모르는 Collector는 이 run에 쓸 자리가 없어서 조용히 run 밖에 결과를 떨군다. 미등록 이름은 `Collectors.resolve`가 `KeyError`
     - 수집 이력은 항상 `self.collectors.hist` — 한 호출의 선택이 아니라 run에 속하므로 인자가 없다
-    - `_make_jobs(trials, trial_store)`가 `Job(name, spec, outer_idx, inner_idx, flow, need_gpu)` 리스트를 만듦. skip 판정은 `trial_store.get_status(name, self.name)`의 fold별 status로만 함. GPU 판정도 여기서 하고, adapter resolve는 **trial 이름당 1회**
-    - Trial 정의를 *trial_store*에 등록하고, `TrialHistTracker`가 fold별 done/error를 이력에 기록
+    - **`_make_jobs(trials)`가 fold 조합을 만든다** — 이름마다 `(outer_idx, inner_idx)` 전 조합을 돌며 `'built'`인 것만 빼고 `Job(name, spec, outer_idx, inner_idx, flow, need_gpu)` 생성. skip 판정은 `trial_store.get_status(name, self.name)`의 fold별 status로만 하므로, **같은 이름을 다시 넘기면 중단된 실행이 이어진다**(반복이 아니라). 정의 조회·spec·GPU 판정은 fold당이 아니라 이름당 1회
+    - `TrialHistTracker`가 fold별 done/error를 이력에 기록(등록은 안 함)
   - `n_jobs`는 실제 작업 수로 상한 처리 (`min(n_jobs, len(jobs))`) — 유휴 워커/progress bar 방지
   - `get_node_info()`: 노드 요약 Markdown
-- **pipeline 불필요** (디스크 상태만으로 동작): `get_status(node_name)`, `reset_nodes(nodes)`, `show_error_nodes(nodes=None, traceback=False, trial_store=None)`(trial_store 없으면 노드 에러만 보고), `get_objs(node_name, outer_idx=0, inner_idx=0)`
-  - **셋 다 Pipeline 노드 전용**(`show_error_nodes`만 예외 — `trial_store`를 주면 Trial 에러도 같이 본다). Trial은 디스크에 아무것도 안 남기므로 `get_status`는 몇 번을 돌렸든 `None`, `reset_nodes`는 지울 게 없고, `get_objs`는 `FileNotFoundError`. Trial 쪽 대응물은 `trial_store.get_status(name, exp.name)` / `remove_hist(...)` / (모델 대신) Collector가 모은 결과
+- **pipeline 불필요** (디스크 상태만으로 동작): `get_status(node_name)`, `reset_nodes(nodes)`, `show_error_nodes(nodes=None, traceback=False)`, `get_objs(node_name, outer_idx=0, inner_idx=0)`
+  - **넷 다 Pipeline 노드 전용.** Trial은 디스크에 아무것도 안 남기므로 `get_status`는 몇 번을 돌렸든 `None`, `reset_nodes`는 지울 게 없고, `get_objs`는 `FileNotFoundError`. Trial 쪽 대응물은 `trial_store.get_status(name, exp.name)` / `Project.show_error_trials(experimenter=)` / `remove_trial_result(name)` / (모델 대신) Collector가 모은 결과
+  - **에러 보고가 갈리는 기준은 이력의 주인이다** — 노드 이력은 run의 `node_hist`, Trial 이력은 프로젝트의 `experiment_hist`. 예전엔 `show_error_nodes` 하나가 둘을 합쳐 내놨는데, 출력 라벨이 `[이름] fold o_i` 하나뿐이라 노드인지 Trial인지 구분이 안 됐다. 포맷은 `_run_common.format_errors`가 공유(둘 다 실패를 같은 모양으로 설명하므로)
 - **OS log capture** (`open_os_log`/`close_os_log`/`os_log`):
   - `open_os_log(log_path=None)`: 이 프로세스의 OS-level stdout/stderr(fd 1/2)를 `{path}/__worker_logs/master.log`(기본값)로 dup2 리다이렉트 — `self._os_log_state`에 원본 fd/`sys.stdout`·`stderr` 백업 보관. 이미 open이면 에러
   - `close_os_log()`: 리다이렉트 원복. open 안 된 상태에서 호출하면 no-op

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install ml-labs[all]         # All optional dependencies
 
 ## Key Features
 
-- **Project**: Owns the directory layout and what is project-wide — pipelines, Collectors, the Trial store, the shared cache
+- **Project**: Owns the directory layout and what is project-wide — pipelines, the Trial store, the shared cache
 - **PipelineBuilder → Pipeline**: A mutable builder producing an immutable node graph; definitions are declarations, resolved only at execution time
 - **Experimenter**: Evaluates **Trials** — candidate models — with nested cross-validation, caching and error resilience
 - **Trainer**: Trains **Predictors** — the candidates you chose — and exports a standalone `Inferencer`
@@ -33,7 +33,7 @@ pip install ml-labs[all]         # All optional dependencies
 ## Architecture Overview
 
 ```
-Project ─────────── directory layout + pipelines, Collectors, TrialStore, cache
+Project ─────────── directory layout + pipelines, TrialStore, cache
   │
   ├─ PipelineBuilder ──build()──► Pipeline    preprocessing nodes only
   │
@@ -83,7 +83,8 @@ trials = [Trial(f'lr_{c}', 'sklearn.linear_model.LogisticRegression',
                 params={'C': c})
           for c in (0.1, 1.0)]
 
-e.exp([(t, 0, 0) for t in trials], project.trials)
+names = project.set_trials(trials)
+e.exp(names)
 
 print(collectors.get_collector('acc').get_metrics_agg(None)[0])
 ```

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -43,9 +43,9 @@ This is why `Project` indexes run *names* and nothing more: there is no second c
 `Experimenter` splits the data with an outer splitter (`sp`) and an optional inner splitter (`sp_v`), then:
 
 - `build()` runs the Pipeline's nodes fold by fold
-- `exp(trials, trial_store)` runs **Trials** — the candidate models — against those node outputs
+- `exp(trial_names)` runs **Trials** — the candidate models — against those node outputs
 
-Trials live outside the Pipeline. A Trial is a candidate *being compared*, which is why its definitions and per-fold outcomes go to the project-wide `TrialStore`: results only mean something next to other results.
+Trials live outside the Pipeline. A Trial is a candidate *being compared*, which is why its definitions and per-fold outcomes go to the project-wide `TrialStore`: results only mean something next to other results. That ownership is why a run is handed names rather than definitions — it is given the store once, at construction, and adding a Trial to the project is `Project.set_trial`, not a side effect of running one.
 
 **Collectors** attach to Trial runs and capture what happens — metrics, model attributes, SHAP values, out-of-fold predictions for stacking.
 

--- a/docs/concepts/state-model.md
+++ b/docs/concepts/state-model.md
@@ -26,7 +26,7 @@ If an upstream node is in `error`, everything downstream fails without any expli
 | Call | |
 |---|---|
 | `build(nodes)` | `init → built` for Pipeline nodes |
-| `exp(trials, trial_store)` | `init → built` for Trials |
+| `exp(trial_names)` | `init → built` for Trials |
 | `train(predictors)` | `init → built` for nodes, then Predictors |
 | `reset_nodes(nodes)` | any → `init`, deleting the artifacts |
 
@@ -40,12 +40,13 @@ Being already `built` is what makes a run skip work, and that is decided from di
 - **Trials** — skipped when `TrialStore.experiment_hist` records that fold as `'built'`.
 - **Predictors** — skipped when the artifact exists in the Trainer's predictor store.
 
-The consequence is worth stating plainly: **redefining a Trial or Predictor does not re-run it.** A fold already marked `'built'` is silently skipped. To force it, remove the record and the artifact:
+The consequence is worth stating plainly: **a fold already marked `'built'` is silently skipped, whatever the definition says now.** For Trials this is why `Project.set_trial` refuses to redefine a name that has a successful run behind it — the history would otherwise describe results a definition never produced. Running one again is explicit:
 
 ```python
-project.trials.remove_hist(trial_name='lgb', experimenter=e.name)
-e.reset_nodes(['lgb'])
+e.remove_trial_result('lgb')      # this run's results and its history
 ```
+
+For Predictors, which have no such guard, remove the artifact with `reset_nodes`.
 
 ## Staleness — comparing two Pipelines
 

--- a/docs/guide/collectors.md
+++ b/docs/guide/collectors.md
@@ -62,9 +62,9 @@ Connector(edges={'y': '{target}'})                 # exact per-key edge match
 ## Running with Collectors
 
 ```python
-e.exp(folds, project.trials)                                 # every Collector on this run
-e.exp(folds, project.trials, collectors=['acc', 'shap'])     # a subset, by name
-e.exp(folds, project.trials, collectors=[])                  # collect nothing
+e.exp(names)                                 # every Collector on this run
+e.exp(names, collectors=['acc', 'shap'])     # a subset, by name
+e.exp(names, collectors=[])                  # collect nothing
 ```
 
 `collectors=` takes **names** out of the run's own registry, the same way `processor` and `adapter` are string refs. An instance is rejected: a Collector this registry does not know has no place in this run to write to, and would quietly deposit its results outside it. An unregistered name raises `KeyError` — silently skipping would be indistinguishable from "collected nothing".

--- a/docs/guide/experimenter-trials.md
+++ b/docs/guide/experimenter-trials.md
@@ -77,36 +77,49 @@ trials = make_trials('lgb', 'lightgbm.LGBMClassifier',
 ```
 
 !!! warning "A Trial's name is its identity"
-    `TrialStore` is project-wide and keyed by name, so reusing a name overwrites that definition and its artifacts. Give a new configuration a new name.
+    `TrialStore` is project-wide and keyed by name, so a name is what history, results and every run's reference to it all hang on. Give a new configuration a new name.
+
+## Registering
+
+A Trial belongs to the project, so it is added there — separately from running it:
+
+```python
+names = project.set_trials(trials)     # ['lgb_0', 'lgb_1', 'lgb_2', 'lgb_3']
+project.set_trial(trial)               # 'lgb1', or None if unchanged
+```
+
+Both return only what was **added or changed**, so the return value is the work list for the next run. A definition identical to the stored one is not a change and comes back as `None` / omitted.
+
+A name that already ran successfully somewhere is frozen — `set_trial` raises rather than redefine it. The history is keyed by name and a Trial leaves no artifact, so a redefinition would silently leave the old results describing a definition that never produced them. Change one by giving it a new name, or `project.remove_trial(name)` to give up the results with it.
 
 ## Running
 
-`exp()` takes explicit `(trial, outer_idx, inner_idx)` triples — fold expansion happens in your code, so the executor runs exactly the list it is given.
+`exp()` takes Trial names. Each one runs on every fold of the run — folds are not something the caller spells out.
 
 ```python
-folds = [(t, o, i)
-         for t in trials
-         for o in range(e.get_n_splits())
-         for i in range(e.get_n_splits_inner())]
-
-e.exp(folds, project.trials, n_jobs=2, gpu_id_list=[0], logger=logger)
+e.exp(names, n_jobs=2, gpu_id_list=[0], logger=logger)
 ```
 
-`trial_store` is required — it is where definitions are registered, where per-fold outcomes are recorded, and what decides which folds are skipped as already `'built'`. Every Collector registered on the run takes part unless `collectors=` narrows it by name — see [Collectors](collectors.md).
+Folds already recorded `'built'` are dropped, so passing the same names again continues a partial run rather than repeating it.
 
-!!! note "Redefining a Trial does not re-run it"
-    A fold recorded as `'built'` is skipped silently. To force it:
+!!! note "`set_trials()` returns what changed, not what to run"
+    Its return value is an authoring diff — a Trial that was already registered and never ran comes back empty. To run a round, pass the names of that round and let `exp()` skip the folds that are done.
+
+The store itself is not an argument: an Experimenter made by `project.experimenter()` / `load_experimenter()` already holds it, and a standalone one takes it as `Experimenter(..., trial_store=...)`. An unregistered name raises `KeyError`. Every Collector registered on the run takes part unless `collectors=` narrows it by name — see [Collectors](collectors.md).
+
+!!! note "A built fold is not re-run"
+    A fold recorded as `'built'` is skipped silently, whatever the definition says now. To run it again:
 
     ```python
-    project.trials.remove_hist(trial_name='lgb1', experimenter=e.name)
-    e.reset_nodes(['lgb1'])
+    e.remove_trial_result('lgb1')   # this run's results and its history
     ```
 
 ## Reading results
 
 ```python
 e.get_status('scale')
-e.show_error_nodes(trial_store=project.trials)
+e.show_error_nodes()                              # this run's Pipeline nodes
+project.show_error_trials(experimenter=e.name)    # its Trials
 
 from IPython.display import Markdown, display
 display(Markdown(e.get_node_info()))
@@ -114,7 +127,15 @@ display(Markdown(e.get_node_info()))
 project.trials.get_hist(experimenter=e.name)
 ```
 
-Node errors live in the run's own history; Trial errors live in the `TrialStore`, which is why `show_error_nodes` takes the store to report both.
+The split follows the history: node errors are recorded in the run's own store, Trial errors in the project's `TrialStore`, so each is reported by whoever owns them. Both return one line per failed fold, or `None` when nothing failed.
+
+To ask what is still owed a run:
+
+```python
+project.pending_trials(experimenter=e.name)       # errored, or never run
+```
+
+Both cases need the same thing, so they come back as one list — a filter written by hand usually catches only the second and quietly drops the ones that failed. It is deliberately coarse: a Trial interrupted partway through its folds is not reported, since judging that means comparing history against a fold grid the store does not know. Running the names anyway is safe — `exp()` skips the folds that are done.
 
 To pull data out at a fold:
 
@@ -132,7 +153,7 @@ Progress bars and Python logging appear as usual; what escapes is output written
 ```python
 with e.os_log():
     e.build(n_jobs=1)
-    e.exp(folds, project.trials, n_jobs=4)
+    e.exp(names, n_jobs=4)
 
 e.get_worker_logs()          # {'master': ..., 0: ..., 1: ...}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,9 +30,9 @@ e = project.experimenter('cv', df, pipeline_name='main',
                          pipeline_version=project.build_pipeline(p).version)
 e.build()
 
-trial = Trial('lgb', 'lightgbm.LGBMClassifier',
-              {'X': 'scale:(*)', 'y': '{target}'}, method='predict')
-e.exp([(trial, 0, 0)], project.trials)
+project.set_trial(Trial('lgb', 'lightgbm.LGBMClassifier',
+                        {'X': 'scale:(*)', 'y': '{target}'}, method='predict'))
+e.exp(['lgb'])
 ```
 
 Three ideas run through all of it:

--- a/examples/kaggle_s6e6/2. Second Phase.ipynb
+++ b/examples/kaggle_s6e6/2. Second Phase.ipynb
@@ -17,7 +17,7 @@
     "| `p.build()` | `project.build_pipeline(p)` → 버전 부여 후 `e.set_pipeline(...)` |\n",
     "| `Experimenter(df, sp=, path=)` | `project.experimenter(name, df, ...)` / `project.load_experimenter(name, df)` |\n",
     "| `e.set_collector(...)` / `e.get_collector(...)` | `e.collectors` 레지스트리 (run 소유, 등록 즉시 영속화) |\n",
-    "| `e.exp(nodes='xgb1')` | `e.exp([(trial, outer, inner), ...], project.trials, collectors=[이름, ...])` |\n",
+    "| `e.exp(nodes='xgb1')` | `project.set_trials(trials)` 후 `e.exp([이름, ...], collectors=[이름, ...])` |\n",
     "| `e.exp(finalize=True)` | `finalize` 개념 없음 |\n",
     "| 수집 실패는 `collector.warnings` (메모리) | `e.collectors.hist` — **`CollectHist`** (fold 단위 이력) |\n",
     "\n",
@@ -572,17 +572,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def folds(trials):\n",
-    "    return [(t, o, i) for t in trials\n",
-    "            for o in range(e.get_n_splits())\n",
-    "            for i in range(e.get_n_splits_inner())]\n",
-    "\n",
-    "\n",
     "def run(trials, **kw):\n",
-    "    \"\"\"collectors 인자를 안 주면 이 run에 등록된 Collector 전부가 붙고,\n",
+    "    \"\"\"Trial은 프로젝트 소유라 저작(set_trials)과 실행(exp)이 분리돼 있다.\n",
+    "\n",
+    "    exp()에는 이름만 넘긴다 — 이름 하나가 전 fold를 뜻하고, 이미 'built'인\n",
+    "    fold는 알아서 빠지므로 중단된 라운드도 같은 호출로 이어진다.\n",
+    "    set_trials()의 반환은 '바뀐 것'이라 재개 목록이 아니다 — 그래서 여기선\n",
+    "    반환값이 아니라 넘긴 trial 전체의 이름을 쓴다.\n",
+    "\n",
+    "    collectors 인자를 안 주면 이 run에 등록된 Collector 전부가 붙고,\n",
     "    수집 이력도 e.collectors.hist에 남는다.\"\"\"\n",
+    "    project.set_trials(trials)\n",
     "    kw = {'n_jobs': 2, 'gpu_id_list': [0], 'logger': logger, **kw}\n",
-    "    e.exp(folds(trials), project.trials, **kw)"
+    "    e.exp([t.name for t in trials], **kw)"
    ]
   },
   {
@@ -1952,9 +1954,10 @@
     }
    ],
    "source": [
+    "# 수집 결과 + 이 run의 fold 이력을 함께 지운다 — 이력이 fold 스킵의\n",
+    "# 유일한 근거라, 이게 곧 '다시 돌려라'다.\n",
     "for t in missing:\n",
-    "    project.trials.remove_hist(trial_name=t.name, experimenter=e.name)\n",
-    "e.reset_nodes([t.name for t in missing])\n",
+    "    e.remove_trial_result(t.name)\n",
     "\n",
     "with e.os_log():\n",
     "    run(missing)"
@@ -2067,7 +2070,8 @@
     }
    ],
    "source": [
-    "e.show_error_nodes(trial_store=project.trials)\n",
+    "e.show_error_nodes()                            # 이 run의 Pipeline 노드\n",
+    "project.show_error_trials(experimenter=e.name)  # 그 Trial들\n",
     "display(Markdown(e.get_node_info()))"
    ]
   },
@@ -3375,8 +3379,10 @@
     "                 adapter=src.adapter, params=params)\n",
     "\n",
     "\n",
-    "# 이름을 새로 준다 — TrialStore는 이름이 PK이고 프로젝트 전역이라,\n",
-    "# 'lgb5'를 재사용하면 phase2의 그 정의를 덮어쓴다.\n",
+    "# 이름을 새로 준다 — TrialStore는 이름이 PK이고 프로젝트 전역이다.\n",
+    "# 'lgb5'를 재사용하면 project.set_trial이 거절한다: 그 이름엔 이미\n",
+    "# 성공 이력이 있어서, 재정의하면 옛 결과가 그걸 만든 적 없는 정의를\n",
+    "# 설명하게 된다.\n",
     "stk_trials = [stack_trial(f'{name}_stk', ALL_TRIALS[name], m, n)\n",
     "              for m, (name, n) in picked.items()]\n",
     "[(t.name, t.params.get('n_estimators', t.params.get('epochs'))) for t in stk_trials]\n"
@@ -3454,7 +3460,7 @@
     "한 가지 주의: `StackingCollector`는 outer fold 결과를 메모리(`_outer_buf`)에 모았다가 5개가 다\n",
     "차면 그때서야 `{node}.pkl`로 쓴다. 즉 **5 fold가 한 번의 `exp()` 호출에서 다 돌아야** 저장된다 —\n",
     "중간에 실패해 일부 fold만 `'built'`로 기록되면 다음 호출에서 그 fold들은 스킵되고, 버퍼가 영영\n",
-    "안 차서 파일이 안 생긴다. 그럴 땐 `project.trials.remove_hist(trial_name=..., experimenter=...)`로\n",
+    "안 차서 파일이 안 생긴다. 그럴 땐 `e_stk.remove_trial_result(이름)`으로 그 run의 수집 결과와\n",
     "fold 이력을 지우고 전부 다시 돌려야 한다.\n"
    ]
   },
@@ -3478,12 +3484,10 @@
     "    conn(node_query=[t.name for t in stk_trials], edges=y_edges),\n",
     "    params={'output_var': '1:', 'method': 'mean'}, exist='replace')\n",
     "\n",
-    "folds_stk = [(t, o, i) for t in stk_trials\n",
-    "             for o in range(e_stk.get_n_splits())\n",
-    "             for i in range(e_stk.get_n_splits_inner())]\n",
+    "project.set_trials(stk_trials)\n",
     "\n",
     "with e_stk.os_log():\n",
-    "    e_stk.exp(folds_stk, project.trials,\n",
+    "    e_stk.exp([t.name for t in stk_trials],\n",
     "              collectors=['stack_oof'],\n",
     "              n_jobs=2, gpu_id_list=[0], logger=logger)\n"
    ]

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -65,7 +65,7 @@ def _stop_native_redirect(state):
     sys.stdout = state['orig_stdout']
     sys.stderr = state['orig_stderr']
     state['log_f'].close()
-from ._run_common import resolve_common_status, require_built_pipeline
+from ._run_common import resolve_common_status, require_built_pipeline, format_errors
 
 
 
@@ -145,6 +145,13 @@ class Experimenter():
         data_key (str, optional): Identifier verified on reload to prevent
             data mismatch.
         cache (DataCache, optional): Shared LRU cache.
+        trial_store (TrialStore, optional): Where this run reads the Trials it
+            is asked to run and records what they did. Injected once, like
+            *cache*, rather than re-supplied per call — a project has exactly
+            one and it does not change over a run's life. It is not persisted:
+            a ``TrialStore`` is project-level, and a run reopened from its own
+            directory has no way to find one that would not amount to guessing
+            at the layout above it.
 
     Attributes:
         cache (DataCache): Shared LRU cache, or ``None``.
@@ -170,9 +177,10 @@ class Experimenter():
             self, path, name, data, data_names = None,
             sp = ShuffleSplit(n_splits=1, random_state=1), sp_v=None,
             splitter_params=None, title=None, data_key=None,
-            aug_data=None, cache=None
+            aug_data=None, cache=None, trial_store=None
         ):
         self.name = name
+        self.trial_store = trial_store
         self.path = Path(path)
         self.path.mkdir(parents=True, exist_ok=True)
         self._store = ExperimenterStore(self.path)
@@ -230,7 +238,8 @@ class Experimenter():
         self._save()
 
     @staticmethod
-    def load_experimenter(path, data, data_key=None, aug_data=None, cache=None):
+    def load_experimenter(path, data, data_key=None, aug_data=None, cache=None,
+                          trial_store=None):
         """Reopen the Experimenter rooted at *path*.
 
         Everything comes out of that directory — meta and splitters from its
@@ -245,6 +254,8 @@ class Experimenter():
                 given when the Experimenter was created.
             aug_data (optional): External data appended to inner train splits.
             cache (DataCache, optional): Shared LRU cache.
+            trial_store (TrialStore, optional): Not saved with the run, so a
+                reopened Experimenter has one only if it is given one here.
 
         Returns:
             Experimenter: The reopened run.
@@ -276,7 +287,8 @@ class Experimenter():
         exp = Experimenter(
             path, meta['name'], data,
             title=meta.get('title'), data_key=saved_data_key,
-            aug_data=aug_data, cache=cache, **split_kwargs,
+            aug_data=aug_data, cache=cache, trial_store=trial_store,
+            **split_kwargs,
         )
         pipeline = store.load_pipeline()
         if pipeline is not None:
@@ -388,6 +400,15 @@ class Experimenter():
             raise RuntimeError("No pipeline set. Call set_pipeline(pipeline) first.")
         return self.pipeline
 
+    def _require_trial_store(self):
+        if self.trial_store is None:
+            raise RuntimeError(
+                "No trial_store. An Experimenter made by Project.experimenter() / "
+                "load_experimenter() gets the project's; a standalone one takes it "
+                "as Experimenter(..., trial_store=...)."
+            )
+        return self.trial_store
+
     def get_n_splits(self):
         return len(self.outer_folds)
 
@@ -441,71 +462,57 @@ class Experimenter():
         if self.cache is not None:
             self.cache.clear_nodes(nodes)
 
-    def remove_trial_result(self, name, trial_store=None):
-        """Drop what this run has of Trial *name*.
+    def remove_trial_result(self, name):
+        """Drop what this run has of Trial *name* — its results and its history.
 
         A Trial leaves no artifact, so its result is whatever its Collectors
-        kept — held in this run's own registry, which
-        :meth:`Collectors.remove_results` clears along with the matching
-        ``CollectHist`` rows.
+        kept, held in this run's own registry; :meth:`Collectors.remove_results`
+        clears that along with the matching ``CollectHist`` rows. This run's
+        ``experiment_hist`` rows go too, which is what makes the next ``exp()``
+        run the Trial again: folds are skipped on the strength of a recorded
+        ``'built'`` status and nothing else, so the history is the only thing
+        holding one back.
 
-        Pass *trial_store* to drop this run's ``experiment_hist`` rows as well.
-        That is what makes the next ``exp()`` run the Trial again: folds are
-        skipped on the strength of a recorded ``'built'`` status and nothing
-        else, so the history is the only thing holding one back. Only this
-        Experimenter's rows go — another run's record of the same Trial is its
-        own. To remove the Trial from the project entirely, definition
-        included, use ``Project.remove_trial``.
+        Only this Experimenter's rows go — another run's record of the same
+        Trial is its own — and the definition stays, since it belongs to the
+        project. Removing that too is ``Project.remove_trial``.
+
+        The history half is skipped when this run has no :attr:`trial_store`,
+        leaving only the collected results to remove.
 
         Args:
             name (str): Trial name.
-            trial_store (TrialStore, optional): Where this run's Trial history
-                lives. Omitted, the history stays and the folds stay skipped.
         """
         self.collectors.remove_results(name)
-        if trial_store is not None:
-            trial_store.remove_hist(trial_name=name, experimenter=self.name)
+        if self.trial_store is not None:
+            self.trial_store.remove_hist(trial_name=name, experimenter=self.name)
 
-    def show_error_nodes(self, nodes=None, traceback=False, trial_store=None):
-        """Print nodes in ``error`` state.
+    def show_error_nodes(self, nodes=None, traceback=False):
+        """Errors from this run's Pipeline nodes, one line per failed fold.
 
-        Error detail no longer lives on the artifact itself (see
-        ``NodeStore``) — it's recorded in ``TrialStore.experiment_hist``
-        (Trials) or this run's own ``NodeStore`` history (Stages), so this
-        queries both instead of walking fold directories.
+        Pipeline nodes only, as the name says. Error detail does not live on
+        the artifact (see ``NodeStore``) — it is in this run's own
+        ``node_hist`` — so this reads history rather than walking fold
+        directories. Trial errors are the project's to report, since that is
+        where their history lives: ``Project.show_error_trials(experimenter=)``.
 
         Args:
             nodes (list[str], optional): Node names to check. ``None`` checks
                 every node recorded for this run.
             traceback (bool): Include full traceback in output.
-            trial_store (TrialStore, optional): Where Trial history for this
-                run lives. ``None`` skips the Trial half, reporting only
-                Stage errors from this run's own ``NodeStore``.
+
+        Returns:
+            list[str] | None: One line per failed fold, or ``None`` if clean.
         """
         rows = [
             (r['node_name'], r['outer_idx'], r['inner_idx'], r['info'])
             for r in self.node_store.get_hist()
             if r['status'] == 'error'
         ]
-        if trial_store is not None:
-            rows += [
-                (r['trial_name'], r['outer_idx'], r['inner_idx'], r['info'])
-                for r in trial_store.get_hist(experimenter=self.name)
-                if r['status'] == 'error'
-            ]
         if nodes is not None:
             node_set = set(nodes)
             rows = [r for r in rows if r[0] in node_set]
-
-        errors = list()
-        for name, outer_idx, inner_idx, info in rows:
-            err = (info or {}).get('error', {})
-            label = f"[{name}] fold {outer_idx}_{inner_idx}"
-            if traceback:
-                errors.append(f"{label} {err.get('type')}: {err.get('message')}\n{err.get('traceback')}")
-            else:
-                errors.append(f"{label} {err.get('type')}: {err.get('message')}")
-        return errors if errors else None
+        return format_errors(rows, traceback)
 
     def build(self, nodes=None, rebuild=False, n_jobs=1, gpu_id_list=None, logger=None):
         """Build Stage nodes.
@@ -590,18 +597,14 @@ class Experimenter():
                     jobs.append(Job(name, spec, outer_idx, inner_idx, flow, need_gpu=need_gpu))
         return jobs
 
-    def exp(self, trials, trial_store, collectors=None,
-            n_jobs=1, gpu_id_list=None, logger=None):
+    def exp(self, trials, collectors=None, n_jobs=1, gpu_id_list=None, logger=None):
         """Run *trials* against the Stage graph and invoke matching Collectors.
 
         Args:
-            trials: ``[(Trial, outer_idx, inner_idx), ...]`` — each entry names
-                exactly which fold a Trial runs on. Expanding folds here rather
-                than in the executor keeps fold policy in one place and lets the
-                dispatcher take its target list literally.
-            trial_store (TrialStore): Where Trial definitions are registered
-                and fold outcomes are recorded — also what decides which
-                folds are skipped as already built (see :meth:`_make_jobs`).
+            trials (list[str]): Trial names, out of :attr:`trial_store`. Each
+                runs on every fold of this run; folds already recorded
+                ``'built'`` are dropped, so passing the same names again
+                continues a partial run instead of repeating it.
             collectors (list[str], optional): Names to collect with, out of
                 this run's own :attr:`collectors` registry. ``None`` (default)
                 uses every Collector registered there; ``[]`` collects nothing.
@@ -611,19 +614,32 @@ class Experimenter():
             gpu_id_list (list, optional): GPU IDs to use for GPU-enabled trials.
             logger: Logger instance. Default: shared ``DefaultLogger.get_instance()``.
 
-        Trial definitions are registered in *trial_store*, and every fold
-        that actually runs records its outcome there as it finishes (see
-        :class:`~mllabs._tracker.TrialHistTracker`). Folds skipped as already
-        built produce no new row — their result was recorded when they ran.
+        **Names, not Trials.** A Trial belongs to the project, and this reads
+        it out of :attr:`trial_store` rather than taking a definition in.
+        Running was previously also how a Trial got registered, which put
+        authoring inside a run — you could not add one to the project without
+        executing it, and an ``exp()`` call could silently redefine a name
+        another run had already used. Authoring is ``Project.set_trial`` now,
+        and this only executes what is already there.
+
+        Every fold that actually runs records its outcome in the store as it
+        finishes (see :class:`~mllabs._tracker.TrialHistTracker`). Folds
+        skipped as already built produce no new row — their result was
+        recorded when they ran.
+
+        Raises:
+            RuntimeError: If this run has no ``trial_store``.
+            KeyError: If a name is not registered in it.
         """
         from ._executor import _execute_single, _execute_multi
         from ._tracker import LoggerExecuteTracker, TrialHistTracker
         logger = resolve_logger(logger)
         pipeline = self._require_pipeline()
         pipeline.check_data_compatibility(self.data)
+        trial_store = self._require_trial_store()
 
         collectors = self._resolve_collectors(collectors)
-        jobs = self._make_jobs(trials, trial_store)
+        jobs = self._make_jobs(trials)
         if not jobs:
             logger.info("No trials to run")
             return
@@ -633,7 +649,6 @@ class Experimenter():
             c.on_attach(self)
             c._setup(len(self.outer_folds), len(self.outer_folds[0].train_data_flows))
         n_jobs = min(n_jobs, len(jobs))
-        trial_store.register_all(t for t, _, _ in trials)
         tracker = TrialHistTracker(
             LoggerExecuteTracker(len(jobs), n_jobs, logger),
             trial_store, self.name, self.pipeline_version,
@@ -681,40 +696,58 @@ class Experimenter():
                 )
         return self.collectors.resolve(names)
 
-    def _make_jobs(self, trials, trial_store):
-        """Expand ``(Trial, outer, inner)`` entries into runnable Jobs.
+    def _make_jobs(self, trials):
+        """Expand Trial names into one Job per fold that still needs running.
 
-        A fold is skipped only if ``TrialStore.experiment_hist`` already has
-        it recorded as ``'built'`` — a fold recorded as ``'error'``, or with
-        no history row at all, gets a job. Whether the Trial's definition
-        changed since that history was recorded is not checked here; history
-        is the sole source of truth for what still needs to run, and it can
-        be, since a Trial leaves nothing on disk that could disagree with it.
-        Rerunning one is therefore ``TrialStore.remove_hist(...)`` and
-        nothing else.
+        A name means the whole grid: every ``(outer_idx, inner_idx)`` of this
+        run. Fold selection is not something a caller has to spell out —
+        ``'built'`` folds are dropped here, so handing the same names back
+        after a partial run continues it rather than repeating it.
+
+        A fold is skipped only if ``TrialStore.experiment_hist`` records it as
+        ``'built'``; one recorded ``'error'``, or with no row at all, gets a
+        job. Whether the definition changed since is not checked, and can no
+        longer differ silently: ``Project.set_trial`` refuses to redefine a
+        name that has a successful run behind it. Rerunning one is
+        :meth:`remove_trial_result` and nothing else.
+
+        The definition, its spec and its GPU verdict are resolved once per
+        name, not once per fold.
         """
         from ._executor import Job
         from .adapter import resolve_node_adapter
         from .adapter._base import GPU_NO
 
-        gpu_cache = {}
-        hist_cache = {}
+        trial_store = self._require_trial_store()
+        folds = [(o, i)
+                 for o in range(len(self.outer_folds))
+                 for i in range(len(self.outer_folds[o].train_data_flows))]
+
         jobs = []
-        for trial, outer_idx, inner_idx in trials:
-            flow = self.outer_folds[outer_idx].train_data_flows[inner_idx]
+        for name in trials:
+            if not isinstance(name, str):
+                raise TypeError(
+                    f"exp(trials=): expected Trial names, got "
+                    f"{type(name).__name__}. Register the Trial with "
+                    f"project.set_trial(trial) and pass its name."
+                )
+            trial = trial_store.get_by_name(name)
+            if trial is None:
+                raise KeyError(
+                    f"Trial '{name}' is not registered. Add it with "
+                    f"project.set_trial(trial) before running it."
+                )
             spec = trial.get_spec()
+            adapter = resolve_node_adapter(spec.processor, spec.adapter)
+            need_gpu = adapter.get_gpu_usage(spec.params) != GPU_NO
+            status = trial_store.get_status(name, self.name)
 
-            if trial.name not in hist_cache:
-                hist_cache[trial.name] = trial_store.get_status(trial.name, self.name)
-            if hist_cache[trial.name].get((outer_idx, inner_idx)) == 'built':
-                continue
-
-            if trial.name not in gpu_cache:
-                adapter = resolve_node_adapter(spec.processor, spec.adapter)
-                gpu_cache[trial.name] = adapter.get_gpu_usage(spec.params) != GPU_NO
-
-            jobs.append(Job(trial.name, spec, outer_idx, inner_idx, flow,
-                            need_gpu=gpu_cache[trial.name]))
+            for outer_idx, inner_idx in folds:
+                if status.get((outer_idx, inner_idx)) == 'built':
+                    continue
+                flow = self.outer_folds[outer_idx].train_data_flows[inner_idx]
+                jobs.append(Job(name, spec, outer_idx, inner_idx, flow,
+                                need_gpu=need_gpu))
         return jobs
 
     def get_train_data(self, edges, o_idx=0, i_idx=0):

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from ._cache import DataCache
 from ._trial_store import TrialStore
 from ._project_store import ProjectStore
+from ._run_common import format_errors
 from .collector import Collectors
 
 
@@ -95,7 +96,8 @@ class Project:
         for the new run to adopt.
         """
         from ._experimenter import Experimenter
-        exp = Experimenter(self.exp_path(name), name, data, cache=self.cache, **kwargs)
+        exp = Experimenter(self.exp_path(name), name, data, cache=self.cache,
+                           trial_store=self.trials, **kwargs)
         self.store.register_experimenter(name)
         if pipeline_version is not None:
             exp.set_pipeline(self.load_pipeline(pipeline_name, pipeline_version),
@@ -122,7 +124,7 @@ class Project:
         from ._experimenter import Experimenter
         return Experimenter.load_experimenter(
             self.exp_path(name), data, data_key=data_key,
-            aug_data=aug_data, cache=self.cache,
+            aug_data=aug_data, cache=self.cache, trial_store=self.trials,
         )
 
     def trainer(self, name, data, pipeline_name='pipeline', pipeline_version=None, **kwargs):
@@ -156,6 +158,110 @@ class Project:
     def list_trainers(self):
         """Names of every Trainer created through this project."""
         return self.store.list_trainers()
+
+    def set_trial(self, trial):
+        """Add or update one Trial definition. Returns its name if anything changed.
+
+        Authoring a Trial is a project-level act, separate from running one.
+        Registration used to be a side effect of ``Experimenter.exp()``, which
+        meant a Trial could not enter the project without being executed, and
+        that one run could redefine a name another run had already used.
+
+        A name that already has a **successful** run behind it is frozen. The
+        history is keyed by name, and a Trial leaves no artifact, so a
+        redefinition would silently attach the old results to a definition
+        that never produced them — the rows would look like one Trial's record
+        and be two. Changing such a Trial means either a new name, or
+        :meth:`remove_trial` to give up the results with it.
+
+        Args:
+            trial (Trial): Definition to store.
+
+        Returns:
+            str | None: *trial*'s name if it was added or changed, ``None`` if
+            the stored definition already matched — so the return value is the
+            work list for the next ``exp()``.
+
+        Raises:
+            ValueError: If the name has a ``'built'`` fold in
+                ``experiment_hist`` and the definition differs from the
+                stored one.
+        """
+        changed = self.set_trials([trial])
+        return changed[0] if changed else None
+
+    def set_trials(self, trials):
+        """:meth:`set_trial` for many. Returns the names that were added or changed.
+
+        Nothing is written until every Trial has been checked, so a batch
+        holding one frozen name changes nothing at all rather than leaving
+        half of itself registered.
+        """
+        changed = [t for t in trials if not self.trials.has(t)]
+        for trial in changed:
+            built = self.trials.get_hist(trial_name=trial.name, status='built')
+            if built:
+                runs = sorted({r['experimenter'] for r in built})
+                raise ValueError(
+                    f"Trial '{trial.name}' already ran successfully in {runs} and "
+                    f"cannot be redefined — its history would then describe a "
+                    f"definition that never produced it. Use a new name, or "
+                    f"project.remove_trial({trial.name!r}) to drop the results too."
+                )
+        self.trials.register_all(changed)
+        return [t.name for t in changed]
+
+    def show_error_trials(self, experimenter=None, traceback=False):
+        """Errors from Trial runs, one line per failed fold.
+
+        The Trial counterpart of ``Experimenter.show_error_nodes``, and it
+        lives here for the same reason that one lives on the run: a failure is
+        reported by whoever owns the history it is recorded in. Node history
+        is the run's; Trial history is the project's, keyed by experimenter.
+
+        Args:
+            experimenter (str, optional): Report only this run's failures.
+                ``None`` reports every run's.
+            traceback (bool): Include full traceback in output.
+
+        Returns:
+            list[str] | None: One line per failed fold, or ``None`` if clean.
+        """
+        rows = [
+            (r['trial_name'], r['outer_idx'], r['inner_idx'], r['info'])
+            for r in self.trials.get_hist(experimenter=experimenter, status='error')
+        ]
+        return format_errors(rows, traceback)
+
+    def pending_trials(self, experimenter=None):
+        """Registered Trials that errored or have not run.
+
+        The work list: a Trial with an ``'error'`` fold, and one with no
+        history at all, both still owe a run and are indistinguishable in what
+        they need. Written by hand this filter tends to catch only the second
+        — the notebook's version did, so an errored Trial silently dropped out
+        of the list of things left to do.
+
+        Deliberately coarse: a Trial whose run was interrupted partway through
+        the folds is *not* reported, because deciding that means comparing
+        history against a fold grid this store does not know. Running the
+        returned names is safe either way — ``exp()`` skips the folds that
+        are done.
+
+        Args:
+            experimenter (str, optional): Judge against this run's history.
+                ``None`` asks whether a Trial ran anywhere in the project.
+
+        Returns:
+            list[str]: Trial names, in registration order.
+        """
+        pending = []
+        for trial in self.trials.list_trials():
+            rows = self.trials.get_hist(trial_name=trial.name,
+                                        experimenter=experimenter)
+            if not rows or any(r['status'] == 'error' for r in rows):
+                pending.append(trial.name)
+        return pending
 
     def remove_trial(self, name, experimenters=None):
         """Drop *name* from the project — definition, history and collected data.

--- a/mllabs/_run_common.py
+++ b/mllabs/_run_common.py
@@ -57,3 +57,24 @@ def resolve_common_status(statuses):
     if not statuses:
         return None
     return statuses.pop() if len(statuses) == 1 else 'inconsistent'
+
+
+def format_errors(rows, traceback=False):
+    """``(name, outer_idx, inner_idx, info)`` rows as printable error lines.
+
+    Shared by the node-side and Trial-side reporters, which read different
+    stores but describe a failure the same way.
+
+    Returns:
+        list[str] | None: One line per row, or ``None`` if there were none —
+        so an empty result reads as "nothing failed" at a glance.
+    """
+    errors = []
+    for name, outer_idx, inner_idx, info in rows:
+        err = (info or {}).get('error', {})
+        label = f"[{name}] fold {outer_idx}_{inner_idx}"
+        line = f"{label} {err.get('type')}: {err.get('message')}"
+        if traceback:
+            line += f"\n{err.get('traceback')}"
+        errors.append(line)
+    return errors or None

--- a/mllabs/_trial_store.py
+++ b/mllabs/_trial_store.py
@@ -46,6 +46,7 @@ import sqlite3
 from pathlib import Path
 
 from ._store import ArtifactStore
+from ._trial import Trial
 
 _SCHEMA_SQL = """
     CREATE TABLE IF NOT EXISTS trials (
@@ -134,17 +135,23 @@ class TrialStore(ArtifactStore):
             conn.execute("DELETE FROM trials WHERE name = ?", (name,))
 
     def has(self, trial):
-        """Whether *trial*'s exact definition is the one stored under its name."""
-        row = self.get_by_name(trial.name)
-        return (row is not None
-                and row['processor'] == trial.processor
-                and row['method'] == trial.method
-                and row['adapter'] == trial.adapter
-                and row['params'] == trial.params
-                and row['edges'] == trial.edges)
+        """Whether *trial*'s exact definition is the one stored under its name.
+
+        ``False`` when nothing is stored under the name at all, so a caller
+        guarding a redefinition does not have to check for absence separately.
+        Compares what execution depends on; ``desc``/``tag`` are display and
+        selection metadata and do not make a definition a different one.
+        """
+        stored = self.get_by_name(trial.name)
+        return (stored is not None
+                and stored.processor == trial.processor
+                and stored.method == trial.method
+                and stored.adapter == trial.adapter
+                and stored.params == trial.params
+                and stored.edges == trial.edges)
 
     def get_by_name(self, name):
-        """Stored definition for *name*, or ``None``."""
+        """Stored definition for *name* as a :class:`~mllabs.Trial`, or ``None``."""
         with sqlite3.connect(str(self.db_path)) as conn:
             conn.row_factory = sqlite3.Row
             row = conn.execute(
@@ -160,16 +167,23 @@ class TrialStore(ArtifactStore):
 
     @staticmethod
     def _row_to_trial(row):
-        return {
-            'name': row['name'],
-            'desc': row['desc'],
-            'processor': row['processor'],
-            'method': row['method'],
-            'adapter': json.loads(row['adapter']) if row['adapter'] else None,
-            'params': json.loads(row['params']) if row['params'] else {},
-            'edges': json.loads(row['edges']) if row['edges'] else {},
-            'tag': json.loads(row['tag']) if row['tag'] else [],
-        }
+        """A row back as the :class:`~mllabs.Trial` it was stored from.
+
+        Definitions come back as objects rather than dicts because this store
+        is now where a run reads the Trial it is about to execute:
+        ``Experimenter.exp`` is given names and resolves them here, so what
+        comes out has to be the same thing that went in.
+        """
+        return Trial(
+            name=row['name'],
+            processor=row['processor'],
+            edges=json.loads(row['edges']) if row['edges'] else {},
+            method=row['method'],
+            adapter=json.loads(row['adapter']) if row['adapter'] else None,
+            params=json.loads(row['params']) if row['params'] else {},
+            desc=row['desc'],
+            tag=json.loads(row['tag']) if row['tag'] else [],
+        )
 
     # ------------------------------------------------------------------
     # history
@@ -200,7 +214,8 @@ class TrialStore(ArtifactStore):
                  pipeline_version, status, json.dumps(info) if info is not None else None),
             )
 
-    def get_hist(self, trial_name=None, experimenter=None, pipeline_version=None):
+    def get_hist(self, trial_name=None, experimenter=None, pipeline_version=None,
+                 status=None):
         """History rows matching whichever filters are given.
 
         Each row's ``info`` is decoded back into a dict (``None`` if it was
@@ -209,7 +224,8 @@ class TrialStore(ArtifactStore):
         where, params = [], []
         for column, value in (('trial_name', trial_name),
                               ('experimenter', experimenter),
-                              ('pipeline_version', pipeline_version)):
+                              ('pipeline_version', pipeline_version),
+                              ('status', status)):
             if value is not None:
                 where.append(f"{column} = ?")
                 params.append(value)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -50,9 +50,11 @@ def _pipeline_version(project, name):
     return project.build_pipeline(p).version
 
 
-def _all_folds(trial, e):
-    """(trial, outer_idx, inner_idx) for every fold of *e* — what Experimenter.exp expects."""
-    return [(trial, o, i) for o in range(e.get_n_splits()) for i in range(e.get_n_splits_inner())]
+def _register(trial, e):
+    """Register *trial* and return the name — exp() takes names, reads the
+    definition out of the store, and covers every fold of *e* itself."""
+    e.trial_store.register(trial)
+    return trial.name
 
 
 def _run(built, *trials, collectors=None, n_jobs=1):
@@ -69,8 +71,8 @@ def _run(built, *trials, collectors=None, n_jobs=1):
     Trial(s) through exp() together with whatever Collector it's testing.
     """
     trials = trials or (built.trial,)
-    folds = [f for t in trials for f in _all_folds(t, built.e)]
-    built.e.exp(folds, built.project.trials, collectors=collectors, n_jobs=n_jobs)
+    names = [_register(t, built.e) for t in trials]
+    built.e.exp(names, collectors=collectors, n_jobs=n_jobs)
 
 
 @pytest.fixture
@@ -940,7 +942,7 @@ class TestRegistryIsPerRun:
         mc = e.collectors.set_collector(
             'acc', MetricCollector, Connector(),
             params={'output_var': None, 'metric_func': accuracy_metric})
-        e.exp(_all_folds(trial, e), project.trials)
+        e.exp([_register(trial, e)])
         return e, mc
 
     @pytest.fixture
@@ -987,10 +989,10 @@ class TestRegistryIsPerRun:
         next exp() dispatch the Trial again."""
         project, (e_a, mc_a), _ = two_runs
         trial = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 42})
-        e_a.remove_trial_result('dt', project.trials)
+        e_a.remove_trial_result('dt')
 
         assert project.trials.get_status('dt', e_a.name) == {}
-        e_a.exp(_all_folds(trial, e_a), project.trials)
+        e_a.exp([_register(trial, e_a)])
         assert mc_a.get_metric('dt') is not None
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -55,12 +55,13 @@ def pipeline():
 
 
 @pytest.fixture
-def exp(tmp_path, sample_data, pipeline):
+def exp(tmp_path, sample_data, pipeline, trial_store):
     e = Experimenter(
         name='e1',
         data=sample_data,
         path=tmp_path / 'exp',
         sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
+        trial_store=trial_store,
     )
     e.set_pipeline(pipeline.build())
     return e
@@ -104,16 +105,12 @@ def _wp():
     ]
 
 
-def _folds(trials, exp):
-    """Expand a bare Trial list into the ``(trial, outer_idx, inner_idx)``
-    tuples Experimenter.exp expects, across every fold of *exp* — Trainer's
-    set_trials() takes the bare list, but Experimenter.exp() doesn't."""
-    return [
-        (t, o, i)
-        for t in trials
-        for o in range(exp.get_n_splits())
-        for i in range(exp.get_n_splits_inner())
-    ]
+def _names(trials, exp):
+    """Register a bare Trial list and return the names Experimenter.exp takes.
+
+    Each name covers every fold of *exp* — exp() expands the grid itself."""
+    exp.trial_store.register_all(trials)
+    return [t.name for t in trials]
 
 
 def _stage_errored(exp, node_name):
@@ -197,7 +194,7 @@ class TestNJobsCap:
         exp.build(n_jobs=2)
 
         logger = RecordingLogger()
-        exp.exp(_folds(_model(), exp), trial_store, n_jobs=8, logger=logger)  # 2 folds x 1 head = 2 tasks
+        exp.exp(_names(_model(), exp), n_jobs=8, logger=logger)  # 2 folds x 1 head = 2 tasks
 
         worker_sessions = [s for s in logger.created if s != 0]
         assert worker_sessions == [1, 2]
@@ -320,7 +317,7 @@ class TestWorkerWarningVerbosity:
         exp.collectors.set_collector('m', MetricCollector, Connector(),
                                      params={'output_var': None, 'metric_func': _const_metric})
         logger = ProgressSessionLogger(level=['info', 'progress'])  # no 'warning'
-        exp.exp(_folds(_wp(), exp), trial_store, ['m'], logger=logger)
+        exp.exp(_names(_wp(), exp), ['m'], logger=logger)
 
         assert any('PREDICT_WARN_XYZ' in w for w in logger.warning_list)
         assert any('[wp_node]' in w for w in logger.warning_list)   # node prefix present
@@ -378,7 +375,7 @@ class TestDataPrepErrors:
         _setup_full(pipeline, exp)
 
         exp.build(n_jobs=1)
-        exp.exp(_folds(_bad_edges(), exp), trial_store, n_jobs=1)
+        exp.exp(_names(_bad_edges(), exp), n_jobs=1)
 
         assert _trial_built(trial_store, 'dt', exp)
         assert _trial_errored(trial_store, 'bad_dt', exp)
@@ -387,7 +384,7 @@ class TestDataPrepErrors:
         _setup_full(pipeline, exp)
 
         exp.build(n_jobs=2)
-        exp.exp(_folds(_bad_edges(), exp), trial_store, n_jobs=2)
+        exp.exp(_names(_bad_edges(), exp), n_jobs=2)
 
         assert _trial_built(trial_store, 'dt', exp)
         assert _trial_errored(trial_store, 'bad_dt', exp)
@@ -400,7 +397,7 @@ class TestErrorKeyShape:
     the same trial failed on more than one inner fold of the same outer fold."""
 
     @pytest.fixture
-    def exp_inner(self, tmp_path, sample_data, pipeline):
+    def exp_inner(self, tmp_path, sample_data, pipeline, trial_store):
         """Two outer folds x two inner folds — the layout the collapse lost."""
         e = Experimenter(
             name='e_inner',
@@ -408,28 +405,29 @@ class TestErrorKeyShape:
             path=tmp_path / 'exp_inner',
             sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=42),
             sp_v=KFold(n_splits=2),
+            trial_store=trial_store,
         )
         e.set_pipeline(pipeline.build())
         return e
 
-    def _bad_jobs(self, exp_inner, pipeline, trial_store):
+    def _bad_jobs(self, exp_inner, pipeline):
         _setup_full(pipeline, exp_inner)
         exp_inner.build(n_jobs=1)
         bad = _dt('bad_dt', {'X': 'scaler:([)', 'y': '{target}'})
-        return exp_inner._make_jobs(_folds([bad], exp_inner), trial_store)
+        return exp_inner._make_jobs(_names([bad], exp_inner))
 
     _EXPECTED = {(o, i, 'bad_dt') for o in range(2) for i in range(2)}
 
-    def test_single_keys_every_failed_job(self, exp_inner, pipeline, trial_store):
+    def test_single_keys_every_failed_job(self, exp_inner, pipeline):
         from mllabs._executor import _execute_single
-        jobs = self._bad_jobs(exp_inner, pipeline, trial_store)
+        jobs = self._bad_jobs(exp_inner, pipeline)
         assert len(jobs) == 4
         errors = _execute_single(jobs, exp_inner.node_store, collectors=[])
         assert set(errors) == self._EXPECTED
 
-    def test_multi_keys_every_failed_job(self, exp_inner, pipeline, trial_store):
+    def test_multi_keys_every_failed_job(self, exp_inner, pipeline):
         from mllabs._executor import _execute_multi
-        jobs = self._bad_jobs(exp_inner, pipeline, trial_store)
+        jobs = self._bad_jobs(exp_inner, pipeline)
         errors = _execute_multi(jobs, 2, exp_inner.node_store, collectors=[])
         assert set(errors) == self._EXPECTED
 
@@ -441,7 +439,7 @@ class TestExperimentMulti:
         _setup_full(pipeline, exp)
 
         exp.build(n_jobs=2)
-        exp.exp(_folds(_bad_edges(), exp), trial_store, n_jobs=2)
+        exp.exp(_names(_bad_edges(), exp), n_jobs=2)
 
         assert _trial_built(trial_store, 'dt', exp)
         assert _trial_errored(trial_store, 'bad_dt', exp)
@@ -511,7 +509,7 @@ class TestWorkerDeath:
         before = {p.pid for p in multiprocessing.active_children()}
 
         exp.build(n_jobs=2)
-        exp.exp(_folds(_model(), exp), trial_store, n_jobs=2)
+        exp.exp(_names(_model(), exp), n_jobs=2)
 
         leaked = {p.pid for p in multiprocessing.active_children()} - before
         assert not leaked

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -90,8 +90,14 @@ def _dt(name='dt', edges=None):
 
 
 def _folds(trial, exp):
-    """(trial, outer_idx, inner_idx) for every fold of *exp* — what Experimenter.exp expects."""
-    return [(trial, o, i) for o in range(exp.get_n_splits()) for i in range(exp.get_n_splits_inner())]
+    """Register *trial* and return the name list Experimenter.exp expects.
+
+    exp() takes names and reads the definition out of the store, so a test
+    Trial has to be in there first. Registering through the store rather than
+    Project.set_trial deliberately skips the redefinition guard — several
+    tests below redefine a name on purpose to check what a rerun does."""
+    exp.trial_store.register(trial)
+    return [trial.name]
 
 
 def _flow(exp, outer=0, inner=0):
@@ -255,22 +261,80 @@ class TestBuild:
         assert 'Unknown column' in info['error']['message']
 
 
+class TestExpTakesNames:
+    """exp() is handed Trial names and reads the definitions out of the store.
+
+    A Trial belongs to the project, so running one is not also how it gets
+    there: registration used to be a side effect of exp(), which meant a Trial
+    could not be added without executing it, and one run could redefine a name
+    another had already used."""
+
+    def test_a_name_resolves_to_the_stored_definition(self, exp, project):
+        project.set_trial(Trial('dt', TREE, DT_EDGES, params={'max_depth': 7}))
+        jobs = exp._make_jobs(['dt'])
+        assert {j.spec.params['max_depth'] for j in jobs} == {7}
+
+    def test_a_name_covers_every_fold(self, exp, project):
+        """A name means the whole grid — the caller does not spell out folds."""
+        project.set_trial(_dt())
+        jobs = exp._make_jobs(['dt'])
+        assert {(j.outer_idx, j.inner_idx) for j in jobs} == {
+            (o, i) for o in range(exp.get_n_splits())
+            for i in range(exp.get_n_splits_inner())}
+
+    def test_built_folds_are_dropped_so_the_same_names_continue(self, exp, project):
+        """Passing the same names after a partial run continues it."""
+        project.set_trial(_dt())
+        exp.trial_store.record('dt', exp.name, 0, 0, status='built')
+        jobs = exp._make_jobs(['dt'])
+        assert (0, 0) not in {(j.outer_idx, j.inner_idx) for j in jobs}
+        assert (1, 0) in {(j.outer_idx, j.inner_idx) for j in jobs}
+
+    def test_an_unregistered_name_raises(self, exp, project):
+        with pytest.raises(KeyError, match='not registered'):
+            exp.exp(['nope'])
+
+    def test_a_trial_instance_is_not_accepted(self, exp, project):
+        """Caught explicitly — passed through, an instance reaches sqlite as a
+        bind parameter and the error says nothing about what the caller did."""
+        with pytest.raises(TypeError, match='set_trial'):
+            exp.exp([_dt()])
+
+    def test_running_does_not_register(self, exp, project):
+        """Authoring is Project.set_trial — exp() only executes what is there."""
+        project.set_trial(_dt())
+        exp.exp(['dt'])
+        assert len(project.trials.list_trials()) == 1
+
+    def test_without_a_trial_store_it_refuses(self, tmp_path, sample_data, pipeline):
+        standalone = Experimenter(path=tmp_path / 'solo', name='solo', data=sample_data)
+        standalone.set_pipeline(pipeline.build())
+        with pytest.raises(RuntimeError, match='trial_store'):
+            standalone.exp(['dt'])
+
+    def test_a_project_run_is_given_the_projects_store(self, exp, project):
+        assert exp.trial_store is project.trials
+
+    def test_a_reopened_run_is_given_it_too(self, project, sample_data, exp):
+        assert project.load_experimenter('e1', sample_data).trial_store is project.trials
+
+
 class TestExp:
     def test_exp_head(self, exp, pipeline, project):
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         assert _trial_built(project.trials, 'dt', exp)
 
     def test_exp_skips_built(self, exp, pipeline, project):
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         build_id = project.trials.get_info('dt', exp.name)[(0, 0)]['build_id']
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         assert project.trials.get_info('dt', exp.name)[(0, 0)]['build_id'] == build_id
 
     def test_exp_error(self, exp, pipeline, project):
         bad_trial = Trial('bad_dt', 'mock.BadPredictor', {'X': '{f1}', 'y': '{target}'})
-        exp.exp(_folds(bad_trial, exp), project.trials)
+        exp.exp(_folds(bad_trial, exp))
         assert _trial_errored(project.trials, 'bad_dt', exp)
 
     def test_exp_with_collector(self, exp, pipeline, project):
@@ -279,7 +343,7 @@ class TestExp:
             'acc', MetricCollector, Connector(),
             params={'output_var': None, 'metric_func': accuracy_metric},
         )
-        exp.exp(_folds(trial, exp), project.trials, collectors=['acc'])
+        exp.exp(_folds(trial, exp), collectors=['acc'])
         assert mc.has_node('dt')
 
     def test_set_collector_resolves_callable_metric(self, exp, pipeline, project):
@@ -291,7 +355,7 @@ class TestExp:
                     'metric_func': {'__callable__': 'sklearn.metrics.balanced_accuracy_score'}},
         )
         assert mc.metric_func is balanced_accuracy_score
-        exp.exp(_folds(trial, exp), project.trials, collectors=['bacc'])
+        exp.exp(_folds(trial, exp), collectors=['bacc'])
         assert mc.has_node('dt')
 
     def test_the_run_restores_its_own_collectors(self, exp, pipeline, project, sample_data):
@@ -369,7 +433,7 @@ class TestTrialLeavesNoArtifact:
 
     def test_nothing_on_disk_and_nothing_in_the_flow(self, exp, project):
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         flow = _flow(exp)
         assert not flow.node_path('dt').exists()
         assert 'dt' not in flow.list_nodes()
@@ -380,7 +444,7 @@ class TestTrialLeavesNoArtifact:
 
     def test_the_outcome_is_still_recorded(self, exp, project):
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         status = project.trials.get_status('dt', exp.name)
         assert status
         assert set(status.values()) == {'built'}
@@ -388,7 +452,7 @@ class TestTrialLeavesNoArtifact:
     def test_nodes_are_unaffected(self, exp, pipeline, project):
         _setup_stage(pipeline, exp)
         exp.build()
-        exp.exp(_folds(_dt(), exp), project.trials)
+        exp.exp(_folds(_dt(), exp))
         flow = _flow(exp)
         assert flow.status('scaler') == 'built'
         assert 'scaler' in flow.node_objs
@@ -399,19 +463,19 @@ class TestTrialLeavesNoArtifact:
         _setup_stage(pipeline, exp)
         exp.build()
         trial = _dt(edges={'X': 'scaler:(*)', 'y': '{target}'})
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         assert set(project.trials.get_status('dt', exp.name).values()) == {'built'}
 
     def test_rerun_needs_only_remove_hist(self, exp, project):
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         project.trials.remove_hist(trial_name='dt', experimenter=exp.name)
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         assert set(project.trials.get_status('dt', exp.name).values()) == {'built'}
 
     def test_a_failed_trial_records_the_error_and_leaves_nothing(self, exp, project):
         bad = Trial('dt', 'mock.BadPredictor', DT_EDGES)
-        exp.exp(_folds(bad, exp), project.trials)
+        exp.exp(_folds(bad, exp))
         flow = _flow(exp)
         assert not flow.node_path('dt').exists()
         info = project.trials.get_info('dt', exp.name)[(0, 0)]
@@ -422,16 +486,16 @@ class TestTrialLeavesNoArtifact:
     def test_a_failed_fold_is_retried_on_the_next_exp(self, exp, project):
         """'error' is not 'built', so the fold gets a job again — no reset
         needed, and nothing stale can be left behind to confuse it."""
-        exp.exp(_folds(Trial('dt', 'mock.BadPredictor', DT_EDGES), exp), project.trials)
+        exp.exp(_folds(Trial('dt', 'mock.BadPredictor', DT_EDGES), exp))
         assert set(project.trials.get_status('dt', exp.name).values()) == {'error'}
-        exp.exp(_folds(_dt(), exp), project.trials)
+        exp.exp(_folds(_dt(), exp))
         assert _trial_built(project.trials, 'dt', exp)
 
     def test_reset_nodes_on_a_trial_name_is_inert(self, exp, project):
         """It has nothing to remove, so it cannot leave history asserting a
         result whose artifact is gone (#127)."""
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         exp.reset_nodes(['dt'])
         assert set(project.trials.get_status('dt', exp.name).values()) == {'built'}
 
@@ -465,9 +529,9 @@ class TestRebuild:
         """experiment_hist is the whole skip decision — a Trial persists
         nothing that could disagree with it."""
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         first = project.trials.get_hist(trial_name='dt', experimenter=exp.name)
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         second = project.trials.get_hist(trial_name='dt', experimenter=exp.name)
         assert [r['info']['build_id'] for r in first] == [r['info']['build_id'] for r in second]
 
@@ -538,7 +602,7 @@ class TestSaveLoad:
         _setup_stage(pipeline, exp)
         exp.build()
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
 
         loaded = project.load_experimenter(exp.name, sample_data)
         flow = loaded.outer_folds[0].train_data_flows[0]
@@ -554,7 +618,7 @@ class TestSaveLoad:
         assert loaded.pipeline is not None
         assert 'scaler' in loaded.pipeline.nodes
         trial = _dt()
-        loaded.exp(_folds(trial, loaded), project.trials)  # uses restored pipeline, no set_pipeline needed
+        loaded.exp(_folds(trial, loaded))  # uses restored pipeline, no set_pipeline needed
         assert _trial_built(project.trials, 'dt', loaded)
 
     def test_load_data_key_mismatch(self, project, sample_data):
@@ -602,13 +666,13 @@ class TestGetStatus:
         """A Trial persists nothing, so it never shows here however often it
         has run — its status is TrialStore's to answer."""
         trial = _dt()
-        exp.exp(_folds(trial, exp), project.trials)
+        exp.exp(_folds(trial, exp))
         assert exp.get_status('dt') is None
         assert _trial_built(project.trials, 'dt', exp)
 
     def test_get_status_error(self, exp, pipeline, project):
         bad_trial = Trial('bad_dt', 'mock.BadPredictor', {'X': '{f1}', 'y': '{target}'})
-        exp.exp(_folds(bad_trial, exp), project.trials)
+        exp.exp(_folds(bad_trial, exp))
         assert _trial_errored(project.trials, 'bad_dt', exp)
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -143,6 +143,71 @@ class TestPipelineVersions:
         assert [r['version'] for r in project.list_pipeline_versions('main')] == [1, 2]
 
 
+class TestSetTrial:
+    """Authoring a Trial is a project-level act, separate from running one.
+
+    Registration used to be a side effect of Experimenter.exp(), so a Trial
+    could not enter the project without being executed, and a rerun could
+    redefine a name whose history described the old definition."""
+
+    def test_adding_returns_the_name(self, project):
+        assert project.set_trial(_trial()) == 'dt'
+        assert project.trials.get_by_name('dt') is not None
+
+    def test_an_unchanged_definition_returns_none(self, project):
+        project.set_trial(_trial())
+        assert project.set_trial(_trial()) is None
+
+    def test_changing_an_unrun_trial_is_allowed(self, project):
+        project.set_trial(_trial(params={'max_depth': 3}))
+        assert project.set_trial(_trial(params={'max_depth': 5})) == 'dt'
+        assert project.trials.get_by_name('dt').params == {'max_depth': 5}
+
+    def test_a_trial_with_a_successful_run_is_frozen(self, project):
+        project.set_trial(_trial(params={'max_depth': 3}))
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+        with pytest.raises(ValueError, match='run_a'):
+            project.set_trial(_trial(params={'max_depth': 5}))
+        assert project.trials.get_by_name('dt').params == {'max_depth': 3}
+
+    def test_resetting_the_same_definition_stays_allowed(self, project):
+        """The guard is about the definition changing, not about touching it."""
+        project.set_trial(_trial())
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+        assert project.set_trial(_trial()) is None
+
+    def test_a_failed_run_does_not_freeze_it(self, project):
+        """Only a success is a result worth protecting; an error leaves nothing
+        the history would misdescribe."""
+        project.set_trial(_trial(params={'max_depth': 3}))
+        project.trials.record('dt', 'run_a', 0, 0, status='error')
+        assert project.set_trial(_trial(params={'max_depth': 5})) == 'dt'
+
+    def test_removing_it_lifts_the_freeze(self, project):
+        project.set_trial(_trial(params={'max_depth': 3}))
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+        project.remove_trial('dt')
+        assert project.set_trial(_trial(params={'max_depth': 5})) == 'dt'
+
+    def test_set_trials_returns_only_what_changed(self, project):
+        trials = make_trials('dt', processor=TREE, edges=EDGES,
+                             param_grid={'max_depth': [3, 5]})
+        assert project.set_trials(trials) == ['dt_0', 'dt_1']
+        assert project.set_trials(trials) == []
+
+    def test_a_frozen_name_leaves_the_whole_batch_unwritten(self, project):
+        """Checked before anything is written, so a batch does not land half
+        registered — the returned work list would then be a lie."""
+        project.set_trial(_trial('dt_0', params={'max_depth': 3}))
+        project.trials.record('dt_0', 'run_a', 0, 0, status='built')
+        trials = make_trials('dt', processor=TREE, edges=EDGES,
+                             param_grid={'max_depth': [9, 11]})
+        with pytest.raises(ValueError, match='dt_0'):
+            project.set_trials(trials)
+        assert project.trials.get_by_name('dt_1') is None
+        assert project.trials.get_by_name('dt_0').params == {'max_depth': 3}
+
+
 class TestTrialRegistration:
     def test_same_definition_registers_once(self, store):
         store.register(_trial())
@@ -154,9 +219,9 @@ class TestTrialRegistration:
         exactly like redefining a Trial overwrites its on-disk artifact."""
         store.register(_trial(params={'max_depth': 3}))
         store.register(_trial(params={'max_depth': 5}))
-        rows = [t for t in store.list_trials() if t['name'] == 'dt']
+        rows = [t for t in store.list_trials() if t.name == 'dt']
         assert len(rows) == 1
-        assert rows[0]['params'] == {'max_depth': 5}
+        assert rows[0].params == {'max_depth': 5}
 
     def test_name_does_not_split_identity(self, store):
         """Two Trials with an otherwise-identical definition but different
@@ -171,7 +236,7 @@ class TestTrialRegistration:
         trials = make_trials('dt', processor=TREE, edges=EDGES,
                              param_grid={'max_depth': [3, 5]})
         store.register_all(trials)
-        assert {t['name'] for t in store.list_trials()} == {'dt_0', 'dt_1'}
+        assert {t.name for t in store.list_trials()} == {'dt_0', 'dt_1'}
 
     def test_has_before_and_after(self, store):
         assert not store.has(_trial())
@@ -192,9 +257,9 @@ class TestTrialRegistration:
     def test_get_by_name_roundtrip(self, store):
         store.register(_trial(params={'max_depth': 7}))
         got = store.get_by_name('dt')
-        assert got['processor'] == TREE
-        assert got['params'] == {'max_depth': 7}
-        assert got['edges'] == EDGES
+        assert got.processor == TREE
+        assert got.params == {'max_depth': 7}
+        assert got.edges == EDGES
 
     def test_get_by_name_unknown(self, store):
         assert store.get_by_name('nope') is None
@@ -273,7 +338,7 @@ class TestProjectEndToEnd:
 
         row = project.trials.get_hist(trial_name='dt')[0]
         assert row['pipeline_version'] == built.version
-        assert project.trials.get_by_name('dt')['processor'] == TREE
+        assert project.trials.get_by_name('dt').processor == TREE
 
 
 @pytest.fixture
@@ -456,7 +521,8 @@ class TestExperimenterUnderProject:
         e.build()
         trial = make_trials('dt', processor=TREE, edges=EDGES,
                              params={'max_depth': 3, 'random_state': 0})[0]
-        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials)
+        assert project.set_trial(trial) == 'dt'
+        e.exp(['dt'])
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
 
         # history is keyed by the two names, matching the layout on disk
@@ -469,25 +535,27 @@ class TestExperimenterUnderProject:
         artifact — a fold recorded 'built' there is skipped without dispatch."""
         e = self._exp(project, builder, sample_data)
         e.build()
-        trial = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0})
-        e.exp([(trial, 0, 0)], project.trials)
+        project.set_trial(Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0}))
+        e.exp(['dt'])
         build_id_1 = project.trials.get_info('dt', 'run_a')[(0, 0)]['build_id']
 
-        e.exp([(trial, 0, 0)], project.trials)
+        e.exp(['dt'])
         build_id_2 = project.trials.get_info('dt', 'run_a')[(0, 0)]['build_id']
         assert build_id_2 == build_id_1
 
     def test_redefined_trial_with_built_hist_is_not_rerun(self, project, builder, sample_data):
-        """Redefining a Trial no longer forces a rerun of folds the hist
-        already marks 'built' — rerunning is an explicit action now."""
+        """A fold the hist marks 'built' is skipped whatever the definition now
+        says. set_trial refuses such a redefinition, so this goes through the
+        store directly — the skip rule has to hold on its own, since it is what
+        makes the freeze necessary rather than merely tidy."""
         e = self._exp(project, builder, sample_data)
         e.build()
-        trial_v1 = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0})
-        e.exp([(trial_v1, 0, 0)], project.trials)
+        project.set_trial(Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0}))
+        e.exp(['dt'])
         build_id_1 = project.trials.get_info('dt', 'run_a')[(0, 0)]['build_id']
 
-        trial_v2 = Trial('dt', TREE, EDGES, params={'max_depth': 5, 'random_state': 0})
-        e.exp([(trial_v2, 0, 0)], project.trials)
+        project.trials.register(Trial('dt', TREE, EDGES, params={'max_depth': 5, 'random_state': 0}))
+        e.exp(['dt'])
         build_id_2 = project.trials.get_info('dt', 'run_a')[(0, 0)]['build_id']
         assert build_id_2 == build_id_1
 
@@ -497,12 +565,12 @@ class TestExperimenterUnderProject:
         Trial's error status/detail is recorded now."""
         e = self._exp(project, builder, sample_data)
         e.build()
-        bad_trial = Trial('bad', 'mock.BadPredictor', EDGES)
-        e.exp([(bad_trial, 0, 0)], project.trials)
+        project.set_trial(Trial('bad', 'mock.BadPredictor', EDGES))
+        e.exp(['bad'])
         assert project.trials.get_status('bad', 'run_a')[(0, 0)] == 'error'
         build_id_1 = project.trials.get_info('bad', 'run_a')[(0, 0)]['build_id']
 
-        e.exp([(bad_trial, 0, 0)], project.trials)
+        e.exp(['bad'])
         assert project.trials.get_status('bad', 'run_a')[(0, 0)] == 'error'
         build_id_2 = project.trials.get_info('bad', 'run_a')[(0, 0)]['build_id']
         assert build_id_2 != build_id_1
@@ -515,11 +583,96 @@ class TestExperimenterUnderProject:
         the 'done' and 'error' worker messages are covered."""
         e = self._exp(project, builder, sample_data)
         e.build()
-        trial = Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0})
-        bad_trial = Trial('bad', 'mock.BadPredictor', EDGES)
-        e.exp([(trial, 0, 0), (trial, 1, 0), (bad_trial, 0, 0)], project.trials, n_jobs=2)
+        project.set_trials([
+            Trial('dt', TREE, EDGES, params={'max_depth': 3, 'random_state': 0}),
+            Trial('bad', 'mock.BadPredictor', EDGES),
+        ])
+        e.exp(['dt', 'bad'], n_jobs=2)
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
         assert project.trials.get_status('bad', 'run_a')[(0, 0)] == 'error'
+
+
+class TestTrialErrorReporting:
+    """Who reports a failure follows who owns the history it sits in: node
+    history is the run's (Experimenter.show_error_nodes), Trial history is the
+    project's, keyed by experimenter."""
+
+    def test_show_error_trials_reports_the_failed_fold(self, project):
+        project.trials.record('bad', 'run_a', 0, 1, status='error',
+                              info={'error': {'type': 'ValueError', 'message': 'boom',
+                                              'traceback': 'TB'}})
+        lines = project.show_error_trials()
+        assert len(lines) == 1
+        assert '[bad] fold 0_1' in lines[0] and 'ValueError: boom' in lines[0]
+        assert 'TB' not in lines[0]
+
+    def test_traceback_is_opt_in(self, project):
+        project.trials.record('bad', 'run_a', 0, 0, status='error',
+                              info={'error': {'type': 'ValueError', 'message': 'boom',
+                                              'traceback': 'TB'}})
+        assert 'TB' in project.show_error_trials(traceback=True)[0]
+
+    def test_nothing_failed_reads_as_none(self, project):
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+        assert project.show_error_trials() is None
+
+    def test_narrowed_to_one_run(self, project):
+        project.trials.record('bad', 'run_a', 0, 0, status='error')
+        project.trials.record('bad', 'run_b', 0, 0, status='built')
+        assert project.show_error_trials(experimenter='run_a')
+        assert project.show_error_trials(experimenter='run_b') is None
+
+    def test_node_errors_stay_out_of_it(self, project, builder, sample_data):
+        """show_error_nodes is Pipeline nodes only — the two halves used to
+        come back from one call, indistinguishable in the output."""
+        version = project.build_pipeline(builder).version
+        e = project.experimenter('run_a', sample_data, pipeline_name='main',
+                                 pipeline_version=version)
+        project.trials.record('bad', 'run_a', 0, 0, status='error')
+        assert e.show_error_nodes() is None
+
+
+class TestPendingTrials:
+    """Registered Trials that errored or never ran — one list, because both
+    still owe a run. Hand-written, this filter tends to catch only the second
+    (see the notebook it came from)."""
+
+    def test_a_never_run_trial_is_pending(self, project):
+        project.set_trial(_trial())
+        assert project.pending_trials() == ['dt']
+
+    def test_an_errored_trial_is_pending(self, project):
+        """The case a hand-written 'has no history' filter drops."""
+        project.set_trial(_trial())
+        project.trials.record('dt', 'run_a', 0, 0, status='error')
+        assert project.pending_trials() == ['dt']
+
+    def test_a_built_trial_is_not(self, project):
+        project.set_trial(_trial())
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+        assert project.pending_trials() == []
+
+    def test_scoped_to_one_run(self, project):
+        project.set_trial(_trial())
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+        assert project.pending_trials(experimenter='run_a') == []
+        assert project.pending_trials(experimenter='run_b') == ['dt']
+
+    def test_only_registered_trials_are_considered(self, project):
+        """History alone does not make a Trial — a removed definition is not
+        work still owed."""
+        project.trials.record('gone', 'run_a', 0, 0, status='error')
+        assert project.pending_trials() == []
+
+    def test_feeds_straight_into_exp(self, project, builder, sample_data):
+        version = project.build_pipeline(builder).version
+        e = project.experimenter('run_a', sample_data,
+                                 sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=0),
+                                 pipeline_name='main', pipeline_version=version)
+        e.build()
+        project.set_trial(_trial())
+        e.exp(project.pending_trials(experimenter='run_a'))
+        assert project.pending_trials(experimenter='run_a') == []
 
 
 class TestRemoveTrial:
@@ -538,8 +691,8 @@ class TestRemoveTrial:
         e.build()
         e.collectors.set_collector('acc', MetricCollector, Connector(),
                                    params={'output_var': None, 'metric_func': dummy_metric})
-        trial = _trial()
-        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials)
+        project.set_trial(_trial())
+        e.exp(['dt'])
         return e, e.collectors
 
     def test_store_remove_drops_the_definition_only(self, store):
@@ -569,8 +722,8 @@ class TestRemoveTrial:
 
     def test_leaves_other_trials_alone(self, project, builder, sample_data):
         e, collectors = self._run(project, builder, sample_data)
-        other = _trial('dt2')
-        e.exp([(other, 0, 0), (other, 1, 0)], project.trials)
+        project.set_trial(_trial('dt2'))
+        e.exp(['dt2'])
 
         project.remove_trial('dt')
 
@@ -605,10 +758,12 @@ class TestRemoveTrial:
         assert not acc.has_node('dt')
 
     def test_a_removed_trial_runs_again_from_scratch(self, project, builder, sample_data):
+        """Removal takes the definition too, so re-running means authoring it
+        again — which is also what lifts the redefinition freeze."""
         e, collectors = self._run(project, builder, sample_data)
         project.remove_trial('dt')
-        trial = _trial()
-        e.exp([(trial, 0, 0), (trial, 1, 0)], project.trials)
+        assert project.set_trial(_trial()) == 'dt'
+        e.exp(['dt'])
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
 
 


### PR DESCRIPTION
Closes #126.

## What was left of the issue

#135 answered two of the three things #126 raised. The registry became the run's, so `collect_hist=collectors.hist` stopped being a thing you re-supply, and "which collectors make sense is a property of the experiment" became true by construction — `collectors=None` now means the ones registered on that run. Open questions 1, 2 and 4 went with them.

What remained was `trial_store`, and pulling on it surfaced the larger problem underneath.

## The ownership was inverted

A Trial belongs to the project. `TrialStore` is project-wide precisely so several Experimenters' results sit next to each other, and `experiment_hist` is keyed by experimenter for the same reason.

But the only way a Trial entered the project was `Experimenter.exp()` calling `register_all()` on its way past. Two consequences:

- **You could not add a Trial without running it.** Authoring had no unit of its own — the thing #131 says an agent loop is missing.
- **`register_all` is an unconditional `INSERT OR REPLACE`.** One run could redefine a name another run had already used, while `experiment_hist` kept describing the definition that actually ran. `TrialStore.has()` existed to detect precisely this and nothing called it.

## Authoring moves to the project

```python
names = project.set_trials(trials)     # ['lgb_0', 'lgb_1', ...]
project.set_trial(trial)               # 'lgb1', or None if unchanged
```

Both return only what was **added or changed**, so the return value is an authoring diff.

A name that already has a `'built'` fold behind it is **frozen** — `set_trial` raises rather than redefine it. The history is keyed by name and a Trial leaves no artifact, so a redefinition would leave the old results describing a definition that never produced them: one record that is really two. Change it under a new name, or `remove_trial()` to give up the results with it. A history of nothing but `'error'` guards no result, so that stays editable.

`set_trials` checks every Trial before writing any — a batch holding one frozen name changes nothing, rather than landing half-registered and returning a work list that is a lie.

## exp() takes names, and expands folds itself

```python
e.exp(names, n_jobs=2, gpu_id_list=[0], logger=logger)
```

Definitions come out of the store, so running registers nothing. Folds left the signature too: `_make_jobs` builds the `(outer, inner)` grid and drops what is already `'built'`, which makes passing the same names again a **resume** rather than a repeat. The cross-product callers used to build was boilerplate for "all of them" — the example notebook's `folds()` helper disappears entirely.

An unregistered name raises `KeyError`; a `Trial` instance where a name belongs raises `TypeError` (passed through, it reached sqlite as a bind parameter and the error said nothing about the caller's mistake).

## trial_store is injected, once

Beside `cache` and `collectors`: a project has exactly one and it does not change over a run's life. `Project.experimenter()` / `load_experimenter()` supply it; a standalone run takes `Experimenter(..., trial_store=...)`.

It is **not persisted**. A `TrialStore` is project-level, and a run reopened from its own directory could only find one by guessing at the layout above it — the implicit coupling this architecture avoids everywhere else. `exp()`, `show_error_nodes()` and `remove_trial_result()` all lose the argument.

## Store changes

- `get_by_name` / `list_trials` return `Trial` objects rather than dicts, matching `PredictorStore`. The store is now where a run reads what it is about to execute, so what comes out has to be what went in.
- `has()` returns `False` for an absent name, which is what lets `set_trial` use it as one guard instead of two.
- `get_hist()` gains a `status` filter.

## Error reporting splits along ownership

`show_error_nodes()` had been reporting nodes *and* Trials through one label format, so `[scaler]` and `[xgb1]` came back indistinguishable, and `nodes=` filtered both. It is Pipeline nodes only now, and the Trial side is `Project.show_error_trials(experimenter=)` — reported by whoever owns the history it sits in. Both share `_run_common.format_errors`.

## Project.pending_trials(experimenter=)

Registered Trials that errored **or** never ran. Both still owe a run, and written by hand this filter tends to catch only the second — #130 flagged exactly that bug in the notebook this API comes from, where an errored Trial silently dropped out of the list of things left to do.

Deliberately coarse: a Trial interrupted partway through its folds is not reported, since judging that means comparing history against a fold grid `TrialStore` does not know. Running the returned names anyway is safe — `exp()` skips the folds that are done. If the precise version is ever wanted it belongs on the run, which is the thing that knows the grid.

## Notes

- Tests: 1011 passed, 128 skipped.
- `examples/kaggle_s6e6/2. Second Phase.ipynb` is updated: `folds()` is gone, `run()` is `set_trials` then names, the recollect path is `remove_trial_result`, and the stacking run registers on the project before running by name.
- The "give a new name" comment in the stacking cell now has a mechanism behind it rather than being a rule the reader has to remember.
