### PR TITLE
feat(Project): read the state that spans stores, and preview what a change costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,9 +204,17 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
   - **성공 이력이 있는 이름은 얼린다**: `experiment_hist`에 `'built'` fold가 있는데 정의가 다르면 `ValueError`. 이력은 이름으로 키잉되고 Trial은 아티팩트를 안 남기므로, 재정의하면 옛 결과가 그걸 만든 적 없는 정의를 설명하게 된다 — 한 Trial의 기록처럼 보이는 두 개가 됨. 바꾸려면 새 이름이거나 `remove_trial`(결과까지 포기). `'error'`뿐이면 지킬 결과가 없으니 허용
   - `set_trials`는 **전부 검사한 뒤에 쓴다** — 하나가 얼려 있으면 아무것도 안 바뀐다(절반만 등록되면 반환한 작업 목록이 거짓이 됨)
   - 문지기 없는 저수준 경로는 `trials.register()` — 테스트가 재정의 동작을 직접 확인할 때 씀
-- **`show_error_trials(experimenter=None, traceback=False)`**: Trial 실행 에러를 fold당 한 줄로. `Experimenter.show_error_nodes`의 Trial판이고 **여기 있는 이유는 이력의 주인이 여기라서**(노드 이력은 Experimenter, Trial 이력은 프로젝트). 실패가 없으면 `None`
+- **`error_trials(experimenter=None)`**: Trial 실행 실패를 fold당 dict 하나로 — `trial_name`/`experimenter`/`outer_idx`/`inner_idx`/`pipeline_version` + 평탄화된 `type`/`message`/`traceback`. `Experimenter.error_nodes`의 Trial판이고 **여기 있는 이유는 이력의 주인이 여기라서**(노드 이력은 Experimenter, Trial 이력은 프로젝트). 깨끗하면 `[]`
 - **`pending_trials(experimenter=None)`**: 등록된 Trial 중 **에러났거나 이력이 아예 없는** 이름 목록. 둘 다 "아직 돌려야 할 것"이라 한 목록으로 낸다 — 손으로 쓰면 후자만 잡아서 실패한 게 조용히 빠진다(#130이 노트북에서 지목한 실제 버그)
   - **일부러 거칠다**: fold 일부만 돌다 끊긴 건 안 잡는다 — 그걸 판정하려면 fold 그리드와 대조해야 하는데 이 store는 그걸 모른다. 반환된 이름을 그냥 돌려도 안전하다(`exp()`가 끝난 fold를 건너뜀)
+- **`collect_errors(experimenter=None, collectors=None)`**: 수집 실패를 fold당 dict 하나로. 세 번째 에러 읽기이고(노드는 `Experimenter.error_nodes`, Trial은 위 `error_trials`), **유일하게 Experimenter를 거쳐야 읽는다** — Collector 이력은 레지스트리 소유고 레지스트리는 Experimenter별이라, 자기 store가 없어 `Experimenter.collect_errors`에 묻는다
+  - 팬아웃하면서 **`experimenter` 키를 얹는다** — `collect_hist`엔 그 컬럼이 일부러 없고(어느 것이냐는 db가 어디 있느냐로 답한다), 여러 레지스트리를 가로지를 때만 필요해지는 값이라
+- **`stale_nodes(pipeline=None, experimenter=None)`**: 그 정의를 채택하면 어느 노드의 아티팩트가 날아가는지를 **채택 전에** 본다 → `{experimenter: [노드...]}`. `Experimenter.stale_nodes` 위임
+  - `pipeline=None`이면 **working copy**를 `self.pipeline.copy().build()`로 빌드해 쓴다 — copy는 db가 없어서(`PipelineBuilder(path=None)` → `_store=None`) `build()`가 버전을 안 찍는다. 조회가 publish하면 이전 published가 archived로 내려가고, `add_experimenter`/`add_trainer`의 기본값이 published라 **미리보기가 다음 채택 대상을 바꿔버린다**
+  - `load_pipeline()`을 넘기면 반대 방향 질문이 된다 — 각 Experimenter가 published보다 얼마나 뒤처졌나
+  - 노드 전용. Trial은 채택이 안 건드리므로 여기 안 나온다
+- **`uncollected_trials(experimenter=None, collectors=None)`**: 돌긴 했는데 매칭되는 Collector가 아무것도 못 남긴 Trial. `Experimenter.uncollected_trials`에 위임하고 **`{experimenter: {collector: [trial...]}}`로 중첩**해 돌려준다(같은 Trial 이름이 여러 Experimenter에 있어도 읽히게)
+  - 여기 있는 이유는 Collector가 답할 수 없어서다 — 노드 이름으로만 키잉돼 있고 프로젝트를 모른다. 반대로 `Experimenter`는 `trial_store`를 주입받고 레지스트리를 소유해서 세 조각이 거기서 만난다
 - **`remove_trial(name)`**: Trial 하나를 프로젝트에서 완전히 지운다 — 정의(`TrialStore.trials`) + 이력(`experiment_hist`, **모든 experimenter**) + 각 Experimenter가 수집한 데이터와 그 `CollectHist`. Trial은 아티팩트를 안 남기는 대신 흔적이 서로 모르는 store들에 흩어져 있고, **그걸 다 보는 건 Project뿐**이라 여기 있다(단일 store 위의 편의 래퍼가 아니라, 주인 없는 교차 연산에 주인을 준 것)
   - 프로젝트 전역 절반(정의 + 전 experimenter 이력)은 각각 SQL 한 문장이고, Experimenter별 절반은 **`experimenters` 순회** → `Experimenter.remove_trial_result(name)` 위임
   - **대상을 고르는 인자가 없다** — 하나 빼면 프로젝트가 더 이상 정의하지 않는 Trial의 결과가 남고, 그 뒤엔 어느 Experimenter가 아직 들고 있는지 아무도 못 답한다
@@ -250,6 +258,16 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - `cache`(`DataCache`, optional) — `None`이면 캐시 없이 동작. store는 optional이 아니라(자기가 만듦) standalone Experimenter도 meta/splitter/Pipeline이 전부 저장됨
 - **`collectors`**: `Collectors({path}/collectors)` — 생성자에서 만들고(생성자가 곧 복원) `node_store`와 같은 자리. Collector가 쓰는 건 전부 노드 이름만으로 키잉되므로 **경로가 두 Experimenter를 가르는 유일한 수단**이다 — 프로젝트 전역 레지스트리였다면 이름이 겹치는 Trial마다 서로의 결과를 덮어썼다(무증상, 그리고 하필 비교가 필요한 바로 그 경우에). 대가는 Experimenter 간 비교가 store N개에 대한 읽기가 되는 것(#130)
 - **`trial_store`**(`TrialStore`, optional): 실행할 Trial을 읽고 결과를 기록하는 곳. `cache`처럼 **생성자에서 한 번** 주입 — 프로젝트에 하나뿐이고 Experimenter 수명 동안 바뀌지 않는다. **영속화 안 함**: 프로젝트 레벨 객체라 자기 디렉토리만 아는 Experimenter가 찾아낼 방법이 없고, 상위 레이아웃을 추측하는 건 이 구조가 피해온 암묵 결합. 없으면 `_require_trial_store()`가 두 공급 경로를 안내하며 `RuntimeError`
+- **`stale_nodes(pipeline)`**: `set_pipeline(pipeline)`이 지울 노드 이름(정렬). **`set_pipeline`이 이걸 호출한다** — 미리보기와 실제가 한 구현이라 갈라질 수 없다
+  - **사후에 물을 수 없어서 사전에 묻는다**: staleness는 두 Pipeline 비교로 파생되자마자 삭제로 소비되고 어디에도 안 남는다. 채택이 끝난 디스크엔 stale한 아티팩트가 없다(지워졌으니까)
+  - 아직 아무것도 채택 안 했으면 `[]` — 빈 Pipeline은 "이전 정의 없음"이지 "빌드된 게 없음"이 아니라, 그것과 비교하면 전 노드가 나온다
+  - 이름일 뿐 아티팩트가 있다는 주장은 아니다 — 실제로 잃는 게 뭔지는 `get_status(name)`
+  - builder는 `TypeError`. 여기서 빌드하지 않으므로 묻는 행위가 publish하지 않는다
+- **`collect_errors(collectors=None)`**: 이 Experimenter의 레지스트리에 기록된 수집 실패 행(`status='error'`). `None`이면 **이력 전체** — 등록에서 이미 빠진 Collector가 남긴 것도 포함한다(실패는 실제로 일어났으므로). 이름을 주면 그것만. `Project.collect_errors`가 이걸로 읽는다
+- **`uncollected_trials(collectors=None)`**: 여기서 *돌아간* Trial 중 매칭되는 Collector가 아무것도 못 남긴 것 → `{collector: [trial...]}`. **어느 단일 store도 답할 수 없는 유일한 질문**이라 여기 있다 — `experiment_hist`(무엇이 돌았나, 프로젝트 소유지만 이 이름으로 키잉), `collect_hist`(무엇이 수집됐나, 레지스트리 소유), `Connector.match`(어느 Collector가 붙나)가 `trial_store` 주입 덕에 이 객체 안에서 만난다
+  - **`'built'`인 fold만 본다**: 안 돌아간 Trial은 수집 문제가 아니라 `Project.pending_trials`의 몫이고, 그걸 섞으면 `remove_trial_result`가 멀쩡한 이력을 지운다
+  - **행의 부재 / `'error'` / `'empty'`가 전부 같은 쪽**이다 — 셋 다 남은 게 없다는 뜻. 손으로 쓰면 부재만 잡혀서 실패가 조용히 빠진다(#130이 지목한 cell 51의 실제 버그)
+  - fold 하나라도 빠지면 보고한다 — `StackingCollector`처럼 outer 전체가 한 번에 차야 저장되는 Collector가 있어서 부분 수집도 실패다
 - **`remove_trial_result(name)`**: 이 Experimenter가 가진 Trial *결과*를 지운다 — `self.collectors.remove_results(name)`(수집 데이터 + `CollectHist` 행) + 이 Experimenter의 `experiment_hist` 행 → **다음 `exp()`가 그 Trial을 다시 돌린다**(fold 스킵의 유일한 근거가 이력이므로). 다른 Experimenter의 기록도, 정의(프로젝트 소유)도 안 건드림. `trial_store`가 없으면 이력 절반은 건너뜀
 - **pipeline을 쓰는 것들** (미채택이면 빈 Pipeline이라 에러가 아니라 무동작):
   - `build(nodes=None, rebuild=False, n_jobs=1, gpu_id_list=None, logger=None)` — 노드 빌드
@@ -263,9 +281,10 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
     - `TrialHistTracker`가 fold별 done/error를 이력에 기록(등록은 안 함)
   - `n_jobs`는 실제 작업 수로 상한 처리 (`min(n_jobs, len(jobs))`) — 유휴 워커/progress bar 방지
   - `get_node_info()`: 노드 요약 Markdown
-- **pipeline 불필요** (디스크 상태만으로 동작): `get_status(node_name)`, `reset_nodes(nodes)`, `show_error_nodes(nodes=None, traceback=False)`, `get_objs(node_name, outer_idx=0, inner_idx=0)`
-  - **넷 다 Pipeline 노드 전용.** Trial은 디스크에 아무것도 안 남기므로 `get_status`는 몇 번을 돌렸든 `None`, `reset_nodes`는 지울 게 없고, `get_objs`는 `FileNotFoundError`. Trial 쪽 대응물은 `trial_store.get_status(name, exp.name)` / `Project.show_error_trials(experimenter=)` / `remove_trial_result(name)` / (모델 대신) Collector가 모은 결과
-  - **에러 보고가 갈리는 기준은 이력의 주인이다** — 노드 이력은 Experimenter의 `node_hist`, Trial 이력은 프로젝트의 `experiment_hist`. 예전엔 `show_error_nodes` 하나가 둘을 합쳐 내놨는데, 출력 라벨이 `[이름] fold o_i` 하나뿐이라 노드인지 Trial인지 구분이 안 됐다. 포맷은 `_common.format_errors`가 공유(둘 다 실패를 같은 모양으로 설명하므로)
+- **pipeline 불필요** (디스크 상태만으로 동작): `get_status(node_name)`, `reset_nodes(nodes)`, `error_nodes(nodes=None)`, `get_objs(node_name, outer_idx=0, inner_idx=0)`
+  - **넷 다 Pipeline 노드 전용.** Trial은 디스크에 아무것도 안 남기므로 `get_status`는 몇 번을 돌렸든 `None`, `reset_nodes`는 지울 게 없고, `get_objs`는 `FileNotFoundError`. Trial 쪽 대응물은 `trial_store.get_status(name, exp.name)` / `Project.error_trials(experimenter=)` / `remove_trial_result(name)` / (모델 대신) Collector가 모은 결과
+  - **에러 보고가 갈리는 기준은 이력의 주인이다** — 노드 이력은 Experimenter의 `node_hist`, Trial 이력은 프로젝트의 `experiment_hist`. 예전엔 한 메소드가 둘을 합쳐 내놨는데 노드인지 Trial인지 구분이 안 됐다
+  - **셋 다 문자열이 아니라 dict 리스트를 낸다**(`error_nodes`/`error_trials`/`collect_errors`) — 사람이 볼 땐 호출부가 `pd.DataFrame(...)`으로 감싸고, 코드가 먹을 땐 파싱이 없다. 그래서 `show_` 접두사도 없다. 에러 페이로드를 파내는 건 `_common.error_payload`가 공유(노드·Trial은 `info['error']` 아래, 수집은 최상위 + `phase`라 병합)
 - **OS log capture** (`open_os_log`/`close_os_log`/`os_log`):
   - `open_os_log(log_path=None)`: 이 프로세스의 OS-level stdout/stderr(fd 1/2)를 `{path}/__worker_logs/master.log`(기본값)로 dup2 리다이렉트 — `self._os_log_state`에 원본 fd/`sys.stdout`·`stderr` 백업 보관. 이미 open이면 에러
   - `close_os_log()`: 리다이렉트 원복. open 안 된 상태에서 호출하면 no-op
@@ -299,7 +318,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - **history**: SQLite `node_hist(node_name, outer_idx, inner_idx, pipeline_version, status, info)` — PK는 `(node_name, outer_idx, inner_idx)`(Experimenter/Trainer 이름 컬럼 없음 — store 자체가 이미 거기에 스코프돼 있음)
   - `record(name, outer_idx, inner_idx, pipeline_version=, status=, info=)` — `info`는 `status` 제외 나머지 전부(`build_id`, `definition`, `fit_time`, `edges`, `train_shape`, `warnings`, 실패 시 `error`) JSON 인코딩. `NodeInfoTracker`(`_tracker.py`)가 기록
   - `get_hist(node_name=, outer_idx=, inner_idx=, pipeline_version=)`/`get_status(node_name)`/`get_info(node_name)`(`{(outer_idx, inner_idx): ...}`)/`get_fold_info(outer_idx, inner_idx)`(fold 하나의 `{node_name: info}` 전체 — `DataFlow`가 노드의 `edges`를 복원할 때 씀)/`remove_hist(node_name=)`
-  - `'error'`는 오직 여기서만 보임 — `Experimenter.show_error_nodes`/`Trainer.get_node_error`가 조회
+  - `'error'`는 오직 여기서만 보임 — `Experimenter.error_nodes`/`Trainer.get_node_error`가 조회
 
 ### DataFlow / TrainDataFlow (`_flow.py`)
 - **DataFlow**: 생성자가 `NodeStore` 인스턴스(`self.store`, Experimenter/Trainer 전체가 공유) + 이 fold의 `outer_idx`/`inner_idx`를 받음. `status`/`get_obj`/`get_objs`/`get_result`/`list_nodes`/`node_path`는 `self.store.X(name, self.outer_idx, self.inner_idx)`로 위임하는 얇은 메소드. `reset_node`만 위임 + `node_objs`/`_node_edges`에서도 같이 지우는 조합 동작
@@ -582,6 +601,7 @@ v0 (생성 시 자동, 빈 Pipeline)
 4. old에는 있는데 지금 없는 이름 → stale (아티팩트 청소용)
 5. DataSource schema/targets가 바뀌면 → 전부 stale
 
+- **판정 시점은 `set_pipeline` 하나지만, 그 답은 채택 전에 미리 볼 수 있다** — `Experimenter.stale_nodes(pipeline)` / `Project.stale_nodes()`. `set_pipeline`이 그 메소드를 호출해서 지우므로 미리보기가 실제와 어긋나지 않는다. 사후 조회가 없는 게 아니라 **사후엔 답할 대상이 없다**(판정 즉시 지워짐)
 - **Trial은 캐스케이드하지 않는다**: Trial은 Pipeline 밖이라 diff가 이름을 모르고, stale 노드를 읽은 Trial도 건드리지 않는다 — `Experimenter.set_pipeline`은 stale 노드만 `reset_nodes`로 지우고 끝. Trial의 결과가 어떤 pipeline 버전에 대한 것인지는 `TrialStore.experiment_hist`가 `pipeline_version`으로 기록하므로 그 버전에 대한 기록으로 남고(버전을 올릴 의도가 없으면 Pipeline이 바뀔 이유도 없다), 다시 돌리려면 `remove_hist`로 명시적으로 재실행해야 함
 - **Trial 자신의 재정의도 감지하지 않는다**: `Experimenter._make_jobs`는 오직 `experiment_hist`의 fold별 status만 본다 — 재정의된 trial이 이미 `'built'`면 조용히 스킵되므로, 다시 돌리려면 `reset_nodes([trial_name])`을 직접 호출
 - **Predictor는 반대로 캐스케이드한다**: Trainer엔 보존할 "과거 실행" 개념이 없으므로, 바뀐 노드를 읽는 Predictor는 그냥 stale이다. `Trainer.reset_nodes`가 `predictor.node_names() & 리셋된_노드` 교집합으로 같이 지운다. Trial/Predictor를 별도 클래스로 둔 판단이 실제로 갈라지는 지점
@@ -658,7 +678,7 @@ v0 (생성 시 자동, 빈 Pipeline)
 - **_experimenter_store.py**: `ExperimenterStore(path)` — **Experimenter 하나 전용** `{path}/__exp.db`. meta 행 + splitter BLOB + `save_pipeline(pipeline)`/`load_pipeline()`(`_common`에 위임). `fetch`/`load_splitters`/`remove`는 행이 하나뿐이라 `name` 생략 가능
 - **_trainer_store.py**: `TrainerStore(path)` — Trainer판 동형. `{path}/__trainer.db`, `trainer(name PK, pipeline_version, splits BLOB)`. Experimenter판과 다른 점 둘: splits 블롭에 **`split_indices`가 같이** 들어감(splitter가 없을 수도 있고, 학습된 fold와 정확히 같아야 해서), `data_key`/`title`이 **없음**(다른 Trainer와 비교할 일이 없어 라벨도 mismatch 가드도 불필요)
   - **`save(meta)`가 `INSERT OR IGNORE` + `UPDATE`인 이유**(양쪽 store 공통): meta 컬럼만 나열한 `INSERT OR REPLACE`는 같은 행의 BLOB(splitters/splits)을 NULL로 날려버린다
-- **_common.py**: Experimenter/Trainer 공용 — `require_built_pipeline`, `require_frozen_pipeline`(Trainer 전용 게이트), `resolve_common_status`, `save_pipeline(path, pipeline)`/`load_pipeline(path)`(`{path}/pipeline.pkl`, 없으면 `None`), `format_errors`
+- **_common.py**: Experimenter/Trainer 공용 — `require_built_pipeline`, `require_frozen_pipeline`(Trainer 전용 게이트), `resolve_common_status`, `save_pipeline(path, pipeline)`/`load_pipeline(path)`(`{path}/pipeline.pkl`, 없으면 `None`), `error_payload`
 - **_describer.py**: desc_spec, desc_pipeline, desc_node, compare_nodes
 - **_logger.py**: BaseLogger, DefaultLogger (start/update/end_progress, adhoc_progress, rename_progress)
 - **col.py / _connector.py / collector/ / filter/ / adapter/ / processor/**: 해당 섹션 참조

--- a/docs/concepts/state-model.md
+++ b/docs/concepts/state-model.md
@@ -17,7 +17,7 @@ error ──► (reset_nodes) ──► init
 
 State is per node **per fold**. `get_status(name)` reports the state across all folds of a run.
 
-`built` is decided by the artifact on disk — the store simply checks whether `obj.pkl` exists. `error` never appears there, only in the run's history table, which is where `show_error_nodes()` and `get_node_error()` look.
+`built` is decided by the artifact on disk — the store simply checks whether `obj.pkl` exists. `error` never appears there, only in the run's history table, which is where `error_nodes()` and `get_node_error()` look.
 
 If an upstream node is in `error`, everything downstream fails without any explicit propagation logic — its inputs are simply missing.
 

--- a/docs/guide/experimenter-trials.md
+++ b/docs/guide/experimenter-trials.md
@@ -118,8 +118,9 @@ The store itself is not an argument: an Experimenter reached through a `Project`
 
 ```python
 e.get_status('scale')
-e.show_error_nodes()                              # this run's Pipeline nodes
-project.show_error_trials(experimenter=e.name)    # its Trials
+e.error_nodes()                                   # this run's Pipeline nodes
+project.error_trials(experimenter=e.name)         # its Trials
+project.collect_errors(experimenter=e.name)       # its Collectors
 
 from IPython.display import Markdown, display
 display(Markdown(e.get_node_info()))

--- a/examples/kaggle_s6e6/2. Second Phase.ipynb
+++ b/examples/kaggle_s6e6/2. Second Phase.ipynb
@@ -1081,7 +1081,11 @@
     "않는다. `CollectHist`를 조회하면 그 사실이 드러난다.\n",
     "\n",
     "다시 수집하려면 그 Trial의 fold 이력을 명시적으로 지워야 한다 — `reset_nodes()`는 아티팩트만 지우고\n",
-    "스킵 판정에 쓰이는 이력은 건드리지 않는다."
+    "스킵 판정에 쓰이는 이력은 건드리지 않는다.\n",
+    "\n",
+    "`e.uncollected_trials(collector)`가 그 조회다 — 이 run에서 돌아간 fold만 대상으로, 매칭되는\n",
+    "Collector가 아무것도 남기지 못한 Trial을 Collector별로 준다. 프로젝트 전체를 한 번에 보려면\n",
+    "`project.uncollected_trials()`, 수집 중 난 에러는 `project.collect_errors()`다."
    ]
   },
   {
@@ -1094,10 +1098,12 @@
     "collectors.set_collector('cb_evals_results', MA, conn(processor='catboost.CatBoostClassifier'),\n",
     "                         params={'result_key': 'evals_result'}, exist='replace')\n",
     "\n",
-    "cb_trials = [t for t in round1 + round2 + round3 + round4 + round5 if t.name.startswith('cb')]\n",
-    "missing = [t for t in cb_trials\n",
-    "           if not hist.get_hist(collector_name='cb_evals_results', node_name=t.name)]\n",
-    "[t.name for t in missing]"
+    "# 손으로 쓰면 '이력 행이 아예 없는 것'만 잡힌다 — status가 'error'/'empty'인 행이 있는 trial은\n",
+    "# 조용히 빠지고, 아직 안 돌린 trial은 거꾸로 수집 실패로 둔갑해 아래 셀이 멀쩡한 이력을 지운다.\n",
+    "# 이 읽기가 셋을 갈라준다: 이 run에서 'built'로 기록된 fold만 보고, 그 중 하나라도 'collected'\n",
+    "# 행이 없으면 보고한다. 어느 Collector가 어느 Trial에 붙는지도 이름이 아니라 Connector가 정한다.\n",
+    "missing = e.uncollected_trials('cb_evals_results')['cb_evals_results']\n",
+    "missing"
    ]
   },
   {
@@ -1109,11 +1115,11 @@
    "source": [
     "# 수집 결과 + 이 run의 fold 이력을 함께 지운다 — 이력이 fold 스킵의\n",
     "# 유일한 근거라, 이게 곧 '다시 돌려라'다.\n",
-    "for t in missing:\n",
-    "    e.remove_trial_result(t.name)\n",
+    "for name in missing:\n",
+    "    e.remove_trial_result(name)\n",
     "\n",
     "with e.os_log():\n",
-    "    run(missing)"
+    "    e.exp(missing, n_jobs=2, gpu_id_list=[0], logger=logger)"
    ]
   },
   {
@@ -1133,8 +1139,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e.show_error_nodes()                            # 이 run의 Pipeline 노드\n",
-    "project.show_error_trials(experimenter=e.name)  # 그 Trial들\n",
+    "# 셋 다 dict 리스트다 — 사람이 볼 땐 DataFrame으로 감싸고, 코드가 먹을 땐 그대로 쓴다.\n",
+    "pd.DataFrame(e.error_nodes())                       # 이 run의 Pipeline 노드\n",
+    "pd.DataFrame(project.error_trials(experimenter=e.name))   # 그 Trial들\n",
+    "pd.DataFrame(project.collect_errors(experimenter=e.name)) # 수집 실패 (phase 포함)\n",
+    "\n",
     "display(Markdown(e.get_node_info()))"
    ]
   },

--- a/mllabs/_common.py
+++ b/mllabs/_common.py
@@ -77,22 +77,19 @@ def resolve_common_status(statuses):
     return statuses.pop() if len(statuses) == 1 else 'inconsistent'
 
 
-def format_errors(rows, traceback=False):
-    """``(name, outer_idx, inner_idx, info)`` rows as printable error lines.
+def error_payload(info):
+    """A history row's failure, flattened to ``type``/``message``/``traceback``.
 
-    Shared by the node-side and Trial-side reporters, which read different
-    stores but describe a failure the same way.
+    Shared by the node-side and Trial-side readers, which read different stores
+    but record a failure the same way — under ``info['error']``. A row with no
+    payload still answers, with ``None`` in every field, so the caller never has
+    to check whether the key was there.
 
-    Returns:
-        list[str] | None: One line per row, or ``None`` if there were none —
-        so an empty result reads as "nothing failed" at a glance.
+    Collection history is not one of these: ``CollectHist`` writes ``phase``
+    beside the same three fields and writes them at the top level, so it is
+    merged rather than dug out.
     """
-    errors = []
-    for name, outer_idx, inner_idx, info in rows:
-        err = (info or {}).get('error', {})
-        label = f"[{name}] fold {outer_idx}_{inner_idx}"
-        line = f"{label} {err.get('type')}: {err.get('message')}"
-        if traceback:
-            line += f"\n{err.get('traceback')}"
-        errors.append(line)
-    return errors or None
+    err = (info or {}).get('error', {})
+    return {'type': err.get('type'),
+            'message': err.get('message'),
+            'traceback': err.get('traceback')}

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -65,7 +65,7 @@ def _stop_native_redirect(state):
     sys.stdout = state['orig_stdout']
     sys.stderr = state['orig_stderr']
     state['log_f'].close()
-from ._common import resolve_common_status, require_built_pipeline, format_errors
+from ._common import resolve_common_status, require_built_pipeline, error_payload
 from ._pipeline import Pipeline
 
 
@@ -388,19 +388,46 @@ class Experimenter():
         Returns:
             Pipeline: *pipeline*, unchanged.
         """
-        require_built_pipeline(pipeline)
-        # Only a *switch* invalidates. With nothing adopted yet the empty
-        # Pipeline is the absence of a prior definition, not a claim that
-        # nothing was built — reopening restores artifacts, and diffing
-        # against the placeholder would delete every one of them.
-        if not self.pipeline.is_empty:
-            stale = pipeline.diff_from(self.pipeline)
-            if stale:
-                self.reset_nodes(sorted(stale))
+        stale = self.stale_nodes(pipeline)
+        if stale:
+            self.reset_nodes(stale)
         self.pipeline = pipeline
         self._store.save_pipeline(pipeline)
         self._store.set(self.name, 'pipeline_version', self.pipeline_version)
         return pipeline
+
+    def stale_nodes(self, pipeline):
+        """Nodes whose artifacts adopting *pipeline* would drop.
+
+        The answer :meth:`set_pipeline` acts on, available before acting — that
+        call resets exactly this list, because it is this method's caller. One
+        implementation, so a preview cannot drift from the act it previews.
+
+        Asked before rather than after because adoption *spends* the answer:
+        staleness is derived by comparing two Pipelines
+        (:meth:`Pipeline.diff_from`) and immediately turned into deletions, so
+        afterwards there is no stale artifact left to find. Pass the published
+        Pipeline instead of a draft and the same call answers whether this
+        Experimenter is behind, and what catching up would cost.
+
+        Nothing is stale while nothing is adopted: the empty Pipeline is the
+        absence of a prior definition, not a claim that nothing was built, and
+        diffing against it would name every node here.
+
+        Args:
+            pipeline (Pipeline): The candidate, already built. Building is what
+                mints a version, so build first and then ask — this never
+                builds, and so never publishes.
+
+        Returns:
+            list[str]: Node names, sorted. Names, not a claim that each has an
+            artifact here — ``get_status(name)`` says which ones actually cost
+            something to drop.
+        """
+        require_built_pipeline(pipeline)
+        if self.pipeline.is_empty:
+            return []
+        return sorted(pipeline.diff_from(self.pipeline))
 
     def _require_trial_store(self):
         if self.trial_store is None:
@@ -489,32 +516,133 @@ class Experimenter():
         if self.trial_store is not None:
             self.trial_store.remove_hist(trial_name=name, experimenter=self.name)
 
-    def show_error_nodes(self, nodes=None, traceback=False):
-        """Errors from this Experimenter's Pipeline nodes, one line per failed fold.
+    def collect_errors(self, collectors=None):
+        """Collection failures recorded in this Experimenter's registry.
+
+        The read half of what :meth:`remove_trial_result` writes: a Collector's
+        history is this Experimenter's, so asking the project about it means
+        coming through here (``Project.collect_errors``).
+
+        Args:
+            collectors (str | list[str], optional): Registered Collector names.
+                ``None`` reads every row in the history, including any left by a
+                Collector that has since been removed from the registry — the
+                failure still happened.
+
+        Returns:
+            list[dict]: ``collector_name``, ``node_name``, ``outer_idx``,
+            ``inner_idx``, ``pipeline_version``, and the failure merged in flat
+            — ``phase`` (``'output'``/``'ext'``/``'collect'``/``'push'``, which
+            of the four points broke), ``type``, ``message``, ``traceback``.
+            Empty when nothing failed. ``collect_date``/``elapsed`` are not
+            here — that is ``collectors.hist.get_errors()``.
+        """
+        hist = self.collectors.hist
+        if collectors is None:
+            rows = hist.get_errors()
+        else:
+            rows = [row for c in self._collectors_named(collectors)
+                    for row in hist.get_errors(collector_name=c.name)]
+        return [{'collector_name': r['collector_name'],
+                 'node_name': r['node_name'],
+                 'outer_idx': r['outer_idx'],
+                 'inner_idx': r['inner_idx'],
+                 'pipeline_version': r['pipeline_version'],
+                 **(r['info'] or {})}
+                for r in rows]
+
+    def _collectors_named(self, collectors):
+        """Registered Collectors for a name or a list of them.
+
+        A bare string is wrapped rather than iterated — ``resolve`` takes a
+        list, so passing one name straight through would ask for its letters.
+        """
+        if isinstance(collectors, str):
+            collectors = [collectors]
+        return self.collectors.resolve(collectors)
+
+    def uncollected_trials(self, collectors=None):
+        """Trials a Collector matches but has no result for, per Collector.
+
+        Answers the one question about this Experimenter that no single store
+        can: whether a Trial that *ran* here left the Collector anything.
+        `experiment_hist` knows what ran (project-wide, so this Experimenter's
+        rows are keyed by its name), `collect_hist` knows what was collected
+        (registry-local), and which Collectors even apply comes from matching
+        their Connectors against the Trial spec. All three meet here because
+        ``trial_store`` is injected and the registry is ours.
+
+        Written by hand the join tends to lose two things. A Trial that has no
+        history row at all reads as "collected" unless absence is checked for
+        separately, and a Trial that never ran reads as a collection failure —
+        which then invites ``remove_trial_result`` on history that was fine.
+        So only folds recorded ``'built'`` here are considered, and a Trial is
+        reported when any of them lacks a ``'collected'`` row: an ``'error'``, an
+        ``'empty'`` (usually a misconfigured ``output_var``) and a missing row
+        all fall on the same side, since all three mean nothing was kept.
+
+        A Trial that has not run is not a collection problem — that is
+        ``Project.pending_trials``.
+
+        Args:
+            collectors (str | list[str], optional): Registered Collector names.
+                ``None`` asks about every one of them.
+
+        Returns:
+            dict: ``{collector_name: [trial_name, ...]}``, one key per asked-for
+            Collector, empty list when it has everything.
+        """
+        trial_store = self._require_trial_store()
+        hist = self.collectors.hist
+
+        collected = {(r['collector_name'], r['node_name'], r['outer_idx'], r['inner_idx'])
+                     for r in hist.get_hist(status='collected')}
+        built = {}
+        for r in trial_store.get_hist(experimenter=self.name, status='built'):
+            built.setdefault(r['trial_name'], []).append((r['outer_idx'], r['inner_idx']))
+
+        targets = {c.name for c in self._collectors_named(collectors)}
+        result = {name: [] for name in targets}
+        for trial in trial_store.list_trials():
+            folds = built.get(trial.name)
+            if not folds:
+                continue
+            for c in self.collectors.match(trial.get_spec()):
+                if c.name in targets and any(
+                        (c.name, trial.name, o, i) not in collected for o, i in folds):
+                    result[c.name].append(trial.name)
+        return result
+
+    def error_nodes(self, nodes=None):
+        """Failed folds of this Experimenter's Pipeline nodes, one dict each.
 
         Pipeline nodes only, as the name says. Error detail does not live on
         the artifact (see ``NodeStore``) — it is in this Experimenter's own
         ``node_hist`` — so this reads history rather than walking fold
         directories. Trial errors are the project's to report, since that is
-        where their history lives: ``Project.show_error_trials(experimenter=)``.
+        where their history lives: ``Project.error_trials(experimenter=)``.
 
         Args:
             nodes (list[str], optional): Node names to check. ``None`` checks
                 every node recorded here.
-            traceback (bool): Include full traceback in output.
 
         Returns:
-            list[str] | None: One line per failed fold, or ``None`` if clean.
+            list[dict]: ``node_name``, ``outer_idx``, ``inner_idx``,
+            ``pipeline_version`` and the flattened failure (``type``,
+            ``message``, ``traceback``). Empty when nothing failed. The rest of
+            a node's ``info`` (definition, edges, fit_time…) is not here — that
+            is ``node_store.get_hist()``.
         """
-        rows = [
-            (r['node_name'], r['outer_idx'], r['inner_idx'], r['info'])
+        node_set = None if nodes is None else set(nodes)
+        return [
+            {'node_name': r['node_name'],
+             'outer_idx': r['outer_idx'],
+             'inner_idx': r['inner_idx'],
+             'pipeline_version': r['pipeline_version'],
+             **error_payload(r['info'])}
             for r in self.node_store.get_hist()
-            if r['status'] == 'error'
+            if r['status'] == 'error' and (node_set is None or r['node_name'] in node_set)
         ]
-        if nodes is not None:
-            node_set = set(nodes)
-            rows = [r for r in rows if r[0] in node_set]
-        return format_errors(rows, traceback)
 
     def build(self, nodes=None, rebuild=False, n_jobs=1, gpu_id_list=None, logger=None):
         """Build Stage nodes.

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from ._cache import DataCache
 from ._trial_store import TrialStore
 from ._project_store import ProjectStore
-from ._common import format_errors
+from ._common import error_payload
 
 DATA_FILE = 'data.pkl'
 AUG_DATA_FILE = 'aug_data.pkl'
@@ -391,27 +391,32 @@ class Project:
         self.trials.register_all(changed)
         return [t.name for t in changed]
 
-    def show_error_trials(self, experimenter=None, traceback=False):
-        """Errors from Trial execution, one line per failed fold.
+    def error_trials(self, experimenter=None):
+        """Failed folds of Trial execution, one dict each.
 
-        The Trial counterpart of ``Experimenter.show_error_nodes``, and it
-        lives here for the same reason that one lives there: a failure is
-        reported by whoever owns the history it is recorded in. Node history is
-        the Experimenter's; Trial history is the project's, keyed by experimenter.
+        The Trial counterpart of ``Experimenter.error_nodes``, and it lives
+        here for the same reason that one lives there: a failure is read from
+        whoever owns the history it is recorded in. Node history is the
+        Experimenter's; Trial history is the project's, keyed by experimenter.
 
         Args:
-            experimenter (str, optional): Report only this Experimenter's
-                failures. ``None`` reports every one's.
-            traceback (bool): Include full traceback in output.
+            experimenter (str, optional): Only this Experimenter's failures.
+                ``None`` reads every one's.
 
         Returns:
-            list[str] | None: One line per failed fold, or ``None`` if clean.
+            list[dict]: ``trial_name``, ``experimenter``, ``outer_idx``,
+            ``inner_idx``, ``pipeline_version`` and the flattened failure
+            (``type``, ``message``, ``traceback``). Empty when clean.
         """
-        rows = [
-            (r['trial_name'], r['outer_idx'], r['inner_idx'], r['info'])
+        return [
+            {'trial_name': r['trial_name'],
+             'experimenter': r['experimenter'],
+             'outer_idx': r['outer_idx'],
+             'inner_idx': r['inner_idx'],
+             'pipeline_version': r['pipeline_version'],
+             **error_payload(r['info'])}
             for r in self.trials.get_hist(experimenter=experimenter, status='error')
         ]
-        return format_errors(rows, traceback)
 
     def pending_trials(self, experimenter=None):
         """Registered Trials that errored or have not run.
@@ -442,6 +447,90 @@ class Project:
             if not rows or any(r['status'] == 'error' for r in rows):
                 pending.append(trial.name)
         return pending
+
+    def collect_errors(self, experimenter=None, collectors=None):
+        """Collection failures across the project, one dict each.
+
+        The third error read beside :meth:`error_trials` and
+        ``Experimenter.error_nodes``, and the only one that has to go through
+        an Experimenter: a Collector's history belongs to the registry that owns
+        it, and the registry is per-Experimenter. So this asks each one via
+        ``Experimenter.collect_errors`` rather than reading a store of its own,
+        and adds the ``experimenter`` key that ``collect_hist`` deliberately
+        has no column for — which one it was is answered by whose db it is.
+
+        Args:
+            experimenter (str, optional): Only this Experimenter's failures.
+                ``None`` reads every one's.
+            collectors (str | list[str], optional): Registered Collector names.
+                ``None`` reads every one of them.
+
+        Returns:
+            list[dict]: ``Experimenter.collect_errors`` rows with
+            ``experimenter`` added. Empty when clean.
+        """
+        return [{'experimenter': name, **row}
+                for name in self._experimenter_names(experimenter)
+                for row in self.experimenters[name].collect_errors(collectors)]
+
+    def uncollected_trials(self, experimenter=None, collectors=None):
+        """Trials that ran but left a matching Collector nothing.
+
+        A Collector cannot answer this alone — it is keyed by node name and
+        knows nothing of the project — so the question is asked here and
+        delegated to ``Experimenter.uncollected_trials``, which has the
+        project's ``trial_store`` injected and owns the registry.
+
+        Args:
+            experimenter (str, optional): Ask only this one. ``None`` asks every
+                Experimenter in the project.
+            collectors (str | list[str], optional): Registered Collector names.
+                ``None`` asks about every one of them.
+
+        Returns:
+            dict: ``{experimenter_name: {collector_name: [trial_name, ...]}}`` —
+            nested rather than flattened so the answer stays readable when a
+            Trial name appears under more than one Experimenter.
+        """
+        return {name: self.experimenters[name].uncollected_trials(collectors)
+                for name in self._experimenter_names(experimenter)}
+
+    def stale_nodes(self, pipeline=None, experimenter=None):
+        """What adopting a definition would cost each Experimenter, before adopting.
+
+        Delegates to ``Experimenter.stale_nodes``, the same code ``set_pipeline``
+        resets by — a preview of the real thing, not a second opinion about it.
+
+        Defaults to the working copy, built through ``pipeline.copy()`` so the
+        snapshot has no db and :meth:`PipelineBuilder.build` mints nothing.
+        Asking what an edit would cost must not be what commits the edit: a
+        published version demotes the previous one, and ``add_experimenter`` /
+        ``add_trainer`` take published by default, so a mere preview would
+        change what the next call adopts.
+
+        Pipeline nodes only. A Trial is never reset by adoption — its
+        ``experiment_hist`` row records the version it ran against and stays a
+        true record of it, so rerunning is a separate, explicit act.
+
+        Args:
+            pipeline (Pipeline, optional): The candidate. ``None`` uses the
+                working copy as it stands. Pass :meth:`load_pipeline` output
+                instead to ask the other direction — how far behind the
+                published definition each Experimenter is.
+            experimenter (str, optional): Ask only this one. ``None`` asks every
+                Experimenter in the project.
+
+        Returns:
+            dict: ``{experimenter_name: [node_name, ...]}``, empty list for an
+            Experimenter the change does not touch.
+        """
+        if pipeline is None:
+            pipeline = self.pipeline.copy().build()
+        return {name: self.experimenters[name].stale_nodes(pipeline)
+                for name in self._experimenter_names(experimenter)}
+
+    def _experimenter_names(self, experimenter=None):
+        return self.list_experimenters() if experimenter is None else [experimenter]
 
     def remove_trial(self, name):
         """Drop *name* from the project — definition, history and collected data.

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -26,6 +26,10 @@ def dummy_metric(y, pred):
     return 0.5
 
 
+def boom_metric(y, pred):
+    raise ValueError('boom')
+
+
 @pytest.fixture
 def sample_data():
     np.random.seed(42)
@@ -1137,3 +1141,96 @@ class TestProcessCollector:
         result = pc.get_output()
         assert list(result.columns) == ['dt__target_1']
         assert result.shape == (20, 1)
+
+
+class TestCollectState:
+    """Reading what was collected — the one question that spans stores."""
+
+    def _acc(self, e, name='acc', connector=None, metric=accuracy_metric):
+        return e.collectors.set_collector(
+            name, MetricCollector, connector or Connector(),
+            params={'output_var': None, 'metric_func': metric})
+
+    def test_uncollected_empty_when_everything_collected(self, built_exp):
+        mc = self._acc(built_exp.e)
+        _run(built_exp, collectors=[mc.name])
+        assert built_exp.e.uncollected_trials() == {'acc': []}
+
+    def test_uncollected_reports_collector_attached_after_the_run(self, built_exp):
+        """The case the history is there to expose: folds already recorded
+        'built' are skipped, so a Collector attached afterwards never sees them
+        and exp() reports nothing wrong."""
+        _run(built_exp, collectors=[])
+        self._acc(built_exp.e)
+        assert built_exp.e.uncollected_trials() == {'acc': ['dt']}
+
+    def test_uncollected_ignores_a_trial_that_never_ran(self, built_exp):
+        """Not run is not a collection failure — that is pending_trials. Getting
+        this wrong invites remove_trial_result on history that was fine."""
+        self._acc(built_exp.e)
+        _register(built_exp.trial, built_exp.e)
+        assert built_exp.e.uncollected_trials() == {'acc': []}
+
+    def test_uncollected_ignores_a_trial_the_connector_skips(self, multi_head_exp):
+        mc = self._acc(multi_head_exp.e, connector=Connector(node_query='dt1'))
+        _run(multi_head_exp, multi_head_exp.trial1, multi_head_exp.trial2,
+             collectors=[mc.name])
+        assert multi_head_exp.e.uncollected_trials() == {'acc': []}
+
+    def test_uncollected_counts_a_failed_collect(self, built_exp):
+        """An error row and a missing row mean the same thing here — nothing
+        was kept — so both land in the list."""
+        mc = self._acc(built_exp.e, name='boom', metric=boom_metric)
+        _run(built_exp, collectors=[mc.name])
+        assert built_exp.e.uncollected_trials() == {'boom': ['dt']}
+
+    def test_uncollected_selects_by_name(self, built_exp):
+        good = self._acc(built_exp.e)
+        bad = self._acc(built_exp.e, name='boom', metric=boom_metric)
+        _run(built_exp, collectors=[good.name, bad.name])
+        assert built_exp.e.uncollected_trials('boom') == {'boom': ['dt']}
+
+    def test_collect_errors_rows(self, built_exp):
+        """The failure is merged in flat — phase says which of the four points
+        broke, and nothing has to be dug out of a nested info."""
+        mc = self._acc(built_exp.e, name='boom', metric=boom_metric)
+        _run(built_exp, collectors=[mc.name])
+        rows = built_exp.e.collect_errors()
+        assert len(rows) == built_exp.e.get_n_splits()
+        assert {r['collector_name'] for r in rows} == {'boom'}
+        assert rows[0]['node_name'] == 'dt'
+        assert rows[0]['phase'] == 'collect'
+        assert rows[0]['type'] == 'ValueError'
+        assert rows[0]['message'] == 'boom'
+
+    def test_collect_errors_empty_when_clean(self, built_exp):
+        mc = self._acc(built_exp.e)
+        _run(built_exp, collectors=[mc.name])
+        assert built_exp.e.collect_errors() == []
+
+    def test_project_collect_errors_adds_the_experimenter(self, built_exp):
+        """collect_hist has no experimenter column on purpose — which one it is
+        gets answered by whose db it is, so the fan-out supplies the key."""
+        mc = self._acc(built_exp.e, name='boom', metric=boom_metric)
+        _run(built_exp, collectors=[mc.name])
+        rows = built_exp.project.collect_errors()
+        assert len(rows) == built_exp.e.get_n_splits()
+        assert rows[0]['experimenter'] == 'exp_built'
+        assert rows[0]['collector_name'] == 'boom'
+        assert rows[0]['phase'] == 'collect'
+
+    def test_project_collect_errors_empty_when_clean(self, built_exp):
+        mc = self._acc(built_exp.e)
+        _run(built_exp, collectors=[mc.name])
+        assert built_exp.project.collect_errors() == []
+
+    def test_project_collect_errors_by_experimenter(self, built_exp):
+        mc = self._acc(built_exp.e, name='boom', metric=boom_metric)
+        _run(built_exp, collectors=[mc.name])
+        assert built_exp.project.collect_errors('exp_built')
+        assert built_exp.project.collect_errors('exp_built', collectors='boom')
+
+    def test_project_uncollected_trials_is_nested_by_experimenter(self, built_exp):
+        _run(built_exp, collectors=[])
+        self._acc(built_exp.e)
+        assert built_exp.project.uncollected_trials() == {'exp_built': {'acc': ['dt']}}

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -612,6 +612,55 @@ class TestSetPipeline:
         assert flow.status('scaler') is None
 
 
+class TestStaleNodes:
+    """Adoption spends the answer — it derives staleness and turns it straight
+    into deletions — so before adopting is the only moment it can be read."""
+
+    def test_nothing_adopted_is_nothing_stale(self, tmp_path, sample_data, pipeline):
+        """The empty Pipeline means 'no prior definition', not 'nothing was
+        built'; diffing against it would name every node."""
+        e = Experimenter(path=tmp_path / 'fresh', name='e1', data=sample_data)
+        assert e.stale_nodes(pipeline.build()) == []
+
+    def test_unchanged_definition_is_nothing_stale(self, exp, pipeline):
+        _setup_stage(pipeline, exp)
+        exp.build()
+        assert exp.stale_nodes(pipeline.build()) == []
+
+    def test_changed_node_is_named(self, exp, pipeline):
+        _setup_stage(pipeline, exp)
+        exp.build()
+        pipeline.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        assert exp.stale_nodes(pipeline.build()) == ['scaler']
+
+    def test_preview_is_exactly_what_adoption_resets(self, exp, pipeline):
+        """Why the two share one implementation: what the preview names is what
+        loses its artifact, with nothing else touched."""
+        _setup_stage(pipeline, exp)
+        exp.build()
+        flow = _flow(exp)
+        pipeline.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        candidate = pipeline.build()
+
+        predicted = exp.stale_nodes(candidate)
+        assert predicted and all(flow.status(n) == 'built' for n in predicted)
+        exp.set_pipeline(candidate)
+        assert all(flow.status(n) is None for n in predicted)
+
+    def test_asking_changes_nothing(self, exp, pipeline):
+        _setup_stage(pipeline, exp)
+        exp.build()
+        adopted = exp.pipeline_version
+        pipeline.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        exp.stale_nodes(pipeline.build())
+        assert exp.pipeline_version == adopted
+        assert _flow(exp).status('scaler') == 'built'
+
+    def test_builder_is_rejected(self, exp, pipeline):
+        with pytest.raises(TypeError, match='built Pipeline'):
+            exp.stale_nodes(pipeline)
+
+
 class TestSaveLoad:
     def test_load_restores(self, project, exp, pipeline, sample_data):
         _setup_stage(pipeline, exp)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -704,43 +704,90 @@ class TestExperimenterUnderProject:
 
 
 class TestTrialErrorReporting:
-    """Who reports a failure follows who owns the history it sits in: node
-    history is the run's (Experimenter.show_error_nodes), Trial history is the
+    """Who answers for a failure follows who owns the history it sits in: node
+    history is the run's (Experimenter.error_nodes), Trial history is the
     project's, keyed by experimenter."""
 
-    def test_show_error_trials_reports_the_failed_fold(self, project):
+    def test_error_trials_reports_the_failed_fold(self, project):
         project.trials.record('bad', 'run_a', 0, 1, status='error',
                               info={'error': {'type': 'ValueError', 'message': 'boom',
                                               'traceback': 'TB'}})
-        lines = project.show_error_trials()
-        assert len(lines) == 1
-        assert '[bad] fold 0_1' in lines[0] and 'ValueError: boom' in lines[0]
-        assert 'TB' not in lines[0]
+        rows = project.error_trials()
+        assert rows == [{'trial_name': 'bad', 'experimenter': 'run_a',
+                         'outer_idx': 0, 'inner_idx': 1, 'pipeline_version': None,
+                         'type': 'ValueError', 'message': 'boom', 'traceback': 'TB'}]
 
-    def test_traceback_is_opt_in(self, project):
-        project.trials.record('bad', 'run_a', 0, 0, status='error',
-                              info={'error': {'type': 'ValueError', 'message': 'boom',
-                                              'traceback': 'TB'}})
-        assert 'TB' in project.show_error_trials(traceback=True)[0]
+    def test_a_row_without_a_payload_still_answers(self, project):
+        """The failure fields are always there, so a caller never has to check
+        whether info carried them."""
+        project.trials.record('bad', 'run_a', 0, 0, status='error')
+        assert project.error_trials()[0]['type'] is None
 
-    def test_nothing_failed_reads_as_none(self, project):
+    def test_nothing_failed_is_empty(self, project):
         project.trials.record('dt', 'run_a', 0, 0, status='built')
-        assert project.show_error_trials() is None
+        assert project.error_trials() == []
 
     def test_narrowed_to_one_run(self, project):
         project.trials.record('bad', 'run_a', 0, 0, status='error')
         project.trials.record('bad', 'run_b', 0, 0, status='built')
-        assert project.show_error_trials(experimenter='run_a')
-        assert project.show_error_trials(experimenter='run_b') is None
+        assert project.error_trials(experimenter='run_a')
+        assert project.error_trials(experimenter='run_b') == []
 
     def test_node_errors_stay_out_of_it(self, project, builder, sample_data):
-        """show_error_nodes is Pipeline nodes only — the two halves used to
-        come back from one call, indistinguishable in the output."""
+        """error_nodes is Pipeline nodes only — the two halves used to come back
+        from one call, indistinguishable in the output."""
         version = builder.build().version
         e = project.add_experimenter('run_a', sample_data,
                                  pipeline_version=version)
         project.trials.record('bad', 'run_a', 0, 0, status='error')
-        assert e.show_error_nodes() is None
+        assert e.error_nodes() == []
+
+
+class TestStaleNodes:
+    """What an edit would cost, asked before adopting it — the only moment the
+    answer exists, since set_pipeline turns it straight into deletions."""
+
+    @staticmethod
+    def _built_run(project, builder, sample_data, name='run_a'):
+        e = project.add_experimenter(name, sample_data, pipeline_version=builder.build().version)
+        e.build()
+        return e
+
+    def test_untouched_working_copy_costs_nothing(self, project, builder, sample_data):
+        e = self._built_run(project, builder, sample_data)
+        assert project.stale_nodes() == {'run_a': []}
+        assert e.get_status('scaler') == 'built'
+
+    def test_edit_names_the_node_it_would_drop(self, project, builder, sample_data):
+        self._built_run(project, builder, sample_data)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        assert project.stale_nodes() == {'run_a': ['scaler']}
+
+    def test_asking_does_not_publish(self, project, builder, sample_data):
+        """The working copy is built through copy(), which has no db — a
+        preview that minted a version would demote the published one and
+        change what add_experimenter() adopts next."""
+        self._built_run(project, builder, sample_data)
+        before = project.list_pipeline_versions()
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        project.stale_nodes()
+        assert project.list_pipeline_versions() == before
+
+    def test_narrowed_to_one_run(self, project, builder, sample_data):
+        self._built_run(project, builder, sample_data, 'run_a')
+        self._built_run(project, builder, sample_data, 'run_b')
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        assert project.stale_nodes(experimenter='run_a') == {'run_a': ['scaler']}
+
+    def test_published_pipeline_asks_the_other_direction(self, project, builder, sample_data):
+        """How far behind a run is: it adopted v0, the project has since
+        published the node."""
+        e = project.add_experimenter('run_a', sample_data,
+                                     pipeline_version=builder.build().version)
+        e.build()
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        builder.build()
+        assert project.stale_nodes(project.load_pipeline()) == {'run_a': ['scaler']}
 
 
 class TestPendingTrials:


### PR DESCRIPTION
Closes #130.

## What was measured first

Across the example project — two notebooks, 158 cells — six cells read state. Four are one-line reads of a single store (`collect_hist` grouped by status, its errors, its elapsed, an `experiment_hist` dump), one is already served by the library, and **one spans stores and is wrong**. The 2026-08-04 conclusion that call-site assembly is enough holds for the four; they are left exactly as they are.

So this is not about convenience. Two things earn code:

## 1. A cross-store join that fails silently

The notebook asked which Trials a Collector kept nothing for by looking for a **missing** `collect_hist` row:

```python
missing = [t for t in cb_trials
           if not hist.get_hist(collector_name='cb_evals_results', node_name=t.name)]
```

A Trial whose collection recorded `'error'` has a row, so it drops out — and `missing` feeds `remove_trial_result` plus a rerun. Written correctly the join is ~13 lines over three stores and needs six things right; the notebook skipped one.

`Experimenter.uncollected_trials(collectors=None)` does it, because the three pieces meet there: `experiment_hist` (what ran — the project's store, injected), `collect_hist` (what was kept — the registry's, which is per-Experimenter), and `Connector.match` (which Collectors even apply).

- Only folds recorded `'built'` here count. A Trial that never ran is not a collection failure — that is `pending_trials` — and confusing the two invites `remove_trial_result` on history that was fine.
- A missing row, an `'error'` and an `'empty'` all fall on the same side: all three mean nothing was kept.
- Any fold short is reported, since a `StackingCollector` only writes once its outer folds are all in.

`Project.uncollected_trials` fans out and nests by Experimenter.

## 2. Staleness, which is not stored anywhere

`set_pipeline` derives it by diffing two Pipelines and immediately spends it on deleting artifacts — so after adopting there is nothing stale left to find. The only moment the answer exists is **before**:

```python
project.stale_nodes()                        # what my current edits would drop
project.stale_nodes(project.load_pipeline())  # how far behind published each run is
e.stale_nodes(candidate)                     # one run
```

`set_pipeline` now calls `Experimenter.stale_nodes`, so the preview and the act are one implementation and cannot drift.

`Project.stale_nodes()` builds the working copy through `pipeline.copy()`, which has no db, so `build()` mints nothing. Asking what an edit would cost must not be what commits it: publishing demotes the current version, and `add_experimenter`/`add_trainer` take published by default, so a mere preview would change what the next call adopts.

Pipeline nodes only — adoption never touches a Trial, whose `experiment_hist` row stays a true record of the version it ran against.

## 3. Errors come back as data

| before | now |
|---|---|
| `Experimenter.show_error_nodes(nodes, traceback)` | `Experimenter.error_nodes(nodes=None)` |
| `Project.show_error_trials(experimenter, traceback)` | `Project.error_trials(experimenter=None)` |
| `Project.show_collect_errors(experimenter, traceback)` | `Project.collect_errors(experimenter=None, collectors=None)` |

Each returns dicts: the store's identity columns plus the failure flattened — `type`, `message`, `traceback`, and `phase` for collection (`'output'`/`'ext'`/`'collect'`/`'push'`, which of the four points broke). Wrapping in a DataFrame is the caller's business; code that wants to act no longer parses a report. `_common.format_errors` gives way to `error_payload`.

**Breaking**: the three renames, the dropped `traceback=` argument (the field is always in the row), and `[]` instead of `None` for a clean read.

## Left open, deliberately

- **Policy is baked into `uncollected_trials`** — no argument selects "errors only" or excludes `'empty'`. No demand for it yet; raw `hist.get_hist()` is still there.
- **Version awareness** — a Trial collected under v3 counts as collected while the run is on v7. What that *should* mean is a policy question about old results, not a read, so it is left for a separate issue.
- **Trainer** has no `stale_nodes`; a preview there also has to account for the Predictor cascade.

## Tests

`tests/test_collector.py::TestCollectState` (12), `tests/test_experimenter.py::TestStaleNodes` (6), `tests/test_project.py::TestStaleNodes` (5), plus the error readers reworked in `TestTrialErrorReporting`.

Full suite green locally: 1172 passed, 17 skipped.