### PR TITLE
perf(DataFlow): read artifacts on demand, and put train output under the cache budget (#138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,8 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 
 ### DataCache (`_cache.py`)
 - `cachetools.LRUCache` 기반, 용량(bytes) 단위 관리. `Project`가 소유(`project.cache`)해서 모든 Experimenter/Trainer가 공유
-- 키는 **`(scope, node, typ)`** — `scope`는 그 fold를 만든 `TrainDataFlow`가 **자기 생성자에서 만드는 랜덤 id**(`self.scope = uuid.uuid4().hex`). 경로 문자열을 쓰지 않는 이유: run을 Project 없이 독립 생성하고 `cache=`를 외부 주입받을 수 있으므로, 서로 다른 물리 디렉토리가 우연히 같은 상대경로 문자열이 되어 충돌할 수 있음
+- 키는 **`(scope, node, typ)`** — `typ`은 `'train'`/`'valid'`/`'test'` **셋 다**. 노드 출력 중 예산 밖에 있는 건 없다
+- `scope`는 그 fold를 만든 `TrainDataFlow`가 **자기 생성자에서 만드는 랜덤 id**(`self.scope = uuid.uuid4().hex`). 경로 문자열을 쓰지 않는 이유: run을 Project 없이 독립 생성하고 `cache=`를 외부 주입받을 수 있으므로, 서로 다른 물리 디렉토리가 우연히 같은 상대경로 문자열이 되어 충돌할 수 있음
   - **`TrainDataFlow` 인스턴스 하나 = 정확히 그 (run, fold) 하나**(fold마다 새로 만들고 공유 안 함)라, 인스턴스 자신의 랜덤 id만으로 이미 "이 run의 이 fold"가 유일하게 식별됨 — `outer_idx`/`inner_idx`를 키에 또 넣지 않는 이유
   - 트레이드오프: 리로드하면(새 Python 인스턴스 = 새 scope id) 이전 인스턴스가 캐싱해둔 항목은 다시 못 만남 — cache miss일 뿐 잘못된 값이 나오는 게 아니라 허용 가능한 손실로 판단
 - `get_data(scope, node, typ)`, `put_data(scope, node, typ, data)`
@@ -285,19 +286,26 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - `NodeStore`는 열린 커넥션을 `self`에 들고 있지 않아 picklable — 서브프로세스 워커에 스폰 시점에 인스턴스 자체를 넘긴다(`ProcessWorker(conn, collectors, store, ...)`)
 - **history**: SQLite `node_hist(node_name, outer_idx, inner_idx, pipeline_version, status, info)` — PK는 `(node_name, outer_idx, inner_idx)`(run_name 컬럼 없음 — store 자체가 이미 그 run에 스코프돼 있음)
   - `record(name, outer_idx, inner_idx, pipeline_version=, status=, info=)` — `info`는 `status` 제외 나머지 전부(`build_id`, `definition`, `fit_time`, `edges`, `train_shape`, `warnings`, 실패 시 `error`) JSON 인코딩. `NodeInfoTracker`(`_tracker.py`)가 기록
-  - `get_hist(node_name=, outer_idx=, inner_idx=, pipeline_version=)`/`get_status(node_name)`/`get_info(node_name)`(`{(outer_idx, inner_idx): ...}`)/`get_fold_info(outer_idx, inner_idx)`(fold 하나의 `{node_name: info}` 전체 — `DataFlow.load()`가 씀)/`remove_hist(node_name=)`
+  - `get_hist(node_name=, outer_idx=, inner_idx=, pipeline_version=)`/`get_status(node_name)`/`get_info(node_name)`(`{(outer_idx, inner_idx): ...}`)/`get_fold_info(outer_idx, inner_idx)`(fold 하나의 `{node_name: info}` 전체 — `DataFlow`가 노드의 `edges`를 복원할 때 씀)/`remove_hist(node_name=)`
   - `'error'`는 오직 여기서만 보임 — `Experimenter.show_error_nodes`/`Trainer.get_node_error`가 조회
 
 ### DataFlow / TrainDataFlow (`_flow.py`)
 - **DataFlow**: 생성자가 `NodeStore` 인스턴스(`self.store`, run 전체가 공유) + 이 fold의 `outer_idx`/`inner_idx`를 받음. `status`/`get_obj`/`get_objs`/`get_result`/`list_nodes`/`node_path`는 `self.store.X(name, self.outer_idx, self.inner_idx)`로 위임하는 얇은 메소드. `reset_node`만 위임 + `node_objs`/`_node_edges`에서도 같이 지우는 조합 동작
-  - `node_objs`: `{name: (obj, result)}`, `_node_edges`: `{name: edges}`
-  - **`load()`가 `self.store.get_fold_info(...)`를 한 번 조회**해서 `edges`까지 복원한 뒤 `load_objs(name, edges=...)`. history에 행이 없는 노드는 로드 안 함(안전한 기본값). 여기 올라오는 건 Pipeline 노드뿐이다 — Trial은 애초에 아무것도 안 남기고 Trainer의 Predictor는 자기 store에 있어서, 둘 다 이 store에 아티팩트를 두지 않는다(학습된 모델이 메모리로 딸려 들어오지 않음)
+  - `node_objs`: `{name: obj}` — **`obj.pkl`의 캐시일 뿐**이고 result는 안 들고 있음. `_node_edges`: `{name: edges}`
+  - **생성자는 아무것도 안 읽는다.** run은 fold마다 flow를 하나씩 미리 만들기 때문에, 생성자에서 읽는 건 곧 그리드 전체를 읽는 것이다(5×3 그리드 × 10노드 = processor 150 + 중간 데이터셋 150). 읽기는 `_processor(name)`이 처음 필요할 때 하고, 안 건드린 fold는 끝까지 안 읽힌다
+  - **`_processor(name)`**: `node_objs` → (없으면) `store.status`로 `'built'` 확인 → `load_obj(name)`. 안 빌드됐거나 이력 행이 없으면 **`KeyError`로 시끄럽게 실패**한다. 예전엔 `_resolve`가 조용히 `None`을 반환하고 `get_data`가 그 세그먼트를 건너뛰어서, 컬럼이 빠진 채로 아무 말도 없이 진행됐다
+  - `_fold_edges(name)`: `edges`는 두 pkl 어디에도 없어서 `store.get_fold_info(...)`(fold당 쿼리 1회, 아티팩트 안 건드림)에서 온다. **미스면 재조회** — 빌드 전에 이미 fold 스냅샷을 읽어둔 flow가 있고, 빌드는 flow에 아무것도 안 건네므로 옛 스냅샷으로 답하면 안 된다
+  - 여기 올라오는 건 Pipeline 노드뿐이다 — Trial은 애초에 아무것도 안 남기고 Trainer의 Predictor는 자기 store에 있어서, 둘 다 이 store에 아티팩트를 두지 않는다(학습된 모델이 메모리로 딸려 들어오지 않음). 다른 데서 들고 온 걸 쓰려면 `node_objs`에 직접 넣으면 된다(`Trainer.process`) — store보다 먼저 조회된다
   - `get_data(source_data, edges)` → `{key: data}`
 - **TrainDataFlow** (DataFlow 상속): 노드 빌드 기능 추가. `store`를 그대로 받아 `super().__init__(store, outer_idx=, inner_idx=)`로 넘김 — fold별로 자기 NodeStore를 새로 만들지 않음
   - `data_source`: DataWrapperProvider (train/valid/**test** 제공 — `test_idx` 보유)
   - `outer_idx`/`inner_idx`는 NodeStore 키(아티팩트 경로, history row) 전용 — DataCache 키에는 안 들어감(`self.scope`가 대신함). **Trainer도 자연스러운 `(split_idx, 0)`을 그대로 쓴다**
   - `get_train(edges)`, `get_valid(edges)`, `get_test(edges)` — flow 하나로 job의 모든 입력을 만들 수 있어야 `Job`이 자족적이 됨
-  - `set_objs(name, obj, result, info)`: 현재 fit의 즉석 info에서 `edges`만 추출 — 디스크/history를 안 거침. **`chained` 실행(=노드 빌드)에서만 호출**된다 — leaf(Trial/Predictor)를 여기 올리면 아무도 안 읽는 모델이 flow 메모리에 남는다
+  - **`_resolve_typ`: 셋 다 `DataCache`를 거치지만 복구 방법이 다르다**
+    - valid/test는 **재계산**(`obj.process`)
+    - train은 **`result.pkl` 재읽기**. 재계산하면 안 된다 — train 출력은 `fit_process`가 낸 값이고, cross-fitting 노드에선 같은 행에 대해 `process`가 내는 값과 다르다(`CrossFitTransformer`는 fit 때 OOF, 이후엔 full model). 재계산은 downstream이 보는 숫자를 말없이 바꾼다
+    - 단, `method`가 순수 `fit`인 노드는 fit 시점 출력이 없어 `result.pkl`이 `None`이고, 그때는 `process`가 곧 train 출력의 정의다 — 재계산이 대체재가 아니라 정답인 유일한 경우
+  - **게시(`set_objs`)는 없다** — 빌드는 아티팩트를 쓰고 끝, 다음에 읽는 쪽이 디스크에서 가져간다. 그래서 `node_objs`의 모든 항목은 버려도 안전하다
 
 ### Trainer (`_trainer.py`)
 - **Project 의존성 없음. 주입받는 건 `cache` 하나**(Experimenter와 동형) — 생성자: `Trainer(path, name, data, splitter=None, splitter_params=None, aug_data=None, cache=None)`. store(`TrainerStore(self.path)`)는 자기가 만들고, Pipeline은 `set_pipeline()`으로만
@@ -322,9 +330,9 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - `predictors=None`이면 이미 등록된 것들을 그대로 이어서 학습(중단된 학습 재개)
   - `Trial`을 넘기면 `TypeError` — `Predictor.from_trial(trial, experimenter=)`로 명시 승격해야 출처가 기록됨
   - 학습 대상 노드는 **넘긴 predictors 기준**(`_nodes_for(predictors)`)이지 등록된 전체가 아님
-  - `Job.flow`는 Predictor에도 **노드 flow**가 들어감(입력을 만드는 건 노드 그래프) — 아티팩트는 `predictor_store`로 가고, **flow에는 게시되지 않는다**(`chained=False`). Predictor는 leaf라 아무도 안 읽는데 flow에 올리면 모델만 메모리에 남기 때문. 나중에 필요한 쪽(`process()`/`to_inferencer()`)이 `predictor_store`에서 직접 꺼낸다
+  - `Job.flow`는 Predictor에도 **노드 flow**가 들어감(입력을 만드는 건 노드 그래프) — 아티팩트는 `predictor_store`로 간다. 노드 flow의 lazy 로드는 자기 store만 보므로 Predictor 모델은 거기 닿지 않고, 필요한 쪽(`process()`/`to_inferencer()`)이 `predictor_store`에서 직접 꺼낸다
 - `get_status(node_name)` / `get_node_error(node_name)`: `_store_for(name)`으로 두 store 중 하나를 골라 조회 — Predictor 에러도 기록됨
-- `process(data, v=None)`: generator, split마다 Predictor output을 `v`(DSL 문자열)로 필터 후 concat하여 yield. Predictor 모델은 `flow.load()`가 안 집어오므로(이력이 다른 store에 있음 — 그게 메모리에 안 딸려오게 하는 장치) `predictor_store`에서 on-demand로 꺼내고, **edges는 정의에서 채운다** — 아티팩트에도 이 flow의 이력에도 없기 때문(안 채우면 `_resolve`가 전부 None을 반환해 조용히 아무것도 yield 안 함)
+- `process(data, v=None)`: generator, split마다 Predictor output을 `v`(DSL 문자열)로 필터 후 concat하여 yield. Predictor 모델은 노드 flow의 lazy 로드가 닿지 않는 store에 있으므로(그게 메모리에 안 딸려오게 하는 장치) `predictor_store`에서 꺼내 `flow.node_objs`에 직접 넣고, **edges는 정의에서 채운다** — 아티팩트에도 이 flow의 이력에도 없기 때문
 - `to_inferencer(v=None)`: 학습된 Processor를 추출하여 Inferencer 생성
 - `reset_nodes(nodes)`: 하위 종속 노드 포함 초기화. Predictor는 leaf라 그래프 캐스케이드 대상이 아니지만, 리셋된 노드를 읽는 Predictor는 `node_names()` 교집합으로 같이 리셋됨
 - 저장/로드: `save()`(meta + splits를 `_store`에 기록), 복원은 `Trainer.load_trainer()`. Pipeline은 `{path}/pipeline.pkl`, splitter/split_indices는 `__trainer.db`의 splits BLOB, **Predictor는 `predictor_defs`에서** 복원
@@ -625,10 +633,10 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 단일 프로세스로 `Job` 리스트를 실행. 세 종류가 전부 같은 `_process`를 타고, 호출부가 바꾸는 건 **결과가 어디로 가느냐**뿐이다.
 
 - **`store`는 그 job 종류의 기록을 소유한 store** — 노드/Predictor는 `NodeStore`, Trial은 `TrialStore`. 아티팩트 기록은 `store.stores_artifacts`가 True일 때만(Trial은 False라 아무것도 안 남는다)
-- **`chained`는 "이 job들이 flow를 통해 서로 먹이는가"** — Pipeline 노드에서만 True. 두 가지가 같이 켜진다: 완료된 obj/result를 `set_objs`로 flow에 게시(뒤 job이 읽으라고), 그리고 edges가 참조하는 게 다 빌드될 때까지 대기(`get_missing_nodes`). leaf(Trial/Predictor)는 둘 다 안 함
+- **`chained`는 "이 job들이 flow를 통해 서로 먹이는가"** — Pipeline 노드에서만 True. 하는 일은 하나: edges가 참조하는 게 다 빌드될 때까지 대기(`get_missing_nodes`). leaf(Trial/Predictor)는 안 함
   - 대기 게이트를 leaf에 걸면 안 되는 이유: 참조 노드가 끝내 안 빌드되면 그 job이 에러 하나 없이 조용히 사라진다 — `_job_inputs`가 `KeyError`를 내고 prep error로 기록되는 게 올바른 동작
-  - `set_objs`를 leaf에 하면 안 되는 이유: 아무도 안 읽는데 학습된 모델만 flow 메모리에 실행 내내 붙어 있게 된다
-- **완료 표시는 `done` 집합**(`(outer_idx, inner_idx, name)`) — 예전엔 `flow.node_objs` 등록 여부가 겸했는데, 그러면 flow에 안 올리는 leaf가 영원히 `ready`로 남는다
+  - **끝난 job을 flow에 건네주지 않는다** — 디스크의 아티팩트가 다음 job이 읽을 것이고, flow가 필요할 때 알아서 읽는다. 그래서 `chained`가 걸린 곳에선 `store.stores_artifacts`가 참이어야 하는데, chained는 곧 Pipeline 노드이고 그건 `NodeStore`로 가므로 성립
+- **완료 표시는 `done` 집합**(`(outer_idx, inner_idx, name)`) — 단일/멀티 양쪽 다. `flow.node_objs` 등록 여부로는 안 되는데, flow는 leaf를 아예 안 담고 lazy 로드 때문에 담긴 이유도 여러 가지가 되기 때문
 - **`collectors`는 별개**로 Collector 얘기만 한다: `None`이면 `ext_data` 준비와 매칭을 통째로 스킵(노드엔 Collector가 안 붙음), 리스트면 실행(`[]`는 매치될 게 없는 리스트일 뿐)
 - **반환값은 job 종류와 무관하게 항상 `{(outer_idx, inner_idx, name): error_info}`** — 실패한 job이 ready-루프에서 영원히 재시도되지 않으려면 키가 fold까지 포함한 job 신원이어야 하고, 반환도 그 신원 그대로여야 한다(축약하면 같은 outer fold의 다른 inner fold 실패가 사라지고, 호출부의 `len(jobs) - len(errors)` 집계도 틀어짐). 호출부는 이름만 필요할 때 `{n for _, _, n in errors}`로 뽑는다
 
@@ -636,7 +644,7 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 
 ### `_execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, tracker=None, ..., chained=False)`
 워커 풀 실행. `store`/`chained`/`collectors`의 의미와 반환 모양은 `_execute_single`과 동일.
-- **`chained`일 때만 완료 결과를 되읽어 flow에 올린다** — 되읽기는 `job.flow`가 아니라 인자로 받은 `store`에서. 워커는 이 호출이 지정한 store에 쓰기 때문이고, chained면 둘이 어차피 같지만(노드의 flow는 자기가 쓴 store를 읽는다) 그 전제를 코드가 기대는 대신 말하게 둔 것
+- **끝난 job의 아티팩트를 되읽지 않는다** — 부모는 오케스트레이션만 한다. 워커 결과를 매번 읽어 flow에 올리면, 정작 다음 job이 스스로 할 수 있는 로드 하나 때문에 부모가 그 run의 모든 모델과 중간 출력을 떠안게 된다
 - **ready-job 계산은 매 dispatch 사이클마다 처음부터 다시 스캔**(`_collect_ready()`) — 노드는 형제 노드가 끝나야 readiness가 바뀌므로 목록을 한 번만 만들어두는 방식이 안 맞는다. leaf에도 그대로 맞음(서로 의존 안 하니 한 번 ready면 계속 ready)
 - **워커 배정 fallback**: "내 타입" job이 아직 남아있으면 그 타입 몫 worker를 다른 타입에 안 뺏긴다(`elif free_cpu and not cpu_ready and gpu_fallback_cpu`). ready 목록을 매 사이클 재계산하는 탓에 같은 `_try_dispatch()` 호출 안에서 GPU pass가 막 dispatch한 job이 CPU pass의 판정엔 반영 안 되지만(다음 'done'/'error' 이벤트에서 바로잡힘) 무시할 수준
 - `ProcessWorker(conn, collectors or [], store, ...)`로 store를 그대로 넘김 — 워커 메시지 튜플은 `spec, outer_idx, inner_idx, train_data, valid_data, test_data, ext_data`(워커가 `store.write_objs(spec.name, ...)`로 직접 쓰므로 경로를 미리 조립해 보낼 필요 없음)
@@ -645,9 +653,9 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 #### 워커 사망 처리
 `wait()`는 파이프가 닫힌 것도 ready로 돌려주므로, OOM kill이나 네이티브 라이브러리 segfault로 워커가 죽으면 `recv()`가 `EOFError`를 던진다. 이걸 예외로 전파시키면 정리 코드에 도달하지 못해 나머지 워커가 종료 sentinel을 못 받고 영원히 블록된다(주피터 커널은 안 죽으므로 `daemon=True`도 소용없어 메모리와 CUDA 컨텍스트를 잡은 채 남는다).
 - 사망을 **예외가 아니라 정상 결과**로 취급: in-flight job을 `WorkerLost` 에러로 기록하고, 그 conn을 `all_conns`에서 제거(EOF는 지속 상태라 안 빼면 무한 스핀), 남은 워커로 계속 진행. 전멸하면 못 돌린 job까지 에러로 남겨 호출부 집계가 안 틀리게 함
-- **정리는 `try/finally`** — 루프를 빠져나가는 경로가 여럿(`store.get_objs`, 이력 SQLite 쓰기, tracker 호출)이라 "끝까지 도달했나"에 정리를 걸면 안 된다. `send(None)` → `join(_JOIN_TIMEOUT=10)` → 살아있으면 `terminate()` → `close()`, 각 단계 예외 안전
+- **정리는 `try/finally`** — 루프를 빠져나가는 경로가 여럿(이력 SQLite 쓰기, Collector push, tracker 호출)이라 "끝까지 도달했나"에 정리를 걸면 안 된다. `send(None)` → `join(_JOIN_TIMEOUT=10)` → 살아있으면 `terminate()` → `close()`, 각 단계 예외 안전
 - 기동 시 `'ready'` 대기도 같은 처리 — spawn은 모듈을 재import하므로 Collector 클래스가 모듈 최상위가 아니면 자식이 `'ready'` 전에 죽는다
-- **미해결**: 루프 안 부모쪽 작업(`store.get_objs`/`flow.set_objs`/`tracker.*`/`abort_node`)의 개별 예외는 여전히 실행 전체를 중단시킨다. `finally` 덕에 누수는 없지만 job 단위로 흡수하지는 않음
+- **미해결**: 루프 안 부모쪽 작업(`c.push`/`tracker.*`/`abort_node`)의 개별 예외는 여전히 실행 전체를 중단시킨다. `finally` 덕에 누수는 없지만 job 단위로 흡수하지는 않음
 
 #### Collector 실행
 - **`_run_collectors`는 `(warn_msgs, outcomes)`를 반환** — `outcomes`는 매칭된 Collector당 하나씩 `{collector, status, elapsed, info}`. 실제 캐칭은 `_safe_collect`가 `ext`/`collect`/`push` 세 구간에 대해 하고, 공용 `obj.process` 준비(`output_test`/`output_train`)가 깨지면 매칭된 전원에게 `phase='output'` outcome을 발급한다 — 이 준비는 Trial이 이미 `'built'`로 기록된 **뒤에** 돌기 때문에 여기서 예외가 새면 실행 전체가 죽는다

--- a/mllabs/_executor.py
+++ b/mllabs/_executor.py
@@ -401,16 +401,17 @@ def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None
     says so and nothing is persisted.
 
     *chained* says these jobs feed each other through ``job.flow`` — true
-    only for Pipeline nodes. It turns on both halves of that: completed
-    obj/result are published into the flow (``set_objs``) for later jobs to
-    read, and a job waits until everything its edges reference is built
-    (``get_missing_nodes``). Leaf jobs (Trials, Predictors) get neither.
-    Gating the wait matters: a leaf whose node never built must raise a
-    ``KeyError`` from ``TrainDataFlow._resolve_typ``, caught and recorded as
-    a prep error — under the gate it would instead vanish silently, never
-    dispatched and never an error. Skipping ``set_objs`` matters too: a leaf
-    is read by no one, so publishing it would only pin its fitted model in
-    flow memory for the rest of the run.
+    only for Pipeline nodes. A job then waits until everything its edges
+    reference is built (``get_missing_nodes``). Leaf jobs (Trials,
+    Predictors) don't: a leaf whose node never built must raise a
+    ``KeyError`` out of the flow, caught and recorded as a prep error — under
+    the gate it would instead vanish silently, never dispatched and never an
+    error.
+
+    Nothing is handed to the flow after a job finishes. The artifact on disk
+    is what the next job reads, and the flow loads it when asked. That makes
+    ``store.stores_artifacts`` load-bearing wherever *chained* is set — which
+    holds, since chained means Pipeline nodes and those go to a ``NodeStore``.
 
     *collectors* is separate, and only about Collectors: ``None`` skips
     ``ext_data`` prep and matching entirely (nodes never have Collectors), a
@@ -471,8 +472,6 @@ def _execute_single(jobs, store, gpu_id_list=None, collectors=None, tracker=None
 
             if store.stores_artifacts:
                 store.write_objs(node_name, outer_idx, inner_idx, obj, result)
-            if chained:
-                job.flow.set_objs(node_name, obj, result, info)
             done.add((outer_idx, inner_idx, node_name))
             if tracker:
                 tracker.done(0, node_name, outer_idx, inner_idx, info)
@@ -509,6 +508,11 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
     would make one whose node never built vanish silently instead of being
     recorded as a prep error.
 
+    A finished job's artifact is never read back here. The parent only
+    orchestrates; reading each worker's obj/result to hand to the flow made it
+    accumulate every fitted model and every intermediate output in the run,
+    for the sake of a load the next job can do itself.
+
     Worker assignment prefers matching type: a free worker of the "wrong"
     type is handed to a ready job only when nothing of its own type is
     waiting. Because readiness is a fresh snapshot per cycle, a job
@@ -531,8 +535,8 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
     recorded too, so the caller's ``len(jobs) - len(errors)`` still counts.
 
     Shutdown is in a ``finally`` for the same reason: the loop has several ways
-    out that are not the normal one (a store read, a history write, a tracker
-    call), and any of them reaching the end of the function was what decided
+    out that are not the normal one (a history write, a Collector push, a
+    tracker call), and any of them reaching the end of the function decided
     whether the pool got cleaned up.
 
     Returns ``{(outer_idx, inner_idx, name): error_info}``, same shape and
@@ -684,15 +688,6 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
 
                 if msg_type == 'done':
                     info = data[0]
-                    if chained:
-                        # Read back through *store*, not job.flow's own: the
-                        # worker wrote where this call was told to write. The
-                        # two coincide here (a chained job is a node, whose
-                        # flow reads the very store it was written to), but
-                        # naming the store keeps that an assumption this line
-                        # states rather than one it relies on.
-                        obj, result = store.get_objs(node_name, outer_idx, inner_idx)
-                        job.flow.set_objs(node_name, obj, result, {'edges': job.spec.edges})
                     done.add((outer_idx, inner_idx, node_name))
                     del busy[conn]
                     (free_gpu if worker_idx < n_gpu else free_cpu).append(worker_idx)
@@ -744,7 +739,7 @@ def _execute_multi(jobs, n_jobs, store, gpu_id_list=None, collectors=None, track
         if not all_conns:
             for job in jobs:
                 key = (job.outer_idx, job.inner_idx, job.name)
-                if key in errors or job.name in job.flow.node_objs:
+                if key in errors or key in done:
                     continue
                 errors[key] = _worker_lost_info(job.spec.edges, 'no worker left to run it')
                 if tracker:

--- a/mllabs/_flow.py
+++ b/mllabs/_flow.py
@@ -22,6 +22,16 @@ class DataFlow:
     so both are needed on every call into it. Transforms source data through
     the stage graph given edges. No build functionality.
 
+    Nothing is read from the store until something asks for it. Constructing
+    a flow is free, which matters because a run constructs one per fold up
+    front: opening a built run used to materialise every fold's processors
+    before the caller had asked for anything.
+
+    ``node_objs`` is a cache of ``obj.pkl``, not a place anything lives. The
+    store is the only source, so dropping an entry is always safe and there is
+    nothing to publish into: a build writes its artifact and whoever reads it
+    next takes it off disk.
+
     Args:
         store (NodeStore): This run's artifact+history store (shared across
             every fold of the run — see :class:`TrainDataFlow`).
@@ -32,38 +42,66 @@ class DataFlow:
         self.store = store
         self.outer_idx = outer_idx
         self.inner_idx = inner_idx
-        self.node_objs = {}    # {name: (obj, result)}
+        self.node_objs = {}    # {name: obj} — cache of this fold's obj.pkl
         self._node_edges = {}  # {name: edges dict}
-        self.load()
+        self._fold_info = None
 
-    def load_objs(self, node_name, edges=None):
-        obj, result = self.store.get_objs(node_name, self.outer_idx, self.inner_idx)
-        self.node_objs[node_name] = (obj, result)
+    def _fold_edges(self, node_name):
+        """The ``edges`` recorded for *node_name* in this fold, or ``None``.
+
+        Neither ``obj.pkl`` nor ``result.pkl`` carries edges, so they come from
+        the store's history. One query covers the whole fold and touches no
+        artifact, so unlike the pickles it is cheap enough to keep.
+
+        A miss re-queries rather than answering ``None`` from a stale read: a
+        flow constructed before a node was built holds a fold snapshot without
+        it, and that flow is the one the build then hands work to.
+        """
+        if self._fold_info is None or node_name not in self._fold_info:
+            self._fold_info = self.store.get_fold_info(self.outer_idx, self.inner_idx)
+        info = self._fold_info.get(node_name)
+        return info.get('edges') if info else None
+
+    def load_obj(self, node_name, edges=None):
+        """Read *node_name*'s processor out of the store and cache it here."""
+        obj = self.store.get_obj(node_name, self.outer_idx, self.inner_idx)
+        self.node_objs[node_name] = obj
+        if edges is None:
+            edges = self._fold_edges(node_name)
         if edges is not None:
             self._node_edges[node_name] = edges
-        return obj, result
+        return obj
 
-    def load(self):
-        """Load this fold's processors, recovering each one's ``edges`` via
-        the store's history (``node_hist``) — the artifact itself
-        (obj.pkl/result.pkl) carries neither anymore.
+    def _processor(self, node_name):
+        """This fold's fitted processor for *node_name*, read on first use.
 
-        A node with no matching history row is left unloaded rather than
-        guessed at either way.
+        Only Pipeline nodes are ever here to read. A Trial persists nothing at
+        all, and a Trainer's Predictors go to a store of their own — so neither
+        leaves an artifact in the store this flow reads, and no fitted model
+        comes into memory from either. A caller holding one from elsewhere
+        (:meth:`Trainer.process`) puts it in ``node_objs`` itself, which is
+        consulted before the store.
 
-        Only Pipeline nodes are ever here to load. A Trial persists nothing
-        at all, and a Trainer's Predictors go to a store of their own — so
-        neither leaves an artifact in the store this flow reads, and no
-        fitted model comes into memory from either.
+        Raises:
+            KeyError: If the node has no artifact in this fold, or one with no
+                history row to recover its edges from. Loudly, because the
+                alternative is a segment that contributes no columns and says
+                nothing about it.
         """
-        fold_info = self.store.get_fold_info(self.outer_idx, self.inner_idx)
-        for name in self.store.list_nodes(self.outer_idx, self.inner_idx):
-            if self.store.status(name, self.outer_idx, self.inner_idx) != 'built':
-                continue
-            info = fold_info.get(name)
-            if info is None:
-                continue
-            self.load_objs(name, edges=info.get('edges'))
+        if node_name in self.node_objs:
+            return self.node_objs[node_name]
+        if self.store.status(node_name, self.outer_idx, self.inner_idx) != 'built':
+            raise KeyError(
+                f"node '{node_name}' is not built in fold "
+                f"({self.outer_idx}, {self.inner_idx})"
+            )
+        obj = self.load_obj(node_name)
+        if node_name not in self._node_edges:
+            raise KeyError(
+                f"node '{node_name}' has an artifact in fold "
+                f"({self.outer_idx}, {self.inner_idx}) but no recorded edges"
+            )
+        return obj
 
     def get_data(self, source_data, edges):
         """Transform source_data through stage nodes per edges.
@@ -82,8 +120,7 @@ class DataFlow:
                 data = self._resolve(source_data, node_name)
                 if data is None:
                     continue
-                obj = self.node_objs[node_name][0] if node_name in self.node_objs else None
-                cols = eval_expr(expr, data, processor=obj)
+                cols = eval_expr(expr, data, processor=self.node_objs.get(node_name))
                 data = data.select_columns(cols)
                 parts.append(data)
             if parts:
@@ -110,11 +147,8 @@ class DataFlow:
             return None
         if node_name is None:
             return source_data
-        if node_name not in self.node_objs or node_name not in self._node_edges:
-            return None
-        obj, result = self.node_objs[node_name]
-        edges = self._node_edges[node_name]
-        return obj.process(self.get_data(source_data, edges))
+        obj = self._processor(node_name)
+        return obj.process(self.get_data(source_data, self._node_edges[node_name]))
 
     # -------------------------------------------------------------------------
     # NodeStore delegation — thin, so callers keep treating a flow like a
@@ -144,6 +178,8 @@ class DataFlow:
         self.store.reset_node(name, self.outer_idx, self.inner_idx)
         self.node_objs.pop(name, None)
         self._node_edges.pop(name, None)
+        if self._fold_info is not None:
+            self._fold_info.pop(name, None)
 
 
 class TrainDataFlow(DataFlow):
@@ -175,11 +211,6 @@ class TrainDataFlow(DataFlow):
         self.scope = uuid.uuid4().hex
         super().__init__(store, outer_idx=outer_idx, inner_idx=inner_idx)
 
-    def set_objs(self, node_name, obj, result, info):
-        self.node_objs[node_name] = (obj, result)
-        if info.get('edges') is not None:
-            self._node_edges[node_name] = info['edges']
-
     def get_train(self, edges):
         """{key: data} train output resolved via edges."""
         return self._get_data_typ(edges, 'train')
@@ -205,10 +236,13 @@ class TrainDataFlow(DataFlow):
         for key, dsl_string in edges.items():
             parts = []
             for node_name, expr in iter_segments(dsl_string):
+                # Ahead of the resolve: a cache hit returns the output without
+                # touching the store, but the column selectors still need the
+                # processor, and an unbuilt node still has to fail here.
+                obj = None if node_name is None else self._processor(node_name)
                 data = self._resolve_typ(node_name, typ)
                 if data is None:
                     continue
-                obj = self.node_objs[node_name][0] if node_name in self.node_objs else None
                 cols = eval_expr(expr, data, processor=obj)
                 data = data.select_columns(cols)
                 parts.append(data)
@@ -217,23 +251,40 @@ class TrainDataFlow(DataFlow):
         return result
     
     def _resolve_typ(self, node_name, typ):
-        """Returns data for node_name via cache check → process. Used for valid and test."""
+        """This fold's *typ* output for *node_name*, via the cache.
+
+        All three outputs go through the one cache now, so all three are under
+        its budget. They are recovered differently, though, and the difference
+        is not incidental:
+
+        - valid/test are *recomputed* — ``obj.process`` on that split.
+        - train is *re-read* from ``result.pkl`` whenever one was stored. It
+          has to be. That output is what ``fit_process`` returned, and for a
+          cross-fitting node it is not what ``process`` returns for the same
+          rows: ``CrossFitTransformer`` yields out-of-fold predictions while
+          fitting and full-model predictions afterwards. Recomputing would
+          hand downstream nodes different numbers without saying so.
+
+        A node whose method is plain ``fit`` produced no fit-time output, so
+        ``result.pkl`` holds ``None`` and ``process`` *is* the definition of
+        its train output — the one case where recomputing is the right answer
+        rather than a substitute for a lost one.
+        """
         if node_name is None:
             if typ == 'train':
                 return self.data_source.get_train()
             else:
                 return self.data_source.get_valid()
-        if typ == 'train':
-            obj, result = self.node_objs[node_name]
-            if result is not None:
-                return result
         if self.cache is not None:
             cached = self.cache.get_data(self.scope, node_name, typ)
             if cached is not None:
                 return cached
-        data_out = super()._resolve(
-            self.data_source.get_train() if typ == 'train' else self.data_source.get_valid(), node_name
-        )
+        if typ == 'train':
+            data_out = self.store.get_result(node_name, self.outer_idx, self.inner_idx)
+            if data_out is None:
+                data_out = super()._resolve(self.data_source.get_train(), node_name)
+        else:
+            data_out = super()._resolve(self.data_source.get_valid(), node_name)
         if self.cache is not None:
             self.cache.put_data(self.scope, node_name, typ, data_out)
         return data_out

--- a/mllabs/_store.py
+++ b/mllabs/_store.py
@@ -267,8 +267,8 @@ class NodeStore(ArtifactStore):
     def get_fold_info(self, outer_idx, inner_idx):
         """``{node_name: info}`` for every node recorded in one specific fold.
 
-        Used by ``DataFlow.load()`` to recover edges for artifacts built
-        in an earlier process, one query per fold instead of per node.
+        Used by ``DataFlow`` to recover the edges of an artifact built in an
+        earlier process, one query per fold instead of per node.
         """
         return {
             r['node_name']: r['info']

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -517,11 +517,12 @@ class Trainer:
 
             if predictor_jobs:
                 # A Predictor is a leaf: it reads the node flow but nothing
-                # reads it, so these run unchained — no dependency gate (a
-                # Predictor whose node never built must surface as a prep
-                # error, not vanish) and no set_objs (its model belongs in
-                # predictor_store, not pinned in the node flow's memory).
-                # No Collectors either, a Trainer isn't an Experimenter.
+                # reads it, so these run unchained — no dependency gate, since
+                # a Predictor whose node never built must surface as a prep
+                # error rather than vanish. Its artifact goes to
+                # predictor_store, which the node flow's lazy load never
+                # reaches. No Collectors either, a Trainer isn't an
+                # Experimenter.
                 if n_jobs > 1:
                     predictor_errors = _execute_multi(
                         predictor_jobs, n_jobs, self.predictor_store, gpu_id_list=gpu_id_list,
@@ -565,16 +566,15 @@ class Trainer:
         predictor_edges = {p.name: p.edges for p in self.predictors}
         for fold in self.train_folds:
             flow = fold.train_data_flows[0]
-            flow.load()
             outputs = []
             for name in self.predictor_names():
                 if name not in flow.node_objs:
-                    # Predictor models live in their own store, so flow.load()
-                    # never pulls them in (which is what keeps them out of
-                    # memory) — fetch on demand.
+                    # A Predictor's model is in a store of its own, so the
+                    # flow's own lazy load would never find it — put it in
+                    # node_objs directly, which is consulted before the store.
                     if self.predictor_store.status(name, fold.split_idx, 0) != 'built':
                         continue
-                    flow.node_objs[name] = self.predictor_store.get_objs(
+                    flow.node_objs[name] = self.predictor_store.get_obj(
                         name, fold.split_idx, 0)
                 # _resolve needs the edges too, and neither the artifact nor
                 # this flow's history carries a Predictor's — the definition
@@ -584,8 +584,7 @@ class Trainer:
                 if output is None:
                     continue
                 if v is not None:
-                    obj = flow.node_objs[name][0]
-                    cols = eval_expr(parse(v), output, processor=obj)
+                    cols = eval_expr(parse(v), output, processor=flow.node_objs[name])
                     output = output.select_columns(cols)
                 outputs.append(output)
             if not outputs:

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -211,8 +211,17 @@ class TestBuild:
         _setup_stage(pipeline, exp)
         exp.build()
         flow = _flow(exp)
-        assert 'scaler' in flow.node_objs
         assert flow.status('scaler') == 'built'
+
+    def test_build_leaves_nothing_in_flow_memory(self, exp, pipeline):
+        """A build writes its artifact and hands the flow nothing — whoever
+        reads the node next takes it off disk."""
+        _setup_stage(pipeline, exp)
+        exp.build()
+        flow = _flow(exp)
+        assert 'scaler' not in flow.node_objs
+        flow.get_train({'X': 'scaler:(*)'})
+        assert 'scaler' in flow.node_objs
 
     def test_build_skips_built(self, exp, pipeline):
         _setup_stage(pipeline, exp)
@@ -455,11 +464,11 @@ class TestTrialLeavesNoArtifact:
         exp.exp(_folds(_dt(), exp))
         flow = _flow(exp)
         assert flow.status('scaler') == 'built'
-        assert 'scaler' in flow.node_objs
+        assert flow.get_obj('scaler') is not None
 
     def test_a_trial_reads_nodes_built_in_the_same_process(self, exp, pipeline, project):
-        """Nodes are published into the flow by build(); a Trial reading one
-        through a namespace segment has to find it there."""
+        """A Trial reading a node through a namespace segment loads it out of
+        the store — build() published nothing into the flow."""
         _setup_stage(pipeline, exp)
         exp.build()
         trial = _dt(edges={'X': 'scaler:(*)', 'y': '{target}'})
@@ -501,28 +510,30 @@ class TestTrialLeavesNoArtifact:
 
 
 class TestRebuild:
+    # build_id, not object identity: nothing is held in flow memory across a
+    # build anymore, so two reads of the same artifact are two objects and
+    # `is not` would pass without anything having been rebuilt.
+    def _build_id(self, exp):
+        return exp.node_store.get_info('scaler')[(0, 0)]['build_id']
+
     def test_build_with_rebuild_true(self, exp, pipeline):
         _setup_stage(pipeline, exp)
         exp.build()
-        flow = _flow(exp)
-        old_obj = flow.node_objs['scaler'][0]
+        old_id = self._build_id(exp)
         exp.build(rebuild=True)
-        new_obj = _flow(exp).node_objs['scaler'][0]
-        assert flow.status('scaler') == 'built'
-        assert old_obj is not new_obj
+        assert _flow(exp).status('scaler') == 'built'
+        assert self._build_id(exp) != old_id
 
     def test_set_node_replace_then_build(self, exp, pipeline):
         _setup_stage(pipeline, exp)
         exp.build()
-        flow = _flow(exp)
-        old_obj = flow.node_objs['scaler'][0]
+        old_id = self._build_id(exp)
         # Staleness is a value diff now (no serial) — 'replace' with the exact
         # same definition is correctly a no-op, so this needs an actual change.
         pipeline.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
         _publish(pipeline, exp)
         exp.build()
-        new_obj = _flow(exp).node_objs['scaler'][0]
-        assert new_obj is not old_obj
+        assert self._build_id(exp) != old_id
         assert _flow(exp).status('scaler') == 'built'
 
     def test_exp_skips_folds_already_recorded_built(self, exp, pipeline, project):
@@ -606,8 +617,10 @@ class TestSaveLoad:
 
         loaded = project.load_experimenter(exp.name, sample_data)
         flow = loaded.outer_folds[0].train_data_flows[0]
-        assert 'scaler' in flow.node_objs
+        # Reopening reads no artifact: what it recovers is the ability to.
+        assert flow.node_objs == {}
         assert flow.status('scaler') == 'built'
+        assert flow.get_train({'X': 'scaler:(*)'})['X'].get_shape()[0] > 0
         assert _trial_built(project.trials, 'dt', loaded)
 
     def test_load_restores_pipeline(self, project, exp, pipeline, sample_data):
@@ -729,17 +742,54 @@ class TestNodeStore:
         assert store.get_status('node1') == {(0, 0): 'built'}
         assert store.get_info('node1') == {(0, 0): {'role': 'stage', 'edges': {'X': '{f1}'}}}
 
-    def test_dataflow_autoload(self, tmp_path):
-        """DataFlow composes a NodeStore now (no inheritance) and needs a
-        node_hist row to know a node is a Stage (role) and how to route its
-        edges — see DataFlow.load()."""
+    def test_dataflow_reads_nothing_until_asked(self, tmp_path):
+        """Constructing a flow touches no artifact — a run makes one per fold
+        up front, so anything read here is read for every fold of the grid."""
         store = NodeStore(tmp_path)
         store.write_objs('node1', 0, 0, StandardScaler(), None)
         store.record('node1', 0, 0, status='built',
-                     info={'role': 'stage', 'edges': {'X': '{f1}'}})
+                     info={'edges': {'X': '{f1}'}})
         flow = DataFlow(store, outer_idx=0, inner_idx=0)
-        assert 'node1' in flow.node_objs
+        assert flow.node_objs == {}
         assert flow.status('node1') == 'built'
+
+    def test_dataflow_recovers_edges_on_first_use(self, tmp_path):
+        """DataFlow composes a NodeStore (no inheritance) and neither pickle
+        carries edges, so routing comes from the node_hist row."""
+        store = NodeStore(tmp_path)
+        store.write_objs('node1', 0, 0, StandardScaler(), None)
+        store.record('node1', 0, 0, status='built',
+                     info={'edges': {'X': '{f1}'}})
+        flow = DataFlow(store, outer_idx=0, inner_idx=0)
+        assert flow._processor('node1') is not None
+        assert flow._node_edges['node1'] == {'X': '{f1}'}
+
+    def test_dataflow_raises_for_a_node_that_is_not_built(self, tmp_path):
+        """Loudly — the old answer was a segment that contributed no columns
+        and said nothing about it."""
+        flow = DataFlow(NodeStore(tmp_path), outer_idx=0, inner_idx=0)
+        with pytest.raises(KeyError, match='not built'):
+            flow._processor('node1')
+
+    def test_dataflow_raises_for_an_artifact_with_no_history(self, tmp_path):
+        store = NodeStore(tmp_path)
+        store.write_objs('node1', 0, 0, StandardScaler(), None)
+        flow = DataFlow(store, outer_idx=0, inner_idx=0)
+        with pytest.raises(KeyError, match='no recorded edges'):
+            flow._processor('node1')
+
+    def test_dataflow_sees_a_node_built_after_it_read_the_fold(self, tmp_path):
+        """The fold's history is cached, but a build hands the flow nothing —
+        so a miss has to re-query rather than answer from the old snapshot."""
+        store = NodeStore(tmp_path)
+        flow = DataFlow(store, outer_idx=0, inner_idx=0)
+        with pytest.raises(KeyError):
+            flow._processor('node1')
+
+        store.write_objs('node1', 0, 0, StandardScaler(), None)
+        store.record('node1', 0, 0, status='built',
+                     info={'edges': {'X': '{f1}'}})
+        assert flow._processor('node1') is not None
 
 
 class TestGetMissingNodes:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -838,8 +838,7 @@ class TestTrainerUnderProject:
 
         loaded = project.load_trainer('trainer_reload', wrap(sample_data))
         flow = loaded.train_folds[0].train_data_flows[0]
-        assert 's1' in flow.node_objs
-        assert 's2' in flow.node_objs
+        assert flow.node_objs == {}
 
         # The selection comes back from PredictorStore, so nothing needs
         # re-supplying and nothing is reset by reopening.
@@ -851,6 +850,8 @@ class TestTrainerUnderProject:
         # routes data through s1 -> s2, not just that obj.pkl happened to load.
         train_data = flow.get_train({'X': 's2:(*)', 'y': '{target}'})
         assert train_data['X'].get_shape()[0] > 0
+        assert 's1' in flow.node_objs
+        assert 's2' in flow.node_objs
 
     def test_trainer_reopens_without_a_project(self, project, sample_data):
         """Trainer.load_trainer() reads the Pipeline the Trainer itself saved

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -387,17 +387,20 @@ class TestPredictorStorage:
             assert trainer.node_store.status('scaler', fold.split_idx, 0) == 'built'
 
     def test_predictor_is_not_loaded_into_the_flow(self, pipeline, sample_data, sp_v):
-        """Its history is in the other store, so flow.load() never sees a row
-        for it — which is what keeps the fitted model out of memory."""
+        """Its artifact is in the other store, so the node flow's lazy load
+        can't reach it — which is what keeps the fitted model out of memory.
+        Resolving the nodes it was trained on doesn't drag it in either."""
         trainer = _make_trainer(pipeline, sample_data, sp_v)
         trainer.set_pipeline(pipeline.build())
         trainer.train(_predictors())
 
         flow = trainer.train_folds[0].train_data_flows[0]
         flow.node_objs.clear()
-        flow.load()
+        flow.get_train({'X': 'scaler:(*)'})
         assert 'scaler' in flow.node_objs
         assert 'dt' not in flow.node_objs
+        with pytest.raises(KeyError):
+            flow._processor('dt')
 
     def test_definitions_are_persisted(self, pipeline, sample_data, sp_v):
         trainer = _make_trainer(pipeline, sample_data, sp_v)


### PR DESCRIPTION
Closes #138.

## Lazy, because a run builds a flow per fold up front

`DataFlow.__init__` ended in an unconditional `load()`, and `load()` pulled every built node's `obj.pkl` **and** `result.pkl` for that fold. `Experimenter.__init__` builds one `TrainDataFlow` per `(outer, inner)`, so reopening a built run materialised the whole grid before the caller had asked for anything — a 5×3 grid over ten nodes is 150 processors and 150 intermediate datasets, paid by `load_experimenter`, which is the ordinary way to resume.

Nothing is read now until `_processor()` needs it, and `node_objs` becomes what it already was in substance: a cache of `obj.pkl`. `edges` still come from `node_hist`, but that is one query per fold and touches no artifact, so it stays eager — with a re-query on a miss, since a flow constructed before a node was built holds a snapshot without it.

## Train was the one output with no budget

| output | where it lived | managed? |
|---|---|---|
| valid / test | `DataCache`, keyed `(scope, node, typ)` | LRU, byte-capped |
| **train** | `node_objs[name][1]`, returned directly | **no cap, never evicted** |

Train is the largest split. It goes through the same cache now, so all three are under one budget and `clear_nodes` covers it for free.

**The three are recovered differently, and that is the point.** valid/test are *recomputed* via `obj.process`; train is *re-read* from `result.pkl`. It has to be — train output is what `fit_process` returned, and for a cross-fitting node that is not what `process` returns for the same rows: `CrossFitTransformer` yields out-of-fold predictions while fitting and full-model predictions afterwards. There is no path from an evicted train output back to `obj.process` anymore.

One exception, which the suite caught: a node whose method is plain `fit` stored no fit-time output at all, so `result.pkl` holds `None` and `process` *is* the definition of its train output. That is the one case where recomputing is the answer rather than a substitute for a lost one — not an edge case but the normal path for `method='transform'` nodes.

## Publishing goes with it

`set_objs` existed so a finished job could hand its obj/result to the flow. Lazy loading makes that unnecessary: the artifact is on disk before the flow would have been told, and whoever reads it next takes it from there.

In the worker pool this removes a readback the parent was doing *purely* to publish — the orchestrator had been accumulating every fitted model and every intermediate output in the run for the sake of a load the next job can do itself. `chained` now means one thing: the dependency gate.

The cost is one pickle load per fold per consumer, against the fit that produced it. With no `cache`, train output is re-read rather than held; that is a read, not a recompute, so the values are unchanged.

## Two things that were already wrong

- `DataFlow._resolve` returned `None` for an unloaded node and `get_data` skipped that segment, so a missing node contributed no columns and said nothing about it, while `TrainDataFlow._resolve_typ` indexed `node_objs` and raised `KeyError`. Both are now "load it, or fail loudly".
- `_execute_multi`'s all-workers-lost fallback used `job.name in job.flow.node_objs` as "did this finish". A leaf job is never in `node_objs`, so a Trial or Predictor that had completed was recorded as never run. It uses the `done` set the loop already maintains.

## Left alone

Where fitted processors themselves live — the open question on the issue. Lazy loading already means only folds actually touched hold any, and a count cap is a different unit from the byte budget; mixing them would make the budget mean less than it does. Worth revisiting against a run where processors are demonstrably the problem.

Implementing it did settle one of the three options, though: `eval_expr(processor=obj)` needs the processor on every segment resolution even when the data is a cache hit, so "no cache, read `obj.pkl` per use" would have been expensive in a way the issue did not anticipate.

## Tests

Eight tests asserted the eager behaviour and were re-pointed at the new contract. Two in `TestRebuild` compared `node_objs['scaler'][0]` by identity — under lazy loading two reads are always two objects, so the assertion would have passed without anything being rebuilt; they compare `build_id` from `node_hist` instead. `test_dataflow_autoload` became five tests covering the lazy contract: nothing read at construction, edges recovered on first use, a loud failure for an unbuilt node, a loud failure for an artifact with no history row, and a node built after the flow read the fold.

Full suite: 1137 passed, 7 skipped.
