### PR TITLE
feat(Pipeline): draft or published, and a version each definition carries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ Git 관련 내용(커밋 메시지, PR, 이슈 코멘트)은 영어로 작성한
 ```
 Project(path, data, aug_data, cache_maxsize)   경로·데이터·캐시 소유 + 관리 목록
   ├─ data / aug_data                데이터셋 (data.pkl / aug_data.pkl, 지연 로드)
-  ├─ pipeline ──build()──► Pipeline 프로젝트당 하나. 빌더가 곧 open 버전, build가 publish
+  ├─ pipeline ──build()──► Pipeline 프로젝트당 하나. 빌더가 워킹카피, build가 publish
+  │              draft()──► Pipeline 같은 스냅샷, 등록 안 함 (채택 불가)
   ├─ TrialStore                     Trial 정의 + 실행 이력 (프로젝트 전역 — 결과 비교가 목적)
   ├─ ProjectStore                   이름 목록만 (experimenters / trainers)
   ├─ experimenters{name: Experimenter}   CV 실험 (exp/{name}/) — Trial을 평가
@@ -89,7 +90,8 @@ Disk 칸은 **노드(와 Trainer의 Predictor)** 얘기다 — Trial은 아래 �
 ### PipelineBuilder / Pipeline 분리 (`_pipeline.py`)
 ```
 PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
-  └─ .build() ──► Pipeline  — 불변 스냅샷. grp 상속 해소 완료, 순수 데이터
+  ├─ .build() ──► Pipeline  — 불변 스냅샷. grp 상속 해소 완료, 순수 데이터. 등록됨(published)
+  └─ .draft() ──► Pipeline  — 같은 스냅샷, 등록 안 함. 보기용이라 채택 불가
 ```
 - **Experimenter/Trainer/Inferencer는 `Pipeline`만 보유** — builder를 넘기면 `TypeError`(`_common.require_built_pipeline`). builder를 나중에 수정해도 진행 중인 실행에 새어 들어가지 않음
 - **Pipeline은 노드 전용** — `role` 개념이 코드 어디에도 없다. 노드와 Trial을 구분하는 필드 자체가 없고, 구분이 필요한 자리도 없음(Collector는 Trial job에만 붙는다)
@@ -105,7 +107,7 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
 - `set_grp(exist='diff'|'skip'|'error'|'replace')`, `set_node(exist=...)`, `rename_grp`, `remove_grp`, `remove_node`
   - `role`/`tag` 파라미터 없음
   - **`processor`/`adapter`/`params` 스펙 검증** (`_validate_processor`/`_validate_adapter`/`_validate_params`) — 산 객체를 넘기면 `TypeError`. "Lazy resolution" 섹션 참조
-- `build()` → `Pipeline`
+- `build()` → `Pipeline`(published, 버전 발급 — db 없으면 `ValueError`) / `draft()` → 같은 스냅샷을 등록 없이(`version=None, status='draft'`). 둘 다 `_snapshot()`을 공유
 - `get_node_names(query)`, `get_node_spec(name)`, `_find_descendants(name)`
 - `sync()`: DB가 source of truth. 그룹/노드 필드를 직접 값 비교(`diff()`)해 갱신하고, **그룹이 바뀌면 그 그룹(+자식 그룹) 소속 노드들의 attrs 캐시도 함께 무효화**해 `changes['nodes']['updated']`에 포함시킴(노드 자신의 행은 안 바뀌었어도 상속받는 값이 바뀌었으므로)
 - **`serial` 없음** — 정의 변경을 표시하는 전역 신호를 두지 않는다. staleness는 `Pipeline.diff_from`의 값 비교, 버전은 `PipelineStore`의 단순 `max+1` 카운터가 담당(해시/dedup 없음)
@@ -116,7 +118,7 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
 #### Pipeline (빌드 결과)
 - `nodes`: `{name: _BuiltNode}` — `None` 키는 `_BuiltDataSource` (builder와 동일한 관례)
 - `_BuiltNode` 속성(`__slots__`): `name`, `label`, `processor`, `edges`, `method`, `adapter`, `params`, `desc`, `output_edges`
-- `pipeline_id`(builder 신원) / `build_id`(빌드 호출마다 새 UUID) / `version`(`int | None`) / `status`(`'open'`/`'published'`/`'archived'`) — **`build()`가 세팅**한다("Pipeline 버전" 섹션). db 없는 빌더의 빌드만 `version=None, status='open'`
+- `pipeline_id`(builder 신원) / `build_id`(빌드 호출마다 새 UUID) / `version`(`int | None`) / `status`(`'draft'`/`'published'` — 이 둘뿐) — `build()`가 published로, `draft()`가 draft로 낸다("Pipeline 버전" 섹션). 강등이 없어서 published라고 적힌 pkl은 영원히 published다
 - `get_node(name)`, `get_node_spec(name)`(ProcessorSpec — 노드 전용, DataSource는 `pipeline.datasource`로), `get_node_names(query=None)`
 - `topo_order()`: DataSource에서 내려오는 깊이순 노드명 (DataSource 제외) — 빌드 시 1회 계산해 캐시
 - `descendants(name)`, `check_data_compatibility(data)`
@@ -163,14 +165,16 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
 ### Trial (`_trial.py`)
 평가할 구성 하나. **Experiment 클래스는 없음** — Trial 리스트를 직접 넘긴다.
 
-- **`Trial`**: `name`, `processor`, `method`, `adapter`, `params`, `edges`, `desc`, `tag`
+- **`Trial`**: `name`, `processor`, `method`, `adapter`, `params`, `edges`, `desc`, `tag`, `pipeline_version`
   - `desc`: 순수 표시용 설명 문자열 — `PipelineBuilder`의 `desc`와 같은 역할(매칭/diff/저장 식별에 전혀 관여 안 함). 안 주면 `None`
-  - `get_spec()`: 노드의 `Pipeline.get_node_spec()`과 **똑같은 `ProcessorSpec`** 반환
+  - **`pipeline_version`은 정의의 일부다** — 어느 Pipeline 버전에 대한 후보인지. `None`이면 미스탬프이고 `Project.set_trial`이 최신 published로 채운다. `TrialStore.has()`가 이걸 비교하고 `exp()`가 채택 버전과 대조한다("Trial/Predictor 버전 스탬프" 섹션)
+  - `get_spec()`: 노드의 `Pipeline.get_node_spec()`과 **똑같은 `ProcessorSpec`** 반환 — `pipeline_version`은 안 들어간다. 실행 입력이 아니라 게이트라서 `desc`/`tag`와 같은 자리다
   - **이름이 식별자**. `TrialStore`(`trials` 테이블 PK)의 키이자 `experiment_hist`가 매다는 것이고, `exp()`가 참조하는 것도 이 이름 — Trial 객체는 프로젝트에 등록될 때만 등장하고 실행 경로엔 이름만 다닌다
   - 정의를 값으로 비교하는 별도 유틸(content_key 류)은 없다 — `TrialStore.has()`가 필드별로 직접 비교. 이 비교가 `Project.set_trial`의 문지기(변경 여부 + 성공 이력 있는 이름 동결)를 떠받침
   - `node_names()`: edges가 참조하는 노드 이름 집합
 
-- **`make_trials(name, processor, edges, method, adapter, params, param_grid, tags)`** → `list[Trial]`
+- **`make_trials(name, processor, edges, method, adapter, params, param_grid, tags, pipeline_version)`** → `list[Trial]`
+  - 프로젝트를 모르는 순수 빌더라 `pipeline_version`은 그냥 통과시킬 뿐 — 안 주면 `set_trial`이 채운다. 받는 이유는 스윕 전체를 옛 버전에 대고 저작할 수 있어야 해서(`desc`를 안 받는 것과 다른 점: 저건 표시용, 이건 실행을 가른다)
   - `params`(전 trial 공통) + `param_grid`(`{param: [values]}`) 카테시안 곱, grid 키 정렬 기준 결정적 순서
   - 이름: 단일이면 `{name}`, 복수면 `{name}_{idx}` (0 패딩)
   - `_validate_processor`/`_validate_adapter`/`_validate_params`로 spec 검증 (Pipeline과 동일 규칙)
@@ -193,25 +197,27 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
   - 그래서 "다 훑었나" 플래그가 없다 — dict는 **내가 든 것** 하나만 뜻하고, 접근당 비용은 sqlite 쿼리 하나
 - **`add_experimenter(name, data=None, pipeline_version=None, aug_data=None, **kw)` / `add_trainer(...)`**: **추가 전용** — 이미 있는 이름이면 `ValueError`. 생성은 split을 다시 계산하고 provenance를 리셋하므로 기존 것 위에 하면 재개가 아니라 피해다(#128). 기존 것은 `project.experimenters[name]`으로
   - **존재 판정이 두 질문이다**: `ProjectStore`가 "이 프로젝트가 무엇을 관리하나"(멤버십), `ExperimenterStore.stored_at`/`TrainerStore.stored_at`이 "그 디렉토리가 이미 찼나"(점유). 색인엔 없는데 디스크엔 있는 건 모순이 아니라 "우리 것은 아니지만 자리는 찼다"는 정확한 사실이고, `add_*`는 둘 다 거부한다
-  - `pipeline_version` 기본값은 **양쪽 다 published** — frozen이라 Trainer 게이트를 그냥 통과하고, 아직 아무것도 빌드 안 했으면 v0(빈 Pipeline)라 특수 케이스가 없다. 빌더에 편집만 해두고 빌드 안 한 상태로 추가하면 **그 편집은 안 들어간다**(published가 아니므로) — 채택하려면 `build()`가 먼저
+  - `pipeline_version` 기본값은 **양쪽 다 최신 published** — 채택 가능한 게 published뿐이라 게이트를 그냥 통과하고, 아직 아무것도 빌드 안 했으면 v0(빈 Pipeline)라 특수 케이스가 없다. 빌더에 편집만 해두고 빌드 안 한 상태로 추가하면 **그 편집은 안 들어간다** — 채택하려면 `build()`가 먼저
 - **`remove_experimenter(name)` / `remove_trainer(name)`**: 디렉토리 삭제 + 색인 해제 + 레지스트리에서 제거. **Experimenter는 `experiment_hist` 행까지** 지운다 — 이름이 그 이력의 키라서, 남겨두면 다음에 같은 이름으로 추가한 것이 물려받고 `exp()`가 돌린 적 없는 fold를 건너뛴다. Trial *정의*는 프로젝트 소유라 안 건드림. Trainer는 프로젝트 전역 이력이 없어 디렉토리뿐
   - 디스크 밖에 남는 것: 그 Experimenter/Trainer의 `DataCache` 항목(scope가 랜덤 id라 도달 불가능한 채 LRU에서 밀릴 때까지 남음), 이미 손에 든 파이썬 객체
 - **Pipeline**: `pipeline` property(프로젝트당 하나인 `PipelineBuilder`, 두 번 물어도 같은 객체 — 한 db 위의 두 사본이 갈라지지 않게). `load_pipeline(version=None)`, `list_pipeline_versions()`, `remove_pipeline_version(version)`. 버전 lifecycle은 아래 "Pipeline 버전" 섹션
-  - **`load_pipeline`은 읽기만 한다** — 버전을 주면 그 번호, 안 주면 published. 예전엔 인자가 없으면 working copy를 build했는데, 그건 publish라서 "load"라는 이름이 버전을 찍었고 Experimenter 추가도 덩달아 찍었다. 발급은 `build()` 한 곳에만 있다
+  - **`load_pipeline`은 읽기만 한다** — 버전을 주면 그 번호, 안 주면 최신(`MAX(version)`). 예전엔 인자가 없으면 working copy를 build했는데, 그건 publish라서 "load"라는 이름이 버전을 찍었고 Experimenter 추가도 덩달아 찍었다. 발급은 `build()` 한 곳에만 있다
 - `trials`: `TrialStore`, `store`: `ProjectStore`
 - **`set_trial(trial)` / `set_trials(trials)`**: Trial 저작 진입점. **실행과 분리된 이유** — Trial은 프로젝트 소유인데 등록이 `Experimenter.exp()`의 부수효과였다. 그래서 실행하지 않고는 프로젝트에 넣을 수 없었고, 한 Experimenter가 다른 Experimenter가 이미 쓴 이름을 조용히 덮을 수 있었다
   - 반환은 **추가·변경된 이름**(`set_trial`은 str 또는 `None`, `set_trials`는 list) — 그대로 다음 `exp()`의 작업 목록이 된다. 저장된 정의와 같으면 변경이 아님(`has()`)
   - **성공 이력이 있는 이름은 얼린다**: `experiment_hist`에 `'built'` fold가 있는데 정의가 다르면 `ValueError`. 이력은 이름으로 키잉되고 Trial은 아티팩트를 안 남기므로, 재정의하면 옛 결과가 그걸 만든 적 없는 정의를 설명하게 된다 — 한 Trial의 기록처럼 보이는 두 개가 됨. 바꾸려면 새 이름이거나 `remove_trial`(결과까지 포기). `'error'`뿐이면 지킬 결과가 없으니 허용
-  - `set_trials`는 **전부 검사한 뒤에 쓴다** — 하나가 얼려 있으면 아무것도 안 바뀐다(절반만 등록되면 반환한 작업 목록이 거짓이 됨)
-  - 문지기 없는 저수준 경로는 `trials.register()` — 테스트가 재정의 동작을 직접 확인할 때 씀
+  - **버전을 여기서 찍는다**(`_stamp_version`): `pipeline_version`이 `None`이면 최신 published. 명시하면 그걸 쓰되 **published 목록에 없는 번호면 `ValueError`**(어느 Experimenter에서도 거부되는데 이유가 안 보이므로). 넘긴 `Trial` 객체를 **직접 수정**한다 — 손에 든 것과 저장된 행이 다른 말을 하면 안 되므로
+  - 스탬프가 동결과 맞물린다: 파이프라인이 넘어간 뒤 성공 이력 있는 이름을 다시 등록하면 **버전이 달라져서 "변경"으로 잡히고** 그대로 `ValueError`. 옛 결과가 그걸 만든 적 없는 버전을 설명하게 되는 걸 관례가 아니라 기계가 막는다
+  - `set_trials`는 **전부 검사한 뒤에 쓴다** — 하나가 얼려 있으면 아무것도 안 바뀐다(절반만 등록되면 반환한 작업 목록이 거짓이 됨). **스탬프가 먼저** 도는 이유는 미스탬프 Trial은 저장된 것과 필드가 하나 달라서, 찍기 전에 비교하면 전부 "변경"으로 나오기 때문
+  - 문지기 없는 저수준 경로는 `trials.register()` — 테스트가 재정의 동작을 직접 확인할 때 씀(스탬프도 안 찍히므로 `exp()`가 거부한다. 테스트 헬퍼들이 직접 채워 넣는 이유)
 - **`error_trials(experimenter=None)`**: Trial 실행 실패를 fold당 dict 하나로 — `trial_name`/`experimenter`/`outer_idx`/`inner_idx`/`pipeline_version` + 평탄화된 `type`/`message`/`traceback`. `Experimenter.error_nodes`의 Trial판이고 **여기 있는 이유는 이력의 주인이 여기라서**(노드 이력은 Experimenter, Trial 이력은 프로젝트). 깨끗하면 `[]`
 - **`pending_trials(experimenter=None)`**: 등록된 Trial 중 **에러났거나 이력이 아예 없는** 이름 목록. 둘 다 "아직 돌려야 할 것"이라 한 목록으로 낸다 — 손으로 쓰면 후자만 잡아서 실패한 게 조용히 빠진다(#130이 노트북에서 지목한 실제 버그)
   - **일부러 거칠다**: fold 일부만 돌다 끊긴 건 안 잡는다 — 그걸 판정하려면 fold 그리드와 대조해야 하는데 이 store는 그걸 모른다. 반환된 이름을 그냥 돌려도 안전하다(`exp()`가 끝난 fold를 건너뜀)
 - **`collect_errors(experimenter=None, collectors=None)`**: 수집 실패를 fold당 dict 하나로. 세 번째 에러 읽기이고(노드는 `Experimenter.error_nodes`, Trial은 위 `error_trials`), **유일하게 Experimenter를 거쳐야 읽는다** — Collector 이력은 레지스트리 소유고 레지스트리는 Experimenter별이라, 자기 store가 없어 `Experimenter.collect_errors`에 묻는다
   - 팬아웃하면서 **`experimenter` 키를 얹는다** — `collect_hist`엔 그 컬럼이 일부러 없고(어느 것이냐는 db가 어디 있느냐로 답한다), 여러 레지스트리를 가로지를 때만 필요해지는 값이라
 - **`stale_nodes(pipeline=None, experimenter=None)`**: 그 정의를 채택하면 어느 노드의 아티팩트가 날아가는지를 **채택 전에** 본다 → `{experimenter: [노드...]}`. `Experimenter.stale_nodes` 위임
-  - `pipeline=None`이면 **working copy**를 `self.pipeline.copy().build()`로 빌드해 쓴다 — copy는 db가 없어서(`PipelineBuilder(path=None)` → `_store=None`) `build()`가 버전을 안 찍는다. 조회가 publish하면 이전 published가 archived로 내려가고, `add_experimenter`/`add_trainer`의 기본값이 published라 **미리보기가 다음 채택 대상을 바꿔버린다**
-  - `load_pipeline()`을 넘기면 반대 방향 질문이 된다 — 각 Experimenter가 published보다 얼마나 뒤처졌나
+  - `pipeline=None`이면 **working copy**를 `self.pipeline.draft()`로 스냅샷 떠서 쓴다 — draft는 등록을 안 하므로 조회가 버전을 찍지 않는다. 찍으면 `add_experimenter`/`add_trainer`의 기본값이 최신이라 **미리보기가 다음 채택 대상을 바꿔버린다**
+  - `load_pipeline()`을 넘기면 반대 방향 질문이 된다 — 각 Experimenter가 최신보다 얼마나 뒤처졌나
   - 노드 전용. Trial은 채택이 안 건드리므로 여기 안 나온다
 - **`uncollected_trials(experimenter=None, collectors=None)`**: 돌긴 했는데 매칭되는 Collector가 아무것도 못 남긴 Trial. `Experimenter.uncollected_trials`에 위임하고 **`{experimenter: {collector: [trial...]}}`로 중첩**해 돌려준다(같은 Trial 이름이 여러 Experimenter에 있어도 읽히게)
   - 여기 있는 이유는 Collector가 답할 수 없어서다 — 노드 이름으로만 키잉돼 있고 프로젝트를 모른다. 반대로 `Experimenter`는 `trial_store`를 주입받고 레지스트리를 소유해서 세 조각이 거기서 만난다
@@ -229,16 +235,18 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
 
 ### TrialStore (`_trial_store.py`)
 ```sql
-trials(name PK, desc, processor, method, adapter, params, edges, tag)
+trials(name PK, desc, processor, method, adapter, params, edges, tag,
+       pipeline_version)
 experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
                 pipeline_version, status)
 ```
+- **`pipeline_version`이 양쪽에 다 있는데 뜻이 다르다** — `trials`의 것은 *요구* 버전(정의의 일부, 게이트가 대조하는 값), `experiment_hist`의 것은 *실제로 돈* 버전. 게이트가 있어서 새로 쓰이는 행은 항상 둘이 같지만, 게이트 이전에 기록된 행은 아니고 `get_hist(pipeline_version=)`과 `error_trials()` 반환 dict가 이 컬럼을 쓴다 — 중복이라 지우기엔 비용이 더 크다
 - **인조식별자도 content hash도 없다.** 두 테이블 다 **이름이 PK**(`trials`는 trial 이름, 이력은 trial 이름 + experimenter 이름). `pipeline_version`은 해시가 아니라 **정수**로, 그 실행의 `Experimenter.pipeline_version`을 그대로 기록
 - 이름으로 키잉하는 이유: Experimenter가 이미 이름으로 키잉돼 있어(`{project}/exp/{name}`) 조인 없이 읽히고, **이름을 재정의하면 행을 덮어쓴다**가 두 테이블 모두 일관됨(`register`는 `INSERT OR REPLACE`)
 - 정의 일치 여부는 값 비교 하나로 충분해서(`has()`) 해시 컬럼을 두지 않는다. `experiment_hist`는 실행 로그일 뿐 정의의 출처가 아니므로, 이름이 재정의되면 예전 정의를 복원하는 기능은 없다
 - **재실행 여부는 `experiment_hist`가 판정한다** — `Experimenter._make_jobs`는 `experiment_hist`의 fold별 `status`만 본다: `'built'`면 스킵, `'error'`거나 기록이 없으면 job 생성. **디스크에 이와 어긋날 것이 애초에 없어서**(Trial은 아티팩트를 안 남김) 이게 유일하게 가능한 판정이고, 다시 돌리려면 `e.remove_trial_result(name)` 하나면 된다. 재정의해도 이미 `'built'`인 fold는 자동 재실행되지 않으며, **애초에 그런 재정의가 `Project.set_trial`에서 막힌다**
 - `register(trial)`/`register_all(trials)`: 이름 기준 upsert — **문지기가 없는 저수준 API**. 성공 이력 검사를 거치는 저작 진입점은 `Project.set_trial`/`set_trials`
-- `has(trial)`: 그 이름에 저장된 게 **지금** 이 정의와 같은지 필드별 비교. 저장된 게 아예 없으면 `False`(호출부가 부재를 따로 안 봐도 되게). `desc`/`tag`는 비교 대상이 아님 — 표시·선택용이라 실행이 달라지지 않음
+- `has(trial)`: 그 이름에 저장된 게 **지금** 이 정의와 같은지 필드별 비교. 저장된 게 아예 없으면 `False`(호출부가 부재를 따로 안 봐도 되게). `desc`/`tag`는 비교 대상이 아님 — 표시·선택용이라 실행이 달라지지 않음. **`pipeline_version`은 비교 대상**이다 — 어디서 돌 수 있는지를 가르므로, 같은 필드라도 다른 버전이면 다른 정의다. 파이프라인이 바뀐 뒤 같은 이름을 다시 등록하면 이게 "변경"으로 잡혀서 `set_trial`의 동결에 걸린다
 - `get_by_name(name)`/`list_trials()`: **`Trial` 객체**를 반환(`PredictorStore`와 같음). `exp()`가 이름으로 받아 여기서 정의를 꺼내 실행하므로, 넣은 것과 같은 것이 나와야 함
 - `remove(name)`: **정의만** 삭제 — `experiment_hist`는 그대로 두어 "정의가 사라진 뒤에도 무엇이 돌았는지는 읽힌다". 프로젝트에서 통째로 걷어내는 건 여러 store에 걸친 일이라 `Project.remove_trial(name)`
 - `record(trial_name, experimenter, outer_idx, inner_idx, pipeline_version, status)`, `get_hist(trial_name=, experimenter=, pipeline_version=, status=)`, `get_status(...)`, `remove_hist(...)`
@@ -250,7 +258,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - 복원은 **`Experimenter.load_experimenter(path, data, data_key=None, aug_data=None, cache=None)`** staticmethod. `{path}/__exp.db`가 없으면 `KeyError` — store를 만들기 **전에** 검사한다(안 그러면 없는 Experimenter의 디렉토리와 빈 db를 만들어놓고 실패함)
   - `Project.experimenter(...)`가 하는 일은 경로 + `cache` + ProjectStore 이름 등록 + (버전을 줬으면) `set_pipeline` 뿐
 - **이름이 식별자**: 경로는 `{project}/exp/{name}`, `TrialStore` 이력의 키도 이 이름. UUID 없음
-- **Pipeline은 객체로 지정** — `set_pipeline(pipeline)`이 이미 로드된 `Pipeline`을 받아 채택하며 **status를 안 따진다**(open이든 published든 archived든). 이 클래스는 버전으로 파이프라인을 **로드할 방법 자체가 없다**(project 참조가 없음) — 번호로 지정하려면 `Project.add_experimenter(..., pipeline_version=)`. `pipeline_version`은 **property**로 `self.pipeline`에서 읽는다(복사본을 두지 않으므로 어긋날 값이 없음)
+- **Pipeline은 객체로 지정** — `set_pipeline(pipeline)`이 이미 로드된 `Pipeline`을 받아 채택하며 **`require_published_pipeline`으로 draft를 거부**(Trainer와 같은 게이트, 버전 제한은 없음). 예전엔 아무 status나 받았는데 — 편집 중인 정의로 실험하는 게 실험의 목적이라는 근거였다 — Trial이 버전을 들고 오면서 무너졌다: 채택한 draft는 대조할 번호가 없다. 이 클래스는 버전으로 파이프라인을 **로드할 방법 자체가 없다**(project 참조가 없음) — 번호로 지정하려면 `Project.add_experimenter(..., pipeline_version=)`. `pipeline_version`은 **property**로 `self.pipeline`에서 읽는다(복사본을 두지 않으므로 어긋날 값이 없음)
   - 채택한 Pipeline은 **실험 디렉토리의 `pipeline.pkl`로 저장되고 `load_experimenter()`가 그걸 다시 읽는다** — Project 없이도 마지막에 채택한 Pipeline이 복원됨. **생성자는 안 읽는다** — `Pipeline.empty()`로 두고 `_save()`가 meta를 기본값으로 덮어쓰므로, 기존 디렉토리에 대고 생성자를 부르면 provenance가 사라진다. `Project.add_experimenter`가 이미 있는 이름을 거부하는 이유(#128)
   - **미채택 상태는 `None`이 아니라 `Pipeline.empty()`다** — 파이프라인이 없는 건 결손이 아니라 정상 상태다(Trial은 DataSource를 직접 읽으므로 노드가 하나도 없어도 `exp()`가 돈다). 객체로 말하면 소비자가 전부 분기 없이 맞는다: `build()`는 job이 없고, `topo_order()`는 빈 리스트, `check_data_compatibility`는 공허 통과 — `_require_pipeline()` 같은 게이트가 필요 없다. 프로젝트 안에서는 이게 곧 v0
   - 버전 전환 시 `pipeline.diff_from(self.pipeline)`으로 stale 판정 → `reset_nodes()`로 해당 노드 아티팩트만 제거. Trial은 건드리지 않음("Staleness" 섹션)
@@ -277,6 +285,8 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
     - 미등록 이름은 `KeyError`, 이름 자리에 `Trial`을 넘기면 `TypeError`(안 잡으면 sqlite 바인딩 에러로 새어나가 원인이 안 보임)
     - `collectors`: **이 Experimenter의 `self.collectors`에 등록된 이름 리스트**. `None`=전부, `[]`=수집 안 함. 인스턴스를 넘기면 `TypeError`(`_resolve_collectors`) — 레지스트리가 모르는 Collector는 여기 쓸 자리가 없어서 조용히 이 Experimenter 밖에 결과를 떨군다. 미등록 이름은 `Collectors.resolve`가 `KeyError`
     - 수집 이력은 항상 `self.collectors.hist` — 한 호출의 선택이 아니라 Experimenter에 속하므로 인자가 없다
+    - **버전이 다르면 job을 안 만들고 `ValueError`** — `trial.pipeline_version != self.pipeline_version`. 결과가 돌지도 않은 정의 밑에 쌓이고, 수집 데이터는 노드 이름+fold로만 키잉돼 버전이 안 들어가서 한 이름의 두 버전이 서로의 메트릭을 덮어쓴다
+      - **단, job이 생길 자리에서만 따진다** — fold 상태를 먼저 보고 남은 게 없으면 버전 대조 없이 넘어간다. 쓸 결과가 없으면 잘못 쌓일 것도 없고, "같은 이름을 다시 넘기면 이어진다"가 완료된 라운드에 대해서도 참이어야 한다(안 그러면 노트북을 위에서부터 다시 돌리는 게 에러가 된다). 일부 fold만 남았으면 그대로 거부 — 거기가 정확히 새 결과가 옛 결과 옆에 붙는 자리다
     - **`_make_jobs(trials)`가 fold 조합을 만든다** — 이름마다 `(outer_idx, inner_idx)` 전 조합을 돌며 `'built'`인 것만 빼고 `Job(name, spec, outer_idx, inner_idx, flow, need_gpu)` 생성. skip 판정은 `trial_store.get_status(name, self.name)`의 fold별 status로만 하므로, **같은 이름을 다시 넘기면 중단된 실행이 이어진다**(반복이 아니라). 정의 조회·spec·GPU 판정은 fold당이 아니라 이름당 1회
     - `TrialHistTracker`가 fold별 done/error를 이력에 기록(등록은 안 함)
   - `n_jobs`는 실제 작업 수로 상한 처리 (`min(n_jobs, len(jobs))`) — 유휴 워커/progress bar 방지
@@ -295,7 +305,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - `get_train_data(edges, o_idx=0, i_idx=0)` / `get_valid_data(...)` / `get_test_data(...)`: 출력 추출 헬퍼
 - `aug_data`: 외부 데이터를 DataSource 수준에서 inner train split에 append — 미퍼시스트
 - 저장/로드: meta/splitter는 **그 Experimenter의 `{exp_path}/__exp.db`**(`_experimenter_store.py`) — `experimenter(name PK, data_key, title, pipeline_version, splitters BLOB)`. 프로젝트 전역 experimenter db는 없다
-  - **draft(open)로 돌리면 `pipeline_version`이 NULL**이다. 어느 빌드였는지는 `pipeline.pkl` 안의 `build_id`에만 있어서 SQL로는 안 보임 — 다만 프로젝트 안에서는 `build()`가 언제나 버전을 발급하므로 이 경우는 db 없는 빌더를 직접 넘겼을 때뿐
+  - **`pipeline_version`이 NULL인 경우는 채택 전(`Pipeline.empty()`)뿐이다.** draft는 이제 채택 자체가 안 되고, 프로젝트 안에서는 `add_*`가 곧바로 v0 published를 채택시켜서 이 상태가 관측되지 않는다 — standalone에서 `set_pipeline` 없이 돌릴 때만 남는다(그때는 Trial 스탬프도 `None`이라 게이트가 공허 통과한다)
   - splitter 객체(`sp, sp_v, splitter_params`)는 ref-직렬화 불가라 컬럼이 아니라 **BLOB**(pickle)
 
 ### DataCache (`_cache.py`)
@@ -344,7 +354,8 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
   - **생성자 = 신규 생성**, 복원은 **`Trainer.load_trainer(path, data, aug_data=None, cache=None)`** staticmethod. `{path}/__trainer.db`가 없으면 `KeyError`이고, Experimenter와 같은 이유로 **store를 만들기 전에** 검사
   - 복원 시 split은 **재계산이 아니라 저장된 `split_indices`를 그대로** 씀 — splitter가 아예 없는 Trainer(단일 full-data fold)도 있고, 학습된 fold와 정확히 같아야 하므로
 - 경로 `{project}/trainers/{name}`
-- **`set_pipeline(pipeline)`**: 이미 로드된 `Pipeline` 객체를 받되 **`require_frozen_pipeline`으로 open을 거부**(published/archived만) — `pipeline_version`은 property로 `pipeline.version`에서 읽음. 버전 전환 시 `diff_from`으로 stale 제거(Experimenter와 같이, 지금 것이 비어 있으면 건너뜀). 미채택 기본값도 `Pipeline.empty()`이고 이건 생성자가 직접 넣으므로 게이트를 안 거친다
+- **`set_pipeline(pipeline)`**: 이미 로드된 `Pipeline` 객체를 받되 **`require_published_pipeline`으로 draft를 거부**(Experimenter와 같은 게이트, 버전 제한 없음 — 옛 버전을 채택하는 게 옛 정의로 평가한 Predictor를 학습하는 방법이다) — `pipeline_version`은 property로 `pipeline.version`에서 읽음. 버전 전환 시 `diff_from`으로 stale 제거(Experimenter와 같이, 지금 것이 비어 있으면 건너뜀). 미채택 기본값도 `Pipeline.empty()`이고 이건 생성자가 직접 넣으므로 게이트를 안 거친다
+  - **등록된 Predictor를 새 버전으로 재스탬프한다**(`_restamp_predictors`). 채택이 곧 "이것에 대해 학습하겠다"는 선언이라 들고 있던 Predictor도 따라간다 — 안 그러면 위의 캐스케이드가 아티팩트를 지운 뒤 `train()`이 버전 불일치로 거부해서 **버전 전환 경로 자체가 도달 불가능**해진다. `train()`의 게이트가 약해지지는 않는다: 그건 다른 동작(밖에서 승격돼 들어온 Predictor)을 막는 것이고, 그쪽은 그대로 거부된다
 - **저장소가 넷**:
   - `_store`: `TrainerStore({path})` — meta + splits BLOB + `pipeline.pkl`
   - `node_store`: `NodeStore({path})` — Pipeline 노드 아티팩트+이력
@@ -356,7 +367,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - **`predictors`/`selected_nodes`는 property** — `predictors`는 `predictor_defs.list_predictors()`(상태로 안 들고 있음 → 리로드가 공짜), `selected_nodes`는 `_nodes_for(self.predictors)`로 매번 계산(Predictor가 없으면 전 노드)
 - `predictor_names()`, `predictor_specs()`
 - `train_folds`: `[TrainFold]` — split당 `TrainDataFlow` 하나
-- **`train(predictors=None, n_jobs=1, gpu_id_list=None, logger=None)`**: 노드 먼저(위상 순서), 그 다음 Predictor `Job` 실행. 두 실행은 별개 executor 호출이라 각자 자기 store와 자기 `NodeInfoTracker`를 받음. skip 판정은 양쪽 다 디스크 기반(`store.status(name, split_idx, 0) == 'built'`) — **재정의는 그 자체로 재학습을 유발하지 않는다**(강제하려면 `reset_nodes([name])`)
+- **`train(predictors=None, n_jobs=1, gpu_id_list=None, logger=None)`**: 넘긴 Predictor 중 `pipeline_version`이 `None`인 것은 **채택 버전으로 찍고**, 채택 버전과 다른 것은 `ValueError`. Trainer는 프로젝트를 몰라 "최신 published"를 못 구하지만 자기가 채택한 버전은 알고, 직접 저작한 Predictor는 곧 눈앞의 정의에 대한 것이라 그게 맞는 값이다. 그 다음 노드 먼저(위상 순서), 그 다음 Predictor `Job` 실행. 두 실행은 별개 executor 호출이라 각자 자기 store와 자기 `NodeInfoTracker`를 받음. skip 판정은 양쪽 다 디스크 기반(`store.status(name, split_idx, 0) == 'built'`) — **재정의는 그 자체로 재학습을 유발하지 않는다**(강제하려면 `reset_nodes([name])`)
   - `predictors`는 `predictor_defs.register_all()`로 **upsert 등록**(replace 아님) — 이전 호출에서 학습한 Predictor의 정의와 아티팩트가 살아남는다. replace로 지우면 아티팩트만 남고 정의가 사라져 읽을 수 없게 됨
   - `predictors=None`이면 이미 등록된 것들을 그대로 이어서 학습(중단된 학습 재개)
   - `Trial`을 넘기면 `TypeError` — `Predictor.from_trial(trial, experimenter=)`로 명시 승격해야 출처가 기록됨
@@ -369,16 +380,17 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - 저장/로드: `save()`(meta + splits를 `_store`에 기록), 복원은 `Trainer.load_trainer()`. Pipeline은 `{path}/pipeline.pkl`, splitter/split_indices는 `__trainer.db`의 splits BLOB, **Predictor는 `predictor_defs`에서** 복원
 
 ### Predictor (`_predictor.py`)
-Trainer가 학습하는 끝지점 출력 노드. `name`, `processor`, `method`, `adapter`, `params`, `edges`, `desc`, `tag`, `src_trial`, `src_experimenter` (`__slots__`)
+Trainer가 학습하는 끝지점 출력 노드. `name`, `processor`, `method`, `adapter`, `params`, `edges`, `desc`, `tag`, `src_trial`, `src_experimenter`, `pipeline_version` (`__slots__`)
 
 - **Trial과 왜 별도 클래스인가**: 둘 다 `get_spec()`이 구분 불가능한 `ProcessorSpec`을 내놓으므로 구조만으로는 나눌 이유가 없다. 나누는 건 **의미**다 — Trial은 *비교되는 후보*라서 `TrialStore`가 프로젝트 전역이고 모든 Experimenter의 fold별 결과를 모으는 반면, Predictor는 *이미 내려진 결정*이라 중요한 게 비교 가능성이 아니라 **출처**(어떤 후보가 이걸 정당화했는가). 그래서 `src_trial`/`src_experimenter`를 들고 레지스트리는 Trainer별
 - `Predictor.from_trial(trial, name=None, experimenter=None)`: 실행 정의를 그대로 복사하고 Trial 이름을 `src_trial`로 기록(`name`으로 이름을 바꿔도 출처는 원래 이름으로 남음)
+  - **`pipeline_version`도 그 복사에 포함된다** — 그래서 승격된 Predictor는 자기 후보가 *실제로 평가된* 버전을 요구하고, 다른 데서 학습하려 하면 `train()`이 거부한다. Trainer에서 그 버전을 채택하면 된다(전부 published라 아무거나 채택 가능). **별도 `src_pipeline_version`을 두지 않는 이유**가 이거다 — 요구 버전이 곧 평가된 버전이라 provenance 필드는 같은 값의 두 번째 사본이 된다
 - `get_spec()` → `ProcessorSpec`(Trial/노드와 동일), `node_names()`: edges가 참조하는 노드 이름 집합
 
 ### PredictorStore (`_predictor_store.py`)
 ```sql
 predictors(name PK, desc, processor, method, adapter, params, edges, tag,
-           src_trial, src_experimenter)
+           src_trial, src_experimenter, pipeline_version)
 ```
 - **정의만 있고 이력 테이블이 없다** — Predictor의 fold별 status/info는 그 Trainer의 `predictor_store`(`NodeStore`)의 `node_hist`에 아티팩트와 같이 있음. `TrialStore`가 두 절반을 다 갖는 것과 대비되는데, TrialStore는 프로젝트 전역이라 "어느 Experimenter가 돌렸나"를 답해야 하는 반면 여기는 store 자체가 이미 그 Trainer로 스코프돼 있어서
 - **Trainer별인 이유**: Trial은 **결과가 중심**이라 여러 Experimenter의 성적을 한곳에 모아 비교해야 한다. Predictor는 **아티팩트가 중심**이고 서로 비교할 일이 없다 — 답하는 질문이 "*이* Trainer가 뭘 학습하나"라서 프로젝트 레벨로 공유할 이유가 없음. `Trainer`가 `self.predictors`를 상태로 안 들고 이 store를 직접 읽는 property로 둔 근거이기도 함
@@ -571,25 +583,34 @@ p.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
 "이전 정의를 참조한다"이고, 그건 이름이 아니라 버전이 답할 일이다.
 
 ```
-v0 (생성 시 자동, 빈 Pipeline)
- └─ open ──build()──► published ──build()──► archived
-    (빌더 자신)        (고정, 현재)           (고정, 삭제 가능)
-    삭제 불가          삭제 불가
+                     ┌── build() ──► published (v0, v1, v2, ... 전부)
+PipelineBuilder ─────┤              저장됨 = published. 강등 없음
+(워킹카피, 편집 가능)  └── draft() ──► draft
+                                    번호 없음, 채택 불가, 저장 안 됨
 ```
 
-- **v0는 프로젝트 생성 시점에 published로 심긴다**(`Project._seed_base_version`). "아직 파이프라인이 없다"를 **부재가 아니라 실제 행 하나**로 표현한 것 — 덕분에 `load_pipeline()`이 빈손으로 돌아오는 경우가 없고, Trainer가 그대로 채택할 수 있으며(published는 frozen이고, 빈 정의는 밑에서 바뀔 것도 없다), "published는 정확히 하나"가 프로젝트 탄생 시점부터 참이다
-- **open은 `PipelineBuilder` 자신**이다. 편집 가능한 상태는 그것뿐이라 따로 만들 게 없고, 그래서 언제나 하나다. 번호가 없다 — 초안은 채택한 쪽 밑에서 계속 변하므로 번호는 기록이 지킬 수 없는 주장이 된다
-- **`build()`가 버전을 발급한다.** 정의가 직전 published와 같으면 새로 찍지 않고 **그 번호를 그대로 준다**(`PipelineBuilder._version` → `_same_definition`). 그래서 **버전은 정의가 바뀔 때 정확히 한 번 생기고**, 별도 publish 행위가 없으며, 번호 없는 스냅샷으로 뭔가를 돌릴 방법 자체가 없어서 **모든 이력 행이 자기가 무엇으로 돌았는지 말할 수 있다**. 손 안 댄 빌더를 빌드하면 v0가 그대로 나온다 — 정의한 게 없으니 바뀐 것도 없다
+**상태는 둘뿐이다 — `draft`와 `published`.** `archived`는 없다. 저장됐다는 것이 곧
+published라서 `versions` 테이블에 status 컬럼도 없다(행의 존재가 전부). draft는
+저장 경로를 안 타므로 애초에 테이블에 나타날 수 없어서, 이 구분은 **런타임에만** 있다.
+
+- **v0는 프로젝트 생성 시점에 published로 심긴다**(`Project._seed_base_version`). "아직 파이프라인이 없다"를 **부재가 아니라 실제 행 하나**로 표현한 것 — 덕분에 `load_pipeline()`이 빈손으로 돌아오는 경우가 없고, 아무것도 정의하기 전에도 Experimenter/Trainer가 채택할 것이 있다(채택 가능한 건 published뿐이므로 이게 없으면 안 된다)
+- **`build()`가 버전을 발급한다.** 정의가 직전 버전과 같으면 새로 찍지 않고 **그 번호를 그대로 준다**(`PipelineBuilder._version` → `_same_definition`). 그래서 **버전은 정의가 바뀔 때 정확히 한 번 생기고**, 별도 publish 행위가 없으며, **채택 가능한 것은 전부 자기 번호를 말할 수 있다**. 손 안 댄 빌더를 빌드하면 v0가 그대로 나온다 — 정의한 게 없으니 바뀐 것도 없다
   - **같은 정의인지는 `diff_from`만으로 판정할 수 없다**(`_same_definition`이 DataSource 비교를 더하는 이유). `diff_from`은 "어떤 아티팩트를 지워야 하나"를 답해서 **노드 이름만** 돌려주는데, 아무 노드도 읽지 않는 schema 변경은 stale을 안 만들면서도 엄연히 다른 정의다. 이걸 빼면 노드 없이 schema만 있는 파이프라인은 처음 찍힌 버전에서 영영 못 벗어난다
-  - **비교 대상은 published 하나뿐이다 — 의도된 것이다.** 워킹카피를 예전 정의로 되돌려 빌드하면 archived와 내용이 같은 새 번호가 생기는데, "정의가 바뀔 때 버전이 생긴다"는 규칙에 어긋나지 않고(되돌린 것도 변경이다) 깨지는 것도 없다(staleness는 내용 비교라 아티팩트가 그대로 산다). archived까지 뒤져서 옛 번호를 재사용하려면 published 포인터를 뒤로 옮기거나 archived를 채택시켜야 하는데, 둘 다 이 단순한 상태 기계를 망가뜨린다
-- **published는 항상 정확히 하나** — 새로 찍히면 이전 것은 archived로 내려간다
-- **archived만 삭제 가능**(`Project.remove_pipeline_version`). 지워도 그걸로 돌린 것은 안 깨진다(각자 `pipeline.pkl` 사본을 가짐) — 없어지는 건 provenance가 가리킬 대상뿐
-- **db 없는 빌더**(`PipelineBuilder()`)는 발급할 곳이 없어 `version=None, status='open'`으로 남는다. `Trainer.set_pipeline`이 거부하는 유일한 경우
+  - **비교 대상은 최신 하나뿐이다 — 의도된 것이다.** 워킹카피를 예전 정의로 되돌려 빌드하면 옛 버전과 내용이 같은 새 번호가 생기는데, "정의가 바뀔 때 버전이 생긴다"는 규칙에 어긋나지 않고(되돌린 것도 변경이다) 깨지는 것도 없다(staleness는 내용 비교라 아티팩트가 그대로 산다)
+  - **db 없는 빌더**(`PipelineBuilder()`, `copy()`가 만드는 사본 포함)는 발급할 곳이 없어 `build()`가 `ValueError`다. 스냅샷이 필요하면 `draft()`
+- **`draft()`는 `build()`와 같은 스냅샷을 등록 없이 낸다**(`version=None, status='draft'`). 정의를 *보기* 위한 것 — `Project.stale_nodes`가 "지금 편집한 걸 채택하면 뭘 잃나"를 묻는 데 쓴다. 묻는 행위가 커밋이 되면 안 되므로. 채택은 불가: 번호가 없으면 그걸로 돈 실행이 무엇에 대한 것인지 말할 수 없고, Trial/Predictor를 대조할 대상도 없다
+- **강등이 없어서 pickle된 status가 영구히 정확하다.** `publish()`가 pickle 뜨기 전에 `status = PUBLISHED`를 박고, 그걸 뒤집는 호출이 없다 — 이미 내준 사본을 갱신할 방법이 없으므로 강등 가능한 상태를 두면 객체가 거짓말을 하게 된다. 상태를 둘로 줄인 이유 중 하나가 이것
+- **삭제는 최신만 불가**(`Project.remove_pipeline_version`). 최신이 곧 "번호를 안 주면 이것"이라, 지우면 다음 `add_experimenter`가 조용히 다른 정의를 채택한다. 그 외 버전은 자유 — 지워도 그걸로 돌린 것은 안 깨진다(각자 `pipeline.pkl` 사본을 가짐)
 - **publish는 built Pipeline과 빌더를 둘 다 저장**한다(`v{n}.pkl` / `v{n}_builder.pkl`). `build()`가 grp 상속을 해소해버려서 built 스냅샷은 편집 가능한 정의로 되돌아올 수 없기 때문 — 되돌리기 기능 자체는 아직 없고, 빌더 스냅샷이 그 문을 열어둔 것
 
-**게이트**: `Experimenter.set_pipeline`은 status를 안 따진다(편집 중인 정의로 실험하는 게 실험의 목적).
-`Trainer.set_pipeline`은 `require_frozen_pipeline`으로 **open만 거부** — 학습 결과는 배포로 이어지니
-무엇으로 학습했는지 말할 수 있어야 하고, archived도 고정돼 있으니 그 질문엔 published만큼 잘 답한다.
+**게이트는 두 층이다.**
+- **채택**: `Experimenter.set_pipeline`/`Trainer.set_pipeline` 둘 다 `require_published_pipeline` —
+  거부하는 건 draft 하나뿐이고, **어느 버전이냐는 안 따진다**. 옛 버전이 최신만큼 잘 답하고
+  강등된 것도 없으니, 옛 정의로 평가한 Predictor를 학습하려면 그 버전을 채택하면 된다.
+  예전엔 Experimenter가 아무 status나 받았다(편집 중인 정의로 실험하는 게 실험의 목적) —
+  그 근거는 아래 실행 게이트가 생기면서 무너졌다. 채택한 draft는 대조할 번호가 없다.
+- **실행**: `exp()`/`train()`이 Trial/Predictor의 `pipeline_version`을 채택 버전과 대조 →
+  다르면 `ValueError`. ("Trial/Predictor 버전 스탬프" 섹션)
 
 ## Staleness — 두 Pipeline 버전을 비교한다
 정의 변경 플래그(serial 류)가 아니라 **버전 간 구조 비교**로 판정한다. 판정 지점은 `set_pipeline()` **한 곳**이고, `build()`/`train()`은 "디스크에 있는 건 유효하다"를 전제할 수 있다. 이 방식의 부산물로 **자기가 읽지 않는 노드를 고쳐도 Trial이 유지된다**(전역 플래그로는 이 구분이 안 됨).
@@ -602,9 +623,29 @@ v0 (생성 시 자동, 빈 Pipeline)
 5. DataSource schema/targets가 바뀌면 → 전부 stale
 
 - **판정 시점은 `set_pipeline` 하나지만, 그 답은 채택 전에 미리 볼 수 있다** — `Experimenter.stale_nodes(pipeline)` / `Project.stale_nodes()`. `set_pipeline`이 그 메소드를 호출해서 지우므로 미리보기가 실제와 어긋나지 않는다. 사후 조회가 없는 게 아니라 **사후엔 답할 대상이 없다**(판정 즉시 지워짐)
-- **Trial은 캐스케이드하지 않는다**: Trial은 Pipeline 밖이라 diff가 이름을 모르고, stale 노드를 읽은 Trial도 건드리지 않는다 — `Experimenter.set_pipeline`은 stale 노드만 `reset_nodes`로 지우고 끝. Trial의 결과가 어떤 pipeline 버전에 대한 것인지는 `TrialStore.experiment_hist`가 `pipeline_version`으로 기록하므로 그 버전에 대한 기록으로 남고(버전을 올릴 의도가 없으면 Pipeline이 바뀔 이유도 없다), 다시 돌리려면 `remove_hist`로 명시적으로 재실행해야 함
-- **Trial 자신의 재정의도 감지하지 않는다**: `Experimenter._make_jobs`는 오직 `experiment_hist`의 fold별 status만 본다 — 재정의된 trial이 이미 `'built'`면 조용히 스킵되므로, 다시 돌리려면 `reset_nodes([trial_name])`을 직접 호출
-- **Predictor는 반대로 캐스케이드한다**: Trainer엔 보존할 "과거 실행" 개념이 없으므로, 바뀐 노드를 읽는 Predictor는 그냥 stale이다. `Trainer.reset_nodes`가 `predictor.node_names() & 리셋된_노드` 교집합으로 같이 지운다. Trial/Predictor를 별도 클래스로 둔 판단이 실제로 갈라지는 지점
+- **Trial은 캐스케이드하지 않는다**: Trial은 Pipeline 밖이라 diff가 이름을 모르고, stale 노드를 읽은 Trial도 건드리지 않는다 — `Experimenter.set_pipeline`은 stale 노드만 `reset_nodes`로 지우고 끝. 이력도 그대로 남는다. **버전 스탬프가 더하는 건 삭제가 아니라 정지다** — 새 버전을 채택하면 옛 버전 Trial들이 그냥 그 Experimenter에서 안 돌게 된다(`ValueError`). 결과는 그 버전에 대한 기록으로 보존되고, 다시 돌리려면 그 버전을 채택하거나 새 이름으로 저작해야 함
+- **Trial 자신의 재정의도 감지하지 않는다**: `Experimenter._make_jobs`는 (버전 대조를 통과한 뒤엔) 오직 `experiment_hist`의 fold별 status만 본다 — 재정의된 trial이 이미 `'built'`면 조용히 스킵되므로, 다시 돌리려면 `remove_trial_result(name)`을 직접 호출. 다만 성공 이력이 있는 이름의 재정의는 `Project.set_trial`이 막는다
+- **Predictor는 반대로 캐스케이드한다**: Trainer엔 보존할 "과거 실행" 개념이 없으므로, 바뀐 노드를 읽는 Predictor는 그냥 stale이다. `Trainer.reset_nodes`가 `predictor.node_names() & 리셋된_노드` 교집합으로 같이 지운다. Trial/Predictor를 별도 클래스로 둔 판단이 실제로 갈라지는 지점. 그리고 `set_pipeline`이 이어서 재스탬프하므로 지워진 아티팩트를 곧바로 다시 만들 수 있다
+
+## Trial/Predictor 버전 스탬프 — 정의가 자기 버전을 들고 다닌다
+`pipeline_version`은 이력 행에 붙는 메모가 아니라 **정의의 필드**다. 그래서
+"버전이 다른 같은 이름"이 애초에 만들어지지 않는다.
+
+```
+저작   Project.set_trial   →  Trial.pipeline_version   = 최신 published (없으면)
+       Trainer.train       →  Predictor.pipeline_version = 채택 버전 (없으면)
+       Predictor.from_trial →  Trial의 것을 그대로 복사
+
+실행   Experimenter.exp    →  trial.pipeline_version != self.pipeline_version → ValueError
+       Trainer.train       →  predictor.pipeline_version != self.pipeline_version → ValueError
+```
+
+- **왜 이력 키가 아니라 정의인가**: `experiment_hist`의 PK에 버전을 넣는 안이 먼저 있었는데, 그러면 수집 데이터와 어긋난다 — `MetricCollector`의 PK는 `(node, idx, inner_idx, split)`, `OutputCollector`는 `{path}/{node}/{outer}_{inner}.pkl`, `StackingCollector`는 `{path}/{node}.pkl`로 **전부 버전을 모른다**. 이력만 버전으로 가르면 이력은 두 실행을 주장하는데 메트릭은 하나만 남고 last-write-wins가 된다. 정의에 넣으면 그 충돌이 **생길 수 없다**
+- **왜 각자 다른 데서 찍나**: 진실하게 아는 값이 서로 다르다. Project는 registry를 보니 "최신 published"를 알고, Trainer는 registry에 닿을 수 없지만 **자기가 채택한 버전**은 안다. 직접 저작한 Predictor는 곧 눈앞의 정의에 대한 것이라 후자가 맞는 값이다
+- **`from_trial`은 복사한다** — 승격된 Predictor는 자기 후보가 실제로 평가된 버전을 요구한다. 최신으로 학습하려면 그 버전으로 실험을 다시 돌려야 하고, 옛 정의 그대로 배포하려면 Trainer가 그 버전을 채택하면 된다(강등이 없어 전부 채택 가능)
+- **`Trainer.set_pipeline`만 재스탬프한다** — 채택이 명시적 결정이고 캐스케이드가 이미 아티팩트를 지웠으므로. Experimenter엔 대응물이 없다: 거기선 옛 결과를 **보존**하는 게 목적이라 Trial이 옛 버전에 남는 게 맞다
+- **거친 판정이다 — 의도적이다.** 안 읽는 노드가 바뀌어도 Trial이 거부된다(노드 staleness는 `output_edges`를 타고, Predictor 캐스케이드는 `node_names()` 교집합이라 둘 다 정밀한데). 정밀하게 하려면 **옛 Pipeline 객체**로 `diff_from`을 해야 하는데 Experimenter는 자기 사본 하나뿐이라 못 불러온다 — 버전 스칼라 일치가 자기 디렉토리만으로 할 수 있는 유일한 검사이고, 여기선 정밀도보다 자족성이 값어치가 크다
+- `ProcessorSpec`엔 안 들어간다 — 실행 입력이 아니라 게이트라서 `desc`/`tag`와 같은 자리다
 
 ## Lazy resolution: processor / adapter / params (edges DSL과 동일한 지연 원칙)
 - `set_grp`/`set_node`는 `processor`/`adapter`/`params`를 **스펙 형태만 검증하고 절대 resolve/instantiate하지 않는다** — 실제 값으로의 변환은 전부 사용 시점(`_node_processor.py`)으로 미룸
@@ -678,7 +719,7 @@ v0 (생성 시 자동, 빈 Pipeline)
 - **_experimenter_store.py**: `ExperimenterStore(path)` — **Experimenter 하나 전용** `{path}/__exp.db`. meta 행 + splitter BLOB + `save_pipeline(pipeline)`/`load_pipeline()`(`_common`에 위임). `fetch`/`load_splitters`/`remove`는 행이 하나뿐이라 `name` 생략 가능
 - **_trainer_store.py**: `TrainerStore(path)` — Trainer판 동형. `{path}/__trainer.db`, `trainer(name PK, pipeline_version, splits BLOB)`. Experimenter판과 다른 점 둘: splits 블롭에 **`split_indices`가 같이** 들어감(splitter가 없을 수도 있고, 학습된 fold와 정확히 같아야 해서), `data_key`/`title`이 **없음**(다른 Trainer와 비교할 일이 없어 라벨도 mismatch 가드도 불필요)
   - **`save(meta)`가 `INSERT OR IGNORE` + `UPDATE`인 이유**(양쪽 store 공통): meta 컬럼만 나열한 `INSERT OR REPLACE`는 같은 행의 BLOB(splitters/splits)을 NULL로 날려버린다
-- **_common.py**: Experimenter/Trainer 공용 — `require_built_pipeline`, `require_frozen_pipeline`(Trainer 전용 게이트), `resolve_common_status`, `save_pipeline(path, pipeline)`/`load_pipeline(path)`(`{path}/pipeline.pkl`, 없으면 `None`), `error_payload`
+- **_common.py**: Experimenter/Trainer 공용 — `require_built_pipeline`, `require_published_pipeline`(양쪽 공용 채택 게이트 — draft만 거부), `resolve_common_status`, `save_pipeline(path, pipeline)`/`load_pipeline(path)`(`{path}/pipeline.pkl`, 없으면 `None`), `error_payload`
 - **_describer.py**: desc_spec, desc_pipeline, desc_node, compare_nodes
 - **_logger.py**: BaseLogger, DefaultLogger (start/update/end_progress, adhoc_progress, rename_progress)
 - **col.py / _connector.py / collector/ / filter/ / adapter/ / processor/**: 해당 섹션 참조
@@ -753,7 +794,9 @@ v0 (생성 시 자동, 빈 Pipeline)
 
   pipeline/                         # 프로젝트당 하나
     pipeline.db                     # PipelineBuilder 노드/그룹 정의(= open 버전)
-                                    #   + versions(version PK, status, path, builder_path)
+                                    #   + versions(version PK, path, builder_path)
+                                    #   status 컬럼 없음 — 행이 있으면 published,
+                                    #   draft는 여기 안 온다
     v{n}.pkl                        # 버전별 빌드 결과 Pipeline — 채택용
     v{n}_builder.pkl                # 그 버전을 낸 빌더 — built 스냅샷은 grp가 해소돼
                                     #   편집 가능한 정의로 돌아올 수 없으므로 별도로 남긴다

--- a/docs/guide/experimenter-trials.md
+++ b/docs/guide/experimenter-trials.md
@@ -19,7 +19,7 @@ e = project.add_experimenter(
 - `sp` — the outer splitter. Its held-out part is the *test* fold of each outer split.
 - `sp_v` — the inner splitter, giving each outer fold a train/validation pair for things like early stopping. `None` means one inner fold with no validation set.
 - `splitter_params` — maps a splitter keyword to a column, so `{'y': 'target'}` makes the split stratified on that column.
-- `data=` defaults to the project's; `pipeline_version=` defaults to the published one.
+- `data=` defaults to the project's; `pipeline_version=` defaults to the latest published one. Any published version is adoptable; only a draft is refused.
 
 The name is the identity: it is the directory under `exp/` and the key under which every fold outcome is filed in the `TrialStore`.
 
@@ -91,6 +91,23 @@ project.set_trial(trial)               # 'lgb1', or None if unchanged
 Both return only what was **added or changed**, so the return value is the work list for the next run. A definition identical to the stored one is not a change and comes back as `None` / omitted.
 
 A name that already ran successfully somewhere is frozen — `set_trial` raises rather than redefine it. The history is keyed by name and a Trial leaves no artifact, so a redefinition would silently leave the old results describing a definition that never produced them. Change one by giving it a new name, or `project.remove_trial(name)` to give up the results with it.
+
+### The Pipeline version is part of the definition
+
+`set_trial` stamps the latest published version onto a Trial that carries none, and a Trial runs only where that version is adopted:
+
+```python
+project.set_trial(trial)
+trial.pipeline_version                 # 2 — filled in, on the object you still hold
+
+project.set_trial(Trial(..., pipeline_version=1))   # author against an older one
+```
+
+An `exp()` whose Experimenter adopted a different version raises rather than run. Collected results are keyed by node name and fold with no version in them, so one name meaning two definitions would overwrite its own metrics with nothing to say which won. Adopt the version the Trial names, or give the new definition a new name.
+
+The check applies only where a job would be created. A Trial whose folds are all already built passes quietly however far the pipeline has moved on — there is nothing left to file, and handing back a finished round has to stay a no-op. One with folds still to run is refused, since that is where new results would land beside old ones.
+
+That also puts teeth on the freeze above: after the pipeline moves on, re-registering a name that already succeeded is a *changed* definition, so it raises instead of quietly re-pointing old results at a version that did not produce them.
 
 ## Running
 

--- a/docs/guide/project-pipeline.md
+++ b/docs/guide/project-pipeline.md
@@ -167,20 +167,33 @@ A project is created with **version 0**: the empty Pipeline, published. That is 
 
 | status | |
 |---|---|
-| `open` | the builder itself — editable, unnumbered, never a row |
-| `published` | the current version. Always exactly one |
-| `archived` | superseded by a later publish. Frozen, still referenceable, and the only status that can be deleted |
+| `published` | stored under a number. Every version is one, and nothing is ever demoted |
+| `draft` | a snapshot that was never stored — `version = None`. Cannot be adopted |
+
+Being stored *is* what publishing means, so the `versions` table has no status column and a draft can never appear in it. The distinction exists at runtime only.
 
 ```python
 project.list_pipeline_versions()
-project.load_pipeline()          # the published one — a read, never a write
+project.load_pipeline()          # the latest — a read, never a write
 project.load_pipeline(2)         # a specific version
-project.remove_pipeline_version(1)   # archived only
+project.remove_pipeline_version(1)   # any but the latest
 ```
 
-Removing an archived version breaks nothing that ran against it: every Experimenter and Trainer keeps its own Pipeline copy. What is lost is what a provenance pointer refers to.
+The latest is what an omitted version number resolves to, so it cannot be removed — deleting it would silently change what the next `add_experimenter` adopts. Removing an older one breaks nothing that ran against it: every Experimenter and Trainer keeps its own Pipeline copy. What is lost is what a provenance pointer refers to.
 
-`PipelineBuilder()` constructed without a path has nowhere to mint from, so its build stays `open` with `version = None` — useful in tests, and the one thing `Trainer.set_pipeline` refuses.
+### Looking without publishing
+
+`draft()` returns the same snapshot `build()` does, unregistered:
+
+```python
+snapshot = project.pipeline.draft()
+snapshot.version, snapshot.status    # (None, 'draft')
+project.stale_nodes()                # what adopting the current edits would cost
+```
+
+This is how a question stays a question — `stale_nodes()` leans on it so that asking what an edit would cost is not what commits the edit. A draft cannot be adopted: without a number, nothing that ran against it could say what that was.
+
+`PipelineBuilder()` constructed without a path has nowhere to publish, so `build()` raises there; `draft()` is how you get the snapshot.
 
 ## Inspecting
 

--- a/docs/guide/trainer-predictors.md
+++ b/docs/guide/trainer-predictors.md
@@ -17,7 +17,7 @@ t = project.add_trainer('cv5',
 
 No splitter means one fold over the whole dataset — the usual choice for a final model. With a splitter you get one fold per split, and `Inferencer` will average across them at serve time.
 
-`pipeline_version=` defaults to the published version, which is frozen and therefore exactly what a Trainer may adopt — what it refuses is the working copy, and the default never hands it one.
+`pipeline_version=` defaults to the latest published version. Any published version is adoptable — an older one answers "what was this trained against" as well as the newest, and adopting one is how you train a Predictor promoted from a candidate evaluated on it. What `set_pipeline` refuses is a draft, and the default never hands it one.
 
 Like an Experimenter, a Trainer owns its directory and reopens from it:
 
@@ -43,6 +43,8 @@ pred.src_experimenter   # 'cv5'
 ```
 
 `from_trial` copies the definition verbatim and keeps the Trial's name unless you override it — and even then `src_trial` records the original. Keeping the name matters more than it looks: output columns are named after the node, so a Predictor named like its Trial produces columns that line up with what the experiment collected.
+
+Verbatim includes `pipeline_version`, so a promoted Predictor requires the version its candidate was actually evaluated on, and `train()` refuses any other — training a newer pipeline against it would ship something that was never measured. Adopt that version in the Trainer, or re-run the experiment against the newer one. A Predictor declared directly carries no version and takes the Trainer's own, since the definition in front of it is what it is being written against.
 
 Passing a bare `Trial` to `train()` raises `TypeError`. The promotion is deliberate, so the provenance is recorded rather than guessed.
 

--- a/examples/kaggle_s6e6/2. Second Phase.ipynb
+++ b/examples/kaggle_s6e6/2. Second Phase.ipynb
@@ -4,26 +4,7 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": [
-    "# S6E6 — Second Phase (Project 기반)\n",
-    "\n",
-    "이전 판과 달라진 점만 먼저:\n",
-    "\n",
-    "| 예전 | 지금 |\n",
-    "|---|---|\n",
-    "| `PipelineBuilder(path='exp', name=...)` | `project.pipeline` — **프로젝트당 하나** |\n",
-    "| `p.set_grp(..., role='stage'/'head')` | `role` 없음 — Pipeline은 **노드 전용** |\n",
-    "| 모델을 `set_node(grp='xgb')`로 선언 | 모델은 **`Trial`** — Pipeline 밖, `exp()`에 이름으로 전달 |\n",
-    "| `p.build()` (번호 없음) | `p.build()`가 곧 **publish** — 정의가 바뀔 때 버전이 정확히 하나 생긴다 |\n",
-    "| run마다 `df`를 다시 넘김 | `Project(path, data=df)` — 데이터셋이 프로젝트 상태 |\n",
-    "| `Experimenter(df, sp=, path=)` | `project.add_experimenter(name, ...)` / 기존 것은 `project.experimenters[name]` |\n",
-    "| `e.set_collector(...)` / `e.get_collector(...)` | `e.collectors` 레지스트리 (run 소유, 등록 즉시 영속화) |\n",
-    "| `e.exp(nodes='xgb1')` | `project.set_trials(trials)` 후 `e.exp([이름, ...], collectors=[이름, ...])` |\n",
-    "| `e.exp(finalize=True)` | `finalize` 개념 없음 |\n",
-    "| 수집 실패는 `collector.warnings` (메모리) | `e.collectors.hist` — **`CollectHist`** (fold 단위 이력) |\n",
-    "\n",
-    "grp 상속이 모델에 적용되지 않으므로, 그 자리는 아래 `MODELS` dict + `trial()` 헬퍼가 대신한다."
-   ]
+   "source": "# S6E6 — Second Phase (Project 기반)\n\n이전 판과 달라진 점만 먼저:\n\n| 예전 | 지금 |\n|---|---|\n| `PipelineBuilder(path='exp', name=...)` | `project.pipeline` — **프로젝트당 하나** |\n| `p.set_grp(..., role='stage'/'head')` | `role` 없음 — Pipeline은 **노드 전용** |\n| 모델을 `set_node(grp='xgb')`로 선언 | 모델은 **`Trial`** — Pipeline 밖, `exp()`에 이름으로 전달 |\n| `p.build()` (번호 없음) | `p.build()`가 곧 **publish** — 정의가 바뀔 때 버전이 정확히 하나 생긴다 |\n| 상태가 `open`/`published`/`archived` | **`draft`/`published` 둘뿐** — 저장된 게 곧 published, 강등 없음. 번호 없는 스냅샷은 `p.draft()` |\n| `set_pipeline`이 Experimenter에선 아무거나 | **양쪽 다 published만** — draft는 번호가 없어 대조할 게 없다 |\n| Trial은 정의만 | Trial/Predictor가 **`pipeline_version`을 정의에 달고 있다** — `set_trials`가 찍고 `exp()`/`train()`이 대조 |\n| run마다 `df`를 다시 넘김 | `Project(path, data=df)` — 데이터셋이 프로젝트 상태 |\n| `Experimenter(df, sp=, path=)` | `project.add_experimenter(name, ...)` / 기존 것은 `project.experimenters[name]` |\n| `e.set_collector(...)` / `e.get_collector(...)` | `e.collectors` 레지스트리 (run 소유, 등록 즉시 영속화) |\n| `e.exp(nodes='xgb1')` | `project.set_trials(trials)` 후 `e.exp([이름, ...], collectors=[이름, ...])` |\n| `e.exp(finalize=True)` | `finalize` 개념 없음 |\n| 수집 실패는 `collector.warnings` (메모리) | `e.collectors.hist` — **`CollectHist`** (fold 단위 이력) |\n\ngrp 상속이 모델에 적용되지 않으므로, 그 자리는 아래 `MODELS` dict + `trial()` 헬퍼가 대신한다."
   },
   {
    "cell_type": "code",
@@ -451,45 +432,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "experimenter",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def adopt():\n",
-    "    \"\"\"현재 builder 상태를 빌드해 이 run에 채택시킨다.\n",
-    "    build()가 곧 publish다 — 정의가 바뀌었으면 새 버전이 찍히고, 안 바뀌었으면\n",
-    "    지금 버전을 그대로 돌려준다. 바뀐 노드만 stale 처리되어 아티팩트가 지워진다.\"\"\"\n",
-    "    e.set_pipeline(p.build())\n",
-    "    return e.pipeline_version\n",
-    "\n",
-    "\n",
-    "# add_*는 추가 전용이다 — 이미 있는 이름이면 ValueError. 생성은 split을 다시\n",
-    "# 계산하고 provenance를 리셋하므로 기존 것 위에 부르면 재개가 아니라 피해다.\n",
-    "# 기존 것은 레지스트리로 꺼낸다(같은 이름은 항상 같은 객체).\n",
-    "if 'phase2' not in project.list_experimenters():\n",
-    "    project.add_experimenter(\n",
-    "        'phase2',\n",
-    "        sp=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.8),\n",
-    "        sp_v=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.9),\n",
-    "        splitter_params={'y': y},\n",
-    "        pipeline_version=p.build().version,\n",
-    "    )\n",
-    "\n",
-    "e = project.experimenters['phase2']\n",
-    "e.pipeline_version"
-   ]
+   "outputs": [],
+   "source": "def adopt():\n    \"\"\"현재 builder 상태를 빌드해 이 run에 채택시킨다.\n    build()가 곧 publish다 — 정의가 바뀌었으면 새 버전이 찍히고, 안 바뀌었으면\n    지금 버전을 그대로 돌려준다. 바뀐 노드만 stale 처리되어 아티팩트가 지워진다.\n\n    채택할 수 있는 건 published뿐이다(어느 버전이든 상관없다). 등록 안 된\n    스냅샷 — p.draft() — 은 번호가 없어서 거절된다: 그걸로 돈 실행이 무엇에\n    대한 것인지 말할 수 없고, Trial의 버전을 대조할 대상도 없다.\n\n    새 라운드를 저작하기 전에 이걸 먼저 부르는 게 중요하다. set_trials가\n    찍는 건 '최신 published'라, 빌드만 해두고 채택을 안 하면 Trial은 새\n    버전을, run은 옛 버전을 들고 있게 되어 exp()가 거절한다.\"\"\"\n    e.set_pipeline(p.build())\n    return e.pipeline_version\n\n\n# add_*는 추가 전용이다 — 이미 있는 이름이면 ValueError. 생성은 split을 다시\n# 계산하고 provenance를 리셋하므로 기존 것 위에 부르면 재개가 아니라 피해다.\n# 기존 것은 레지스트리로 꺼낸다(같은 이름은 항상 같은 객체).\nif 'phase2' not in project.list_experimenters():\n    project.add_experimenter(\n        'phase2',\n        sp=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.8),\n        sp_v=StratifiedShuffleSplit(n_splits=1, random_state=123, train_size=0.9),\n        splitter_params={'y': y},\n        pipeline_version=p.build().version,\n    )\n\ne = project.experimenters['phase2']\ne.pipeline_version"
   },
   {
    "cell_type": "code",
@@ -579,25 +526,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "runners",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def run(trials, **kw):\n",
-    "    \"\"\"Trial은 프로젝트 소유라 저작(set_trials)과 실행(exp)이 분리돼 있다.\n",
-    "\n",
-    "    exp()에는 이름만 넘긴다 — 이름 하나가 전 fold를 뜻하고, 이미 'built'인\n",
-    "    fold는 알아서 빠지므로 중단된 라운드도 같은 호출로 이어진다.\n",
-    "    set_trials()의 반환은 '바뀐 것'이라 재개 목록이 아니다 — 그래서 여기선\n",
-    "    반환값이 아니라 넘긴 trial 전체의 이름을 쓴다.\n",
-    "\n",
-    "    collectors 인자를 안 주면 이 run에 등록된 Collector 전부가 붙고,\n",
-    "    수집 이력도 e.collectors.hist에 남는다.\"\"\"\n",
-    "    project.set_trials(trials)\n",
-    "    kw = {'n_jobs': 2, 'gpu_id_list': [0], 'logger': logger, **kw}\n",
-    "    e.exp([t.name for t in trials], **kw)"
-   ]
+   "source": "def run(trials, **kw):\n    \"\"\"Trial은 프로젝트 소유라 저작(set_trials)과 실행(exp)이 분리돼 있다.\n\n    exp()에는 이름만 넘긴다 — 이름 하나가 전 fold를 뜻하고, 이미 'built'인\n    fold는 알아서 빠지므로 중단된 라운드도 같은 호출로 이어진다.\n    set_trials()의 반환은 '바뀐 것'이라 재개 목록이 아니다 — 그래서 여기선\n    반환값이 아니라 넘긴 trial 전체의 이름을 쓴다.\n\n    **저작은 이름당 한 번이다.** Trial은 저작 시점의 파이프라인 버전을\n    정의에 달고 있고(set_trials가 최신 published를 찍는다), exp()는 그\n    버전이 이 run이 채택한 것과 같을 때만 돌린다. 그래서 라운드가 진행돼\n    파이프라인이 v3, v4로 넘어간 뒤 이 노트북을 위에서부터 다시 돌리면\n    round1 trial들이 '다른 정의'가 되고 — 성공 이력이 있으니 set_trial이\n    거절한다. 이미 등록된 이름을 걸러내면 재실행이 '있는 건 그대로,\n    새 라운드만 저작'이 된다. (전 fold가 이미 'built'인 이름은 exp()도\n    만들 job이 없어 버전을 안 따지므로 그냥 조용히 넘어간다.)\n\n    collectors 인자를 안 주면 이 run에 등록된 Collector 전부가 붙고,\n    수집 이력도 e.collectors.hist에 남는다.\"\"\"\n    registered = {t.name for t in project.trials.list_trials()}\n    project.set_trials([t for t in trials if t.name not in registered])\n    kw = {'n_jobs': 2, 'gpu_id_list': [0], 'logger': logger, **kw}\n    e.exp([t.name for t in trials], **kw)"
   },
   {
    "cell_type": "code",
@@ -1295,30 +1228,7 @@
    "id": "stk-trial",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "NO_ES = ('early_stopping', 'early_stopping_rounds', 'eval_metric')\n",
-    "\n",
-    "\n",
-    "def stack_trial(name, src, model, n_rounds):\n",
-    "    \"\"\"src를 그대로 복사하되 early stopping을 빼고 라운드를 고정한 predict_proba trial.\n",
-    "\n",
-    "    MODELS[model]이 아니라 *뽑힌 trial 자신의* params/edges/adapter에서 출발한다 —\n",
-    "    nn6~nn9처럼 계열 기본값 위에 cat_cols 같은 개별 인자가 얹힌 경우가 있어서다.\n",
-    "    \"\"\"\n",
-    "    params = {k: v for k, v in src.params.items() if k not in NO_ES}\n",
-    "    params['epochs' if model == 'nn' else 'n_estimators'] = n_rounds\n",
-    "    return Trial(name, src.processor, dict(src.edges), method='predict_proba',\n",
-    "                 adapter=src.adapter, params=params)\n",
-    "\n",
-    "\n",
-    "# 이름을 새로 준다 — TrialStore는 이름이 PK이고 프로젝트 전역이다.\n",
-    "# 'lgb5'를 재사용하면 project.set_trial이 거절한다: 그 이름엔 이미\n",
-    "# 성공 이력이 있어서, 재정의하면 옛 결과가 그걸 만든 적 없는 정의를\n",
-    "# 설명하게 된다.\n",
-    "stk_trials = [stack_trial(f'{name}_stk', ALL_TRIALS[name], m, n)\n",
-    "              for m, (name, n) in picked.items()]\n",
-    "[(t.name, t.params.get('n_estimators', t.params.get('epochs'))) for t in stk_trials]\n"
-   ]
+   "source": "NO_ES = ('early_stopping', 'early_stopping_rounds', 'eval_metric')\n\n\ndef stack_trial(name, src, model, n_rounds):\n    \"\"\"src를 그대로 복사하되 early stopping을 빼고 라운드를 고정한 predict_proba trial.\n\n    MODELS[model]이 아니라 *뽑힌 trial 자신의* params/edges/adapter에서 출발한다 —\n    nn6~nn9처럼 계열 기본값 위에 cat_cols 같은 개별 인자가 얹힌 경우가 있어서다.\n\n    pipeline_version은 일부러 안 가져온다. src는 저작될 때 그 시점 버전이\n    찍힌 객체인데(set_trials가 넘긴 객체를 직접 수정한다), 이건 새 후보라\n    지금 파이프라인에 대해 평가받아야 한다 — 비워두면 set_trials가 최신\n    published를 찍는다.\n    \"\"\"\n    params = {k: v for k, v in src.params.items() if k not in NO_ES}\n    params['epochs' if model == 'nn' else 'n_estimators'] = n_rounds\n    return Trial(name, src.processor, dict(src.edges), method='predict_proba',\n                 adapter=src.adapter, params=params)\n\n\n# 이름을 새로 준다 — TrialStore는 이름이 PK이고 프로젝트 전역이다.\n# 'lgb5'를 재사용하면 project.set_trial이 거절한다: 그 이름엔 이미\n# 성공 이력이 있어서, 재정의하면 옛 결과가 그걸 만든 적 없는 정의를\n# 설명하게 된다.\nstk_trials = [stack_trial(f'{name}_stk', ALL_TRIALS[name], m, n)\n              for m, (name, n) in picked.items()]\n[(t.name, t.params.get('n_estimators', t.params.get('epochs'))) for t in stk_trials]"
   },
   {
    "cell_type": "code",
@@ -1326,30 +1236,7 @@
    "id": "stk-exp",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from sklearn.model_selection import StratifiedKFold\n",
-    "\n",
-    "# load_pipeline()은 읽기만 한다 — 인자 없으면 published(현재) 버전.\n",
-    "# 예전엔 인자가 없으면 working copy를 build했고 그게 곧 publish라,\n",
-    "# 'load'라는 이름이 버전을 찍었다. 발급은 이제 build() 한 곳뿐이다.\n",
-    "stk_pipeline = project.load_pipeline()\n",
-    "\n",
-    "if 'stack' not in project.list_experimenters():\n",
-    "    project.add_experimenter(\n",
-    "        'stack',\n",
-    "        sp=StratifiedKFold(n_splits=5, shuffle=True, random_state=123),\n",
-    "        sp_v=None,\n",
-    "        splitter_params={'y': y},\n",
-    "        pipeline_version=stk_pipeline.version,\n",
-    "    )\n",
-    "\n",
-    "e_stk = project.experimenters['stack']\n",
-    "\n",
-    "with e_stk.os_log():\n",
-    "    e_stk.build(n_jobs=2, logger=logger)\n",
-    "\n",
-    "e_stk.get_n_splits(), e_stk.get_n_splits_inner()\n"
-   ]
+   "source": "from sklearn.model_selection import StratifiedKFold\n\n# load_pipeline()은 읽기만 한다 — 인자 없으면 최신 published 버전.\n# 예전엔 인자가 없으면 working copy를 build했고 그게 곧 publish라,\n# 'load'라는 이름이 버전을 찍었다. 발급은 이제 build() 한 곳뿐이고,\n# 커밋 없이 보기만 하려면 p.draft()가 따로 있다.\nstk_pipeline = project.load_pipeline()\n\nif 'stack' not in project.list_experimenters():\n    project.add_experimenter(\n        'stack',\n        sp=StratifiedKFold(n_splits=5, shuffle=True, random_state=123),\n        sp_v=None,\n        splitter_params={'y': y},\n        pipeline_version=stk_pipeline.version,\n    )\n\ne_stk = project.experimenters['stack']\n\nwith e_stk.os_log():\n    e_stk.build(n_jobs=2, logger=logger)\n\ne_stk.get_n_splits(), e_stk.get_n_splits_inner()"
   },
   {
    "cell_type": "markdown",
@@ -1386,19 +1273,7 @@
    "id": "stk-collect",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "e_stk.collectors.set_collector(\n",
-    "    'stack_oof', 'mllabs.collector.StackingCollector',\n",
-    "    conn(node_query=[t.name for t in stk_trials], edges=y_edges),\n",
-    "    params={'output_var': '1:', 'method': 'mean'}, exist='replace')\n",
-    "\n",
-    "project.set_trials(stk_trials)\n",
-    "\n",
-    "with e_stk.os_log():\n",
-    "    e_stk.exp([t.name for t in stk_trials],\n",
-    "              collectors=['stack_oof'],\n",
-    "              n_jobs=2, gpu_id_list=[0], logger=logger)\n"
-   ]
+   "source": "e_stk.collectors.set_collector(\n    'stack_oof', 'mllabs.collector.StackingCollector',\n    conn(node_query=[t.name for t in stk_trials], edges=y_edges),\n    params={'output_var': '1:', 'method': 'mean'}, exist='replace')\n\n# 여기선 걸러낼 게 없다 — 새 이름이고, e_stk가 채택한 게 곧 stk_pipeline(최신\n# published)이라 set_trials가 찍는 버전과 같다. 그래서 exp()의 대조를 그냥 통과한다.\nproject.set_trials(stk_trials)\n\nwith e_stk.os_log():\n    e_stk.exp([t.name for t in stk_trials],\n              collectors=['stack_oof'],\n              n_jobs=2, gpu_id_list=[0], logger=logger)"
   },
   {
    "cell_type": "code",
@@ -1441,21 +1316,7 @@
    "id": "stk-train",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from mllabs import Predictor\n",
-    "\n",
-    "preds = [Predictor.from_trial(t, experimenter=e_stk.name) for t in stk_trials]\n",
-    "\n",
-    "# Trainer도 같은 모양. pipeline_version 기본값이 published라 생략해도 되지만,\n",
-    "# e_stk가 채택한 것과 같은 버전임을 명시해둔다.\n",
-    "if 'stack_final' not in project.list_trainers():\n",
-    "    project.add_trainer('stack_final', pipeline_version=stk_pipeline.version)\n",
-    "\n",
-    "t_stk = project.trainers['stack_final']\n",
-    "\n",
-    "t_stk.train(preds, n_jobs=1, gpu_id_list=[0], logger=logger)\n",
-    "t_stk.predictor_names(), t_stk.get_n_splits()\n"
-   ]
+   "source": "from mllabs import Predictor\n\n# from_trial은 pipeline_version까지 그대로 복사한다 — 승격된 Predictor는\n# 자기 후보가 *실제로 평가된* 버전을 요구한다.\npreds = [Predictor.from_trial(t, experimenter=e_stk.name) for t in stk_trials]\n\n# 그래서 여기 pipeline_version은 설명이 아니라 요건이다. Trainer가 다른\n# 버전을 채택하고 있으면 train()이 거절한다 — 평가한 적 없는 정의를 배포로\n# 내보내는 셈이라서. 지금은 stk_trials가 이 버전에서 평가됐고 그게 최신이라\n# 기본값과도 같지만, 나중에 파이프라인이 넘어간 뒤 이 셀만 다시 돌리면\n# 명시해둔 이쪽이 맞다(옛 버전도 강등이 없어 그대로 채택 가능하다).\nif 'stack_final' not in project.list_trainers():\n    project.add_trainer('stack_final', pipeline_version=stk_pipeline.version)\n\nt_stk = project.trainers['stack_final']\n\nt_stk.train(preds, n_jobs=1, gpu_id_list=[0], logger=logger)\nt_stk.predictor_names(), t_stk.get_n_splits()"
   },
   {
    "cell_type": "code",

--- a/mllabs/_common.py
+++ b/mllabs/_common.py
@@ -47,21 +47,26 @@ def require_built_pipeline(pipeline):
         raise TypeError(f"Expected a Pipeline, got {type(pipeline).__name__}")
 
 
-def require_frozen_pipeline(pipeline):
-    """Raise unless *pipeline* is a published or archived version.
+def require_published_pipeline(pipeline):
+    """Raise unless *pipeline* is a stored version.
 
-    The Trainer-side gate. Both frozen statuses pass: what matters is that the
-    definition cannot change under what was trained against it, and an archived
-    version is as fixed as the published one. Only the working copy is refused.
+    The adoption gate, shared by Experimenter and Trainer. Any published
+    version passes — the newest and the oldest answer "what did this run
+    against" equally well, and nothing demotes one.
+
+    What is refused is a draft. It carries no number, so a run that adopted it
+    could not say what it ran against, and a Trial or Predictor could not be
+    checked against it at all. A draft is for looking at a definition, not for
+    running one.
     """
-    from ._pipeline_store import OPEN
+    from ._pipeline_store import PUBLISHED
 
-    if pipeline.status == OPEN:
+    if pipeline.status != PUBLISHED:
         raise ValueError(
-            "This Pipeline is the working copy, which is still editable, so "
-            "nothing could later name what was trained against it. It has no "
-            "version because its builder has no db to mint one from — build it "
-            "from a builder that has one (project.pipeline)."
+            "This Pipeline is a draft, so it carries no version and nothing "
+            "that ran against it could name what that was. Publish it with "
+            "build() on a builder that has a db (project.pipeline), or adopt "
+            "a stored version with project.load_pipeline(version)."
         )
 
 

--- a/mllabs/_experimenter.py
+++ b/mllabs/_experimenter.py
@@ -65,7 +65,8 @@ def _stop_native_redirect(state):
     sys.stdout = state['orig_stdout']
     sys.stderr = state['orig_stderr']
     state['log_f'].close()
-from ._common import resolve_common_status, require_built_pipeline, error_payload
+from ._common import (resolve_common_status, require_built_pipeline,
+                      require_published_pipeline, error_payload)
 from ._pipeline import Pipeline
 
 
@@ -354,7 +355,7 @@ class Experimenter():
             self.close_os_log()
 
     def set_pipeline(self, pipeline):
-        """Adopt an already-loaded Pipeline, published or still a draft.
+        """Adopt an already-loaded Pipeline. It must be a published version.
 
         Takes the Pipeline object directly rather than a version number —
         this class has no way to load one by version itself (see the class
@@ -363,9 +364,13 @@ class Experimenter():
         *pipeline* (its ``.version``), so it's never tracked as a separate,
         possibly-diverging value.
 
-        Any status is accepted, unlike ``Trainer.set_pipeline``. Experimenting
-        against a definition still being edited is the point of experimenting;
-        it is training that has to be able to say what it trained on.
+        The same gate as ``Trainer.set_pipeline``, and any published version
+        passes. This used to accept a draft too, on the grounds that
+        experimenting against a definition under edit is the point of
+        experimenting — but a Trial carries the version it was authored
+        against and is refused unless this Experimenter holds it, and an
+        adopted draft holds nothing to compare with. Publishing costs nothing
+        anyway: an unchanged definition builds to the number it already has.
 
         The Pipeline is written to this Experimenter's own ``pipeline.pkl``,
         which is what the constructor reads back — reopening needs only this
@@ -383,11 +388,16 @@ class Experimenter():
         explicit action.
 
         Args:
-            pipeline (Pipeline): Already-built, already-loaded Pipeline.
+            pipeline (Pipeline): Already-built, already-published Pipeline.
 
         Returns:
             Pipeline: *pipeline*, unchanged.
+
+        Raises:
+            ValueError: If *pipeline* is a draft.
         """
+        require_built_pipeline(pipeline)
+        require_published_pipeline(pipeline)
         stale = self.stale_nodes(pipeline)
         if stale:
             self.reset_nodes(stale)
@@ -841,8 +851,23 @@ class Experimenter():
         name that has succeeded before. Rerunning one is
         :meth:`remove_trial_result` and nothing else.
 
+        A Trial defined against another Pipeline version is then refused rather
+        than run. Its outcome would be filed under a definition it never ran
+        on, and collected results are keyed by node name and fold with no
+        version in them at all, so two versions of one name would overwrite
+        each other's metrics with nothing to say which won.
+
+        **The version is checked only where a job would be created.** A name
+        with every fold already built produces nothing to file, so it passes
+        quietly however far the pipeline has moved on — which is what keeps
+        "hand back the same names and an interrupted pass continues" true.
+        Refusing there would make re-running a finished round an error instead
+        of a no-op. A name with *some* folds left is still refused: that is
+        exactly where new results would land beside old ones.
+
         The definition, its spec and its GPU verdict are resolved once per
-        name, not once per fold.
+        name, not once per fold — and not at all for a name with nothing left
+        to run.
         """
         from ._executor import Job
         from .adapter import resolve_node_adapter
@@ -867,14 +892,24 @@ class Experimenter():
                     f"Trial '{name}' is not registered. Add it with "
                     f"project.set_trial(trial) before running it."
                 )
+            status = trial_store.get_status(name, self.name)
+            pending = [f for f in folds if status.get(f) != 'built']
+            if not pending:
+                continue
+            if trial.pipeline_version != self.pipeline_version:
+                raise ValueError(
+                    f"Trial '{name}' is defined against pipeline version "
+                    f"{trial.pipeline_version}, and this Experimenter has "
+                    f"adopted version {self.pipeline_version}. Its results "
+                    f"would describe a definition it did not run on. Adopt "
+                    f"that version here, or author the Trial under a new name "
+                    f"against this one."
+                )
             spec = trial.get_spec()
             adapter = resolve_node_adapter(spec.processor, spec.adapter)
             need_gpu = adapter.get_gpu_usage(spec.params) != GPU_NO
-            status = trial_store.get_status(name, self.name)
 
-            for outer_idx, inner_idx in folds:
-                if status.get((outer_idx, inner_idx)) == 'built':
-                    continue
+            for outer_idx, inner_idx in pending:
                 flow = self.outer_folds[outer_idx].train_data_flows[inner_idx]
                 jobs.append(Job(name, spec, outer_idx, inner_idx, flow,
                                 need_gpu=need_gpu))

--- a/mllabs/_pipeline.py
+++ b/mllabs/_pipeline.py
@@ -2,7 +2,7 @@ import re
 import uuid
 from pathlib import Path
 from ._describer import desc_pipeline, desc_node, compare_nodes
-from ._pipeline_store import PipelineStore, OPEN, PUBLISHED, ARCHIVED
+from ._pipeline_store import PipelineStore, DRAFT, PUBLISHED
 from ._edge_dsl import referenced_nodes, validate_edges, iter_segments, eval_expr
 
 
@@ -647,14 +647,15 @@ class Pipeline:
             the DataSource (a :class:`_BuiltDataSource`).
         pipeline_id (str): Identity of the builder this was built from.
         build_id (str): Identity of this particular build.
-        version (int | None): Set by :meth:`Project.publish_pipeline` when this
-            Pipeline is frozen as a version. ``None`` while it is an
-            unpublished build of the working copy, which is deliberate: a draft
+        version (int | None): The number this Pipeline is stored under, set by
+            :meth:`PipelineBuilder.build`. ``None`` for a
+            :meth:`PipelineBuilder.draft`, which was never stored: a draft
             changes under anyone who adopted it, so a number here would be a
             claim the record could not keep. ``build_id`` says which draft.
-        status (str): ``'open'`` until published, then ``'published'``. A
-            version demoted by a later publish is ``'archived'`` — read from
-            the store, since the copies already handed out cannot be updated.
+        status (str): ``'draft'`` or ``'published'``, and nothing else. Being
+            stored is what publishing *is*, so this is set once, when the
+            store writes it, and no later call can make it wrong — copies
+            already handed out never go out of date.
     """
 
     def __init__(self, nodes, datasource, pipeline_id, build_id=None):
@@ -663,7 +664,7 @@ class Pipeline:
         self.pipeline_id = pipeline_id
         self.build_id = build_id if build_id is not None else str(uuid.uuid4())
         self.version = None
-        self.status = OPEN
+        self.status = DRAFT
         self._topo_order = _affected_nodes(self.nodes, [None])
         self._specs = {
             name: node.get_spec()
@@ -683,8 +684,11 @@ class Pipeline:
 
         Inside a Project this is version 0, published at creation, so the empty
         state is a real row rather than a fabricated object. This constructor
-        is for the standalone case, where there is no store to mint from — the
-        same reason a db-less builder's build stays ``open`` and unnumbered.
+        is for the standalone case, where there is no store to mint from, and
+        what it returns is a draft for exactly that reason: it never came from
+        one. It is the only Pipeline an Experimenter or Trainer holds without
+        having adopted it, and ``set_pipeline`` replaces it before anything
+        runs.
         """
         return cls({}, _BuiltDataSource('Data_Source', {}, [], []), pipeline_id)
 
@@ -1106,21 +1110,53 @@ class PipelineBuilder:
         the built Pipeline, never the builder, so later ``set_grp``/``set_node``
         calls do not reach into work already in progress.
 
-        **Building publishes.** A builder with a db mints a version here, which
-        makes a version appear exactly when the definition changes — an
-        unchanged builder returns the version it already has rather than a
-        duplicate of it. There is no separate publish step and no such thing as
-        an unnumbered snapshot to run against, so every history row can name the
-        definition it ran on.
-
-        A builder with no db (constructed without a path) has nowhere to mint
-        from, so its build stays ``open`` and unnumbered. That is the one
-        in-memory case ``Trainer.set_pipeline`` refuses.
+        **Building publishes.** A version appears here, and exactly when the
+        definition changes — an unchanged builder returns the version it
+        already has rather than a duplicate of it. There is no separate publish
+        step, and :meth:`draft` is the only way to get an unnumbered snapshot,
+        so anything that can be *adopted* can name itself and every history row
+        can name the definition it ran on.
 
         Returns:
             Pipeline: Snapshot with every node's inherited values resolved,
-            carrying ``version`` and ``status`` unless this builder has no db.
+            carrying ``version`` and ``status = 'published'``.
+
+        Raises:
+            ValueError: If this builder has no db to publish into. Such a
+                builder can still produce a snapshot — that is :meth:`draft`.
         """
+        if self._store is None:
+            raise ValueError(
+                "This PipelineBuilder has no db, so build() has nowhere to "
+                "publish. Construct it with PipelineBuilder(path=...) to "
+                "version it, or call draft() for an unnumbered snapshot."
+            )
+        pipeline = self._snapshot()
+        self._version(pipeline)
+        return pipeline
+
+    def draft(self):
+        """The same snapshot :meth:`build` makes, unregistered.
+
+        ``version`` is ``None`` and ``status`` is ``'draft'``, because being
+        stored is what publishing is and this was not. Use it to *look* at what
+        the working copy currently says — ``Project.stale_nodes`` asks what
+        adopting the current edits would cost — without that question being
+        what commits them.
+
+        A draft cannot be adopted: ``set_pipeline`` refuses it on both
+        Experimenter and Trainer. An unnumbered definition would leave runs
+        unable to say what they ran against, which is the whole reason
+        ``build()`` publishes.
+
+        Returns:
+            Pipeline: Snapshot with every node's inherited values resolved,
+            unnumbered.
+        """
+        return self._snapshot()
+
+    def _snapshot(self):
+        """The built graph itself, before anything decides whether to store it."""
         nodes = {}
         for name, node in self.nodes.items():
             if name is None:
@@ -1145,10 +1181,7 @@ class PipelineBuilder:
             targets=list(ds.targets),
             output_edges=list(ds.output_edges),
         )
-        pipeline = Pipeline(nodes, datasource, self.pipeline_id)
-        if self._store is not None:
-            self._version(pipeline)
-        return pipeline
+        return Pipeline(nodes, datasource, self.pipeline_id)
 
     def _version(self, pipeline):
         """Give *pipeline* the version its definition belongs to, minting one if new."""

--- a/mllabs/_pipeline_store.py
+++ b/mllabs/_pipeline_store.py
@@ -41,19 +41,18 @@ _SCHEMA_SQL = """
     );
     CREATE TABLE IF NOT EXISTS versions (
         version INTEGER PRIMARY KEY,
-        status TEXT NOT NULL,
         path TEXT NOT NULL,
         builder_path TEXT NOT NULL
     );
 """
 
-#: A version that has been frozen and is the current one. Always exactly one.
+#: A version in ``versions``. Every row is one: being stored is what publishing
+#: *is*, so the table needs no column to say so.
 PUBLISHED = 'published'
-#: A version that was published and has since been succeeded by a newer one.
-#: Frozen and still referenceable, and the only status that can be deleted.
-ARCHIVED = 'archived'
-#: The builder's working copy. Editable, unnumbered, never a row in ``versions``.
-OPEN = 'open'
+#: A built snapshot that was never registered — :meth:`PipelineBuilder.draft`.
+#: Unnumbered, and refused by ``set_pipeline`` on both Experimenter and Trainer.
+#: Exists at runtime only: reaching the store is what would make it published.
+DRAFT = 'draft'
 
 
 class PipelineStore:
@@ -182,8 +181,10 @@ class PipelineStore:
         resolves group inheritance away — a built snapshot has no groups left to
         edit, so it could never come back as a working definition.
 
-        Whatever was published before becomes :data:`ARCHIVED`: only the newest
-        is the current one.
+        Nothing is demoted. Every stored version stays :data:`PUBLISHED` and
+        stays adoptable; the newest is merely the one an omitted version number
+        resolves to. That is also what keeps the pickled ``status`` honest — it
+        is written here, once, and no later call can make it wrong.
 
         Args:
             pipeline (Pipeline): The built Pipeline to freeze.
@@ -208,16 +209,13 @@ class PipelineStore:
             with open(builder_path, 'wb') as f:
                 pkl.dump(builder, f)
             conn.execute(
-                "UPDATE versions SET status = ? WHERE status = ?", (ARCHIVED, PUBLISHED)
-            )
-            conn.execute(
-                "INSERT INTO versions (version, status, path, builder_path) VALUES (?, ?, ?, ?)",
-                (version, PUBLISHED, str(version_path), str(builder_path)),
+                "INSERT INTO versions (version, path, builder_path) VALUES (?, ?, ?)",
+                (version, str(version_path), str(builder_path)),
             )
         return version
 
     def load_version(self, version=None):
-        """A frozen Pipeline by number, or the published one if *version* is omitted."""
+        """A stored Pipeline by number, or the latest one if *version* is omitted."""
         row = self._version_row(version)
         with open(row['path'], 'rb') as f:
             return pkl.load(f)
@@ -229,33 +227,39 @@ class PipelineStore:
             return pkl.load(f)
 
     def get_status(self, version):
-        """:data:`PUBLISHED` or :data:`ARCHIVED`, or ``None`` if there is no such version."""
+        """:data:`PUBLISHED` if *version* is stored, ``None`` if there is no such version.
+
+        Two answers rather than three: a stored version is published, and a
+        draft was never stored, so there is nothing else a row could report.
+        """
         if not self.exists():
             return None
         with sqlite3.connect(str(self.db_path)) as conn:
             row = conn.execute(
-                "SELECT status FROM versions WHERE version = ?", (version,)
+                "SELECT version FROM versions WHERE version = ?", (version,)
             ).fetchone()
-        return row[0] if row else None
+        return PUBLISHED if row else None
 
     def remove_version(self, version):
-        """Delete an archived version and both its pickles.
+        """Delete a stored version and both its pickles. Not the latest one.
 
-        Archived only. ``published`` is the current definition and ``open`` is
-        the working copy — neither is disposable. Removing an archived version
-        breaks nothing that ran against it, since every Experimenter and Trainer
-        keeps its own Pipeline copy; what goes is what a provenance pointer
-        refers to.
+        The latest is what an omitted version number resolves to, so deleting
+        it would silently move that pointer: the next ``add_experimenter`` would
+        adopt a different definition than the one before it did, with nothing
+        in the call to say so. Any older version goes freely — every
+        Experimenter and Trainer keeps its own Pipeline copy, so what is lost is
+        what a provenance pointer refers to, not anything that ran.
 
         Raises:
             KeyError: If there is no such version.
-            ValueError: If it is not archived.
+            ValueError: If it is the latest one.
         """
         row = self._version_row(version)
-        if row['status'] != ARCHIVED:
+        if row['version'] == self._version_row()['version']:
             raise ValueError(
-                f"Pipeline version {version} is {row['status']}, and only "
-                f"{ARCHIVED} versions can be removed."
+                f"Pipeline version {version} is the latest one, which is what "
+                f"an omitted version resolves to. Publish a newer definition "
+                f"first, or remove an older version."
             )
         for key in ('path', 'builder_path'):
             Path(row[key]).unlink(missing_ok=True)
@@ -277,7 +281,7 @@ class PipelineStore:
             conn.row_factory = sqlite3.Row
             if version is None:
                 row = conn.execute(
-                    "SELECT * FROM versions WHERE status = ?", (PUBLISHED,)
+                    "SELECT * FROM versions ORDER BY version DESC LIMIT 1"
                 ).fetchone()
             else:
                 row = conn.execute(
@@ -285,7 +289,7 @@ class PipelineStore:
                 ).fetchone()
         if not row:
             raise KeyError(
-                f"No published pipeline in {self.db_path}" if version is None
+                f"No pipeline version in {self.db_path}" if version is None
                 else f"No pipeline version {version!r} in {self.db_path}"
             )
         return row

--- a/mllabs/_predictor.py
+++ b/mllabs/_predictor.py
@@ -39,14 +39,20 @@ class Predictor:
         src_trial (str): Name of the Trial this was promoted from, if any.
         src_experimenter (str): Name of the Experimenter that evaluated
             ``src_trial``, if known.
+        pipeline_version (int | None): The Pipeline version this is defined
+            against — copied from the Trial by :meth:`from_trial`, so a
+            promoted Predictor requires the version its candidate was actually
+            evaluated on. ``None`` means unstamped, which ``Trainer.train``
+            resolves to the version that Trainer has adopted.
     """
 
     __slots__ = ('name', 'processor', 'method', 'adapter', 'params', 'edges',
-                 'desc', 'tag', 'src_trial', 'src_experimenter')
+                 'desc', 'tag', 'src_trial', 'src_experimenter',
+                 'pipeline_version')
 
     def __init__(self, name, processor, edges, method='predict', adapter=None,
                  params=None, desc=None, tag=None, src_trial=None,
-                 src_experimenter=None):
+                 src_experimenter=None, pipeline_version=None):
         self.name = name
         self.processor = processor
         self.edges = dict(edges or {})
@@ -57,6 +63,7 @@ class Predictor:
         self.tag = list(tag or [])
         self.src_trial = src_trial
         self.src_experimenter = src_experimenter
+        self.pipeline_version = pipeline_version
 
     @classmethod
     def from_trial(cls, trial, name=None, experimenter=None):
@@ -65,6 +72,13 @@ class Predictor:
         The execution definition is copied verbatim — the promoted Predictor
         trains exactly what was evaluated — and the Trial's name is recorded
         as ``src_trial`` even when *name* overrides the Predictor's own.
+
+        ``pipeline_version`` is part of that verbatim copy, so the Predictor
+        requires the version its candidate was evaluated against and
+        ``Trainer.train`` refuses to train it under any other. Adopt that
+        version in the Trainer — every published version is adoptable, and
+        nothing else would be training what was actually measured. No separate
+        provenance field records it, because this one already does.
 
         Args:
             trial (Trial): The evaluated candidate to promote.
@@ -87,6 +101,7 @@ class Predictor:
             tag=list(trial.tag),
             src_trial=trial.name,
             src_experimenter=experimenter,
+            pipeline_version=trial.pipeline_version,
         )
 
     def get_spec(self):

--- a/mllabs/_predictor_store.py
+++ b/mllabs/_predictor_store.py
@@ -34,7 +34,8 @@ _SCHEMA_SQL = """
         edges            TEXT,
         tag              TEXT,
         src_trial        TEXT,
-        src_experimenter TEXT
+        src_experimenter TEXT,
+        pipeline_version INTEGER
     );
 """
 
@@ -60,13 +61,13 @@ class PredictorStore:
             conn.execute(
                 "INSERT OR REPLACE INTO predictors "
                 "(name, desc, processor, method, adapter, params, edges, tag, "
-                "src_trial, src_experimenter) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "src_trial, src_experimenter, pipeline_version) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (predictor.name, predictor.desc, predictor.processor,
                  predictor.method, json.dumps(predictor.adapter),
                  json.dumps(predictor.params), json.dumps(predictor.edges),
                  json.dumps(predictor.tag), predictor.src_trial,
-                 predictor.src_experimenter),
+                 predictor.src_experimenter, predictor.pipeline_version),
             )
 
     def register_all(self, predictors):
@@ -90,14 +91,21 @@ class PredictorStore:
             conn.execute("DELETE FROM predictors WHERE name = ?", (name,))
 
     def has(self, predictor):
-        """Whether *predictor*'s exact definition is the one stored under its name."""
+        """Whether *predictor*'s exact definition is the one stored under its name.
+
+        ``pipeline_version`` counts, for the same reason it does in
+        ``TrialStore.has``: it decides which Trainer state the definition may
+        be trained under, so the same fields against another version are
+        another definition.
+        """
         stored = self.get_by_name(predictor.name)
         return (stored is not None
                 and stored.processor == predictor.processor
                 and stored.method == predictor.method
                 and stored.adapter == predictor.adapter
                 and stored.params == predictor.params
-                and stored.edges == predictor.edges)
+                and stored.edges == predictor.edges
+                and stored.pipeline_version == predictor.pipeline_version)
 
     def get_by_name(self, name):
         """Stored :class:`~mllabs.Predictor` for *name*, or ``None``."""
@@ -133,6 +141,7 @@ class PredictorStore:
             tag=json.loads(row['tag']) if row['tag'] else [],
             src_trial=row['src_trial'],
             src_experimenter=row['src_experimenter'],
+            pipeline_version=row['pipeline_version'],
         )
 
     def __repr__(self):

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -33,9 +33,9 @@ class Project:
           trials.db           TrialStore (definitions + execution history)
           data.pkl            the dataset everything here is built against
           aug_data.pkl        data appended to inner train splits, if any
-          pipeline/           pipeline.db — the working copy, i.e. the open
-                               version — plus v{n}.pkl and v{n}_builder.pkl
-                               per published version
+          pipeline/           pipeline.db — the working copy, which is the
+                               builder itself and never a version — plus
+                               v{n}.pkl and v{n}_builder.pkl per published one
           exp/{name}/         Experimenter — its own store, Pipeline copy,
                                NodeStore and Collectors, all self-contained
           trainers/{name}/    Trainer (same, own NodeStore)
@@ -246,9 +246,9 @@ class Project:
         """Add a new Trainer named *name*, under ``{project}/trainers/{name}``.
 
         Same shape as :meth:`add_experimenter`, and the same rule: a taken name
-        raises. *pipeline_version* defaults the same way too — the published
-        version, which is frozen and so is exactly what a Trainer is allowed to
-        adopt. What it refuses is the working copy, and this never hands it one.
+        raises. *pipeline_version* defaults the same way too — the latest
+        published version. Any published version is adoptable, and this never
+        hands over a draft, which is the one thing ``set_pipeline`` refuses.
         """
         from ._trainer import Trainer
         from ._trainer_store import TrainerStore
@@ -354,6 +354,18 @@ class Project:
         and be two. Changing such a Trial means either a new name, or
         :meth:`remove_trial` to give up the results with it.
 
+        **The version is stamped here.** A Trial with no ``pipeline_version``
+        gets the latest published one, this being the only place that both
+        knows the registry and owns the definition. Pass one explicitly to
+        author against an older version; it has to exist, since a number no
+        version answers to would be refused by every Experimenter with nothing
+        to say why.
+
+        Stamping interacts with the freeze on purpose: after the pipeline moves
+        on, re-registering a name that already succeeded is a changed
+        definition, so it raises instead of quietly re-pointing results at a
+        version that did not produce them. Give it a new name.
+
         Args:
             trial (Trial): Definition to store.
 
@@ -365,7 +377,8 @@ class Project:
         Raises:
             ValueError: If the name has a ``'built'`` fold in
                 ``experiment_hist`` and the definition differs from the
-                stored one.
+                stored one, or if *trial* names a version this project has
+                never published.
         """
         changed = self.set_trials([trial])
         return changed[0] if changed else None
@@ -375,8 +388,12 @@ class Project:
 
         Nothing is written until every Trial has been checked, so a batch
         holding one frozen name changes nothing at all rather than leaving
-        half of itself registered.
+        half of itself registered. Stamping comes first for the same reason —
+        an unstamped Trial and the stored one differ in a field, so comparing
+        before stamping would call every Trial changed.
         """
+        for trial in trials:
+            self._stamp_version(trial)
         changed = [t for t in trials if not self.trials.has(t)]
         for trial in changed:
             built = self.trials.get_hist(trial_name=trial.name, status='built')
@@ -390,6 +407,24 @@ class Project:
                 )
         self.trials.register_all(changed)
         return [t.name for t in changed]
+
+    def _stamp_version(self, trial):
+        """Fill in *trial*'s ``pipeline_version``, or check the one it brought.
+
+        Mutates the Trial rather than storing a resolved copy, so the object
+        the caller still holds says the same thing the row does — the two would
+        otherwise disagree about which version the Trial runs on.
+        """
+        if trial.pipeline_version is None:
+            trial.pipeline_version = self.load_pipeline().version
+            return
+        known = {r['version'] for r in self.list_pipeline_versions()}
+        if trial.pipeline_version not in known:
+            raise ValueError(
+                f"Trial '{trial.name}' names pipeline version "
+                f"{trial.pipeline_version}, which this project has not "
+                f"published. Published versions: {sorted(known)}."
+            )
 
     def error_trials(self, experimenter=None):
         """Failed folds of Trial execution, one dict each.
@@ -501,12 +536,11 @@ class Project:
         Delegates to ``Experimenter.stale_nodes``, the same code ``set_pipeline``
         resets by — a preview of the real thing, not a second opinion about it.
 
-        Defaults to the working copy, built through ``pipeline.copy()`` so the
-        snapshot has no db and :meth:`PipelineBuilder.build` mints nothing.
-        Asking what an edit would cost must not be what commits the edit: a
-        published version demotes the previous one, and ``add_experimenter`` /
-        ``add_trainer`` take published by default, so a mere preview would
-        change what the next call adopts.
+        Defaults to the working copy as a :meth:`PipelineBuilder.draft`, which
+        is a snapshot and not a publication. Asking what an edit would cost must
+        not be what commits the edit: ``add_experimenter`` / ``add_trainer``
+        adopt the latest version by default, so a mere preview would change what
+        the next call adopts.
 
         Pipeline nodes only. A Trial is never reset by adoption — its
         ``experiment_hist`` row records the version it ran against and stays a
@@ -525,7 +559,7 @@ class Project:
             Experimenter the change does not touch.
         """
         if pipeline is None:
-            pipeline = self.pipeline.copy().build()
+            pipeline = self.pipeline.draft()
         return {name: self.experimenters[name].stale_nodes(pipeline)
                 for name in self._experimenter_names(experimenter)}
 
@@ -572,7 +606,7 @@ class Project:
     # ------------------------------------------------------------------
 
     def load_pipeline(self, version=None):
-        """A frozen version by number; without one, the published (current) one.
+        """A published version by number; without one, the latest.
 
         A read, and only a read. It used to build :attr:`pipeline` when given
         no version, which publishes — so a call that reads like "load" minted a
@@ -589,9 +623,10 @@ class Project:
 
         Version 0 is what "this project has no pipeline yet" *is*, rather than
         an absence every caller has to handle. It is a real published row, so
-        :meth:`load_pipeline` never comes up empty, a Trainer can adopt it
-        (published is frozen — an empty definition has nothing to change under
-        it), and "exactly one published version" is true from the start.
+        :meth:`load_pipeline` never comes up empty and both an Experimenter and
+        a Trainer can adopt it — which they must, since only a published
+        version can be adopted and this is the one that exists before anything
+        is defined.
 
         Building an untouched working copy returns version 0 rather than
         minting: nothing was defined, so nothing was changed. Version 1 is the
@@ -605,16 +640,21 @@ class Project:
                       PipelineBuilder(), version=0)
 
     def list_pipeline_versions(self):
-        """Every frozen version: ``{version, status, path, builder_path}`` rows."""
+        """Every published version: ``{version, path, builder_path}`` rows.
+
+        No status among them: being listed here is what published means, and a
+        draft never reaches the store.
+        """
         return self._pipeline_store().list_versions()
 
     def remove_pipeline_version(self, version):
-        """Delete an archived version.
+        """Delete a published version. Not the latest one.
 
-        Archived only — the published version is the current definition and the
-        working copy is not a version at all. Nothing that ran against it
-        breaks: every Experimenter and Trainer holds its own Pipeline copy. What
-        is lost is what their provenance points at.
+        The latest is what :meth:`load_pipeline` and ``add_experimenter`` /
+        ``add_trainer`` resolve to when given no number, so removing it would
+        move that pointer silently. Any older one goes freely: nothing that ran
+        against it breaks, since every Experimenter and Trainer holds its own
+        Pipeline copy. What is lost is what their provenance points at.
         """
         self._pipeline_store().remove_version(version)
 

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -12,7 +12,7 @@ from ._logger import resolve_logger
 from ._pipeline import Pipeline
 from ._serialize import _obj_to_ref, serialize_value
 from ._common import (resolve_common_status, require_built_pipeline,
-                      require_frozen_pipeline)
+                      require_published_pipeline)
 
 
 class TrainFold:
@@ -214,7 +214,7 @@ class Trainer:
     # ------------------------------------------------------------------
 
     def set_pipeline(self, pipeline):
-        """Adopt an already-loaded Pipeline. It must be a frozen version.
+        """Adopt an already-loaded Pipeline. It must be a published version.
 
         Takes the Pipeline object directly rather than a version number —
         this class has no way to load one by version itself (see the class
@@ -222,12 +222,12 @@ class Trainer:
         this. ``self.pipeline_version`` is read straight off *pipeline* (its
         ``.version``), never tracked separately.
 
-        The working copy is refused. What a Trainer produces is what gets
-        deployed, so it has to be able to say what it was trained against, and
-        a draft changes under it. An *archived* version is fine — it is frozen,
-        so it answers that question as well as the published one does. What is
-        ruled out is training against something still being edited, not
-        training against something old.
+        A draft is refused, and only a draft. What a Trainer produces is what
+        gets deployed, so it has to be able to say what it was trained against,
+        and a draft carries no number to say it with. *Which* published version
+        is not this call's business: an older one answers that question as well
+        as the newest, and training a Predictor evaluated against an older
+        definition is exactly what adopting that version is for.
 
         The Pipeline is written to this Trainer's own ``pipeline.pkl``, which
         :meth:`load` reads back — reopening needs only this directory, never
@@ -243,14 +243,19 @@ class Trainer:
         past execution to preserve, so a Predictor trained against a
         since-changed node is simply stale.
 
+        The Predictors already registered here move onto the adopted version
+        with it (see ``_restamp_predictors``): adopting is what says which
+        definition this Trainer trains against, and stranding them behind would
+        leave their artifacts deleted and unrebuildable.
+
         Args:
             pipeline (Pipeline): Already-built, already-published Pipeline.
 
         Raises:
-            ValueError: If *pipeline* is the unpublished working copy.
+            ValueError: If *pipeline* is a draft.
         """
         require_built_pipeline(pipeline)
-        require_frozen_pipeline(pipeline)
+        require_published_pipeline(pipeline)
         pipeline.check_data_compatibility(self.data)
         # See Experimenter.set_pipeline: the empty Pipeline means nothing has
         # been adopted, so there is nothing to invalidate against.
@@ -261,7 +266,27 @@ class Trainer:
         self.pipeline = pipeline
         self._store.save_pipeline(pipeline)
         self.save()
+        self._restamp_predictors()
         return pipeline
+
+    def _restamp_predictors(self):
+        """Move the registered Predictors onto the version just adopted.
+
+        Adopting a version here *is* the decision to train against it, so the
+        Predictors this Trainer already holds follow it rather than being
+        stranded: without this the reset above would delete their artifacts and
+        :meth:`train` would then refuse to rebuild them, leaving the whole
+        version-switch path unreachable.
+
+        The gate in :meth:`train` is not weakened by this, because it guards a
+        different motion — a Predictor arriving from elsewhere, promoted from a
+        Trial evaluated against some other version. That one is still refused,
+        which is the case where training would ship something unmeasured.
+        """
+        for predictor in self.predictor_defs.list_predictors():
+            if predictor.pipeline_version != self.pipeline_version:
+                predictor.pipeline_version = self.pipeline_version
+                self.predictor_defs.register(predictor)
 
     @property
     def predictors(self):
@@ -463,6 +488,14 @@ class Trainer:
         Predictor trained by an earlier call keeps its definition and its
         artifacts.
 
+        **Each one has to be defined against the version this Trainer
+        adopted.** One promoted from a Trial carries the version its candidate
+        was evaluated on, so training it elsewhere would ship something that
+        was never measured; adopt that version instead, since every published
+        version is adoptable. One authored here with no version gets this
+        Trainer's — the version it is being defined against is the one in
+        front of it, and this Trainer knows that without a registry to ask.
+
         Args:
             predictors (list[Predictor], optional): What to train. A
                 :class:`~mllabs.Trial` is rejected — promote it explicitly with
@@ -473,6 +506,11 @@ class Trainer:
             n_jobs (int): Number of parallel workers. Default 1 (sequential).
             gpu_id_list (list, optional): GPU IDs for GPU-enabled nodes.
             logger: Logger instance. Default: shared ``DefaultLogger.get_instance()``.
+
+        Raises:
+            TypeError: If *predictors* holds a :class:`~mllabs.Trial`.
+            ValueError: If a Predictor is defined against a different Pipeline
+                version than the adopted one.
         """
         from ._executor import _execute_single, _execute_multi
         from ._tracker import LoggerExecuteTracker, NodeInfoTracker
@@ -491,7 +529,19 @@ class Trainer:
                         f"train() got a Trial ({p.name!r}); promote it with "
                         f"Predictor.from_trial(trial, experimenter=...) first"
                     )
+                if p.pipeline_version is None:
+                    p.pipeline_version = self.pipeline_version
             self.predictor_defs.register_all(predictors)
+        for p in predictors:
+            if p.pipeline_version != self.pipeline_version:
+                raise ValueError(
+                    f"Predictor '{p.name}' is defined against pipeline version "
+                    f"{p.pipeline_version}, and this Trainer has adopted "
+                    f"version {self.pipeline_version}. Training it here would "
+                    f"ship a definition that was never evaluated — adopt that "
+                    f"version with set_pipeline(project.load_pipeline("
+                    f"{p.pipeline_version!r}))."
+                )
 
         # Node staleness is settled when a Pipeline is adopted
         # (set_pipeline); Predictor staleness is checked per job below.

--- a/mllabs/_trial.py
+++ b/mllabs/_trial.py
@@ -18,13 +18,19 @@ class Trial:
     the Head node name played. Redefining a name overwrites both the artifact
     and its ``TrialStore`` row.
 
-    A Trial's own definition says nothing about the preprocessing it read, and
-    it does not live in the pipeline, so a node change cannot cascade into it
-    through the Pipeline graph automatically. ``Experimenter.set_pipeline``
-    deliberately does not cascade either — a Trial's artifact and its
-    ``TrialStore.experiment_hist`` row document the pipeline version it
-    actually ran against, which stays valid even after a newer version is
-    adopted. Rerunning it is a separate, explicit action.
+    ``pipeline_version`` is part of the definition, not a note about it. A
+    Trial's own fields say nothing about the preprocessing it reads, and it
+    does not live in the pipeline, so the graph cannot tell it that its inputs
+    changed; naming the version it was authored against is how it says which
+    definition it means. ``Experimenter.exp`` refuses to run it against any
+    other version, so the same name can never accumulate results from two
+    different pipelines. ``Experimenter.set_pipeline`` still does not cascade
+    into Trials — adopting a new version leaves their history alone, and what
+    the version stamp adds is that they simply stop running there.
+
+    ``Project.set_trial`` fills it in with the latest published version when it
+    is left unset, so authoring one by hand does not mean tracking versions by
+    hand.
 
     The Trainer side makes the opposite call, which is why it has its own
     :class:`~mllabs.Predictor` rather than reusing this class: a Trainer keeps
@@ -42,13 +48,16 @@ class Trial:
             ``PipelineBuilder``'s ``desc`` — never affects matching, diffing,
             or storage identity.
         tag (list[str]): Selection tags.
+        pipeline_version (int | None): The Pipeline version this was authored
+            against. ``None`` means unstamped, which ``Project.set_trial``
+            resolves to the latest published version on registration.
     """
 
     __slots__ = ('name', 'processor', 'method', 'adapter', 'params', 'edges',
-                 'desc', 'tag')
+                 'desc', 'tag', 'pipeline_version')
 
     def __init__(self, name, processor, edges, method='predict', adapter=None,
-                 params=None, desc=None, tag=None):
+                 params=None, desc=None, tag=None, pipeline_version=None):
         self.name = name
         self.processor = processor
         self.edges = dict(edges or {})
@@ -57,6 +66,7 @@ class Trial:
         self.params = dict(params or {})
         self.desc = desc
         self.tag = list(tag or [])
+        self.pipeline_version = pipeline_version
 
     def get_spec(self):
         """This Trial's :class:`~mllabs._pipeline.ProcessorSpec`.
@@ -96,7 +106,7 @@ class Trial:
 
 
 def make_trials(name, processor, edges, method='predict', adapter=None,
-                params=None, param_grid=None, tags=None):
+                params=None, param_grid=None, tags=None, pipeline_version=None):
     """Build a list of Trials sweeping *param_grid* over one fixed processor.
 
     Every Trial shares processor/method/adapter/edges; ``params`` holds the
@@ -125,6 +135,10 @@ def make_trials(name, processor, edges, method='predict', adapter=None,
         param_grid (dict, optional): ``{param: [values]}``. Omitted yields a
             single Trial from *params* alone.
         tags (list[str], optional): Tags applied to every Trial.
+        pipeline_version (int, optional): Pipeline version every Trial in the
+            sweep is authored against. Left unset, ``Project.set_trial`` fills
+            in the latest published one — pass it only to sweep against an
+            older version.
 
     Returns:
         list[Trial]
@@ -173,5 +187,6 @@ def make_trials(name, processor, edges, method='predict', adapter=None,
             adapter=adapter,
             params=merged,
             tag=list(tags or []),
+            pipeline_version=pipeline_version,
         ))
     return trials

--- a/mllabs/_trial_store.py
+++ b/mllabs/_trial_store.py
@@ -50,14 +50,15 @@ from ._trial import Trial
 
 _SCHEMA_SQL = """
     CREATE TABLE IF NOT EXISTS trials (
-        name        TEXT PRIMARY KEY,
-        desc        TEXT,
-        processor   TEXT NOT NULL,
-        method      TEXT,
-        adapter     TEXT,
-        params      TEXT,
-        edges       TEXT,
-        tag         TEXT
+        name             TEXT PRIMARY KEY,
+        desc             TEXT,
+        processor        TEXT NOT NULL,
+        method           TEXT,
+        adapter          TEXT,
+        params           TEXT,
+        edges            TEXT,
+        tag              TEXT,
+        pipeline_version INTEGER
     );
     CREATE TABLE IF NOT EXISTS experiment_hist (
         trial_name       TEXT NOT NULL,
@@ -110,11 +111,12 @@ class TrialStore(ArtifactStore):
         with sqlite3.connect(str(self.db_path)) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO trials "
-                "(name, desc, processor, method, adapter, params, edges, tag) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "(name, desc, processor, method, adapter, params, edges, tag, "
+                "pipeline_version) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (trial.name, trial.desc, trial.processor,
                  trial.method, json.dumps(trial.adapter), json.dumps(trial.params),
-                 json.dumps(trial.edges), json.dumps(trial.tag)),
+                 json.dumps(trial.edges), json.dumps(trial.tag),
+                 trial.pipeline_version),
             )
 
     def register_all(self, trials):
@@ -141,6 +143,12 @@ class TrialStore(ArtifactStore):
         guarding a redefinition does not have to check for absence separately.
         Compares what execution depends on; ``desc``/``tag`` are display and
         selection metadata and do not make a definition a different one.
+
+        ``pipeline_version`` *is* compared. It decides where the Trial is
+        allowed to run, so the same fields against a different version are a
+        different definition — which is what makes ``Project.set_trial`` refuse
+        to re-point a name that has already succeeded, rather than leaving the
+        rule to convention.
         """
         stored = self.get_by_name(trial.name)
         return (stored is not None
@@ -148,7 +156,8 @@ class TrialStore(ArtifactStore):
                 and stored.method == trial.method
                 and stored.adapter == trial.adapter
                 and stored.params == trial.params
-                and stored.edges == trial.edges)
+                and stored.edges == trial.edges
+                and stored.pipeline_version == trial.pipeline_version)
 
     def get_by_name(self, name):
         """Stored definition for *name* as a :class:`~mllabs.Trial`, or ``None``."""
@@ -183,6 +192,7 @@ class TrialStore(ArtifactStore):
             params=json.loads(row['params']) if row['params'] else {},
             desc=row['desc'],
             tag=json.loads(row['tag']) if row['tag'] else [],
+            pipeline_version=row['pipeline_version'],
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -56,7 +56,13 @@ def _pipeline_version(project):
 
 def _register(trial, e):
     """Register *trial* and return the name — exp() takes names, reads the
-    definition out of the store, and covers every fold of *e* itself."""
+    definition out of the store, and covers every fold of *e* itself.
+
+    Stamped with the run's own pipeline version, which Project.set_trial would
+    otherwise do: exp() refuses a Trial defined against another version, and
+    these tests are about Collectors."""
+    if trial.pipeline_version is None:
+        trial.pipeline_version = e.pipeline_version
     e.trial_store.register(trial)
     return trial.name
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -110,7 +110,12 @@ def _wp():
 def _names(trials, exp):
     """Register a bare Trial list and return the names Experimenter.exp takes.
 
-    Each name covers every fold of *exp* — exp() expands the grid itself."""
+    Each name covers every fold of *exp* — exp() expands the grid itself.
+    Stamped with the run's own pipeline version, which Project.set_trial would
+    otherwise do: exp() refuses a Trial defined against another version."""
+    for t in trials:
+        if t.pipeline_version is None:
+            t.pipeline_version = exp.pipeline_version
     exp.trial_store.register_all(trials)
     return [t.name for t in trials]
 

--- a/tests/test_experimenter.py
+++ b/tests/test_experimenter.py
@@ -86,7 +86,12 @@ def _folds(trial, exp):
     exp() takes names and reads the definition out of the store, so a test
     Trial has to be in there first. Registering through the store rather than
     Project.set_trial deliberately skips the redefinition guard — several
-    tests below redefine a name on purpose to check what a rerun does."""
+    tests below redefine a name on purpose to check what a rerun does. It also
+    skips the version stamp, so that is done here: exp() refuses a Trial
+    defined against another version, and these tests are about everything
+    except that."""
+    if trial.pipeline_version is None:
+        trial.pipeline_version = exp.pipeline_version
     exp.trial_store.register(trial)
     return [trial.name]
 
@@ -571,6 +576,15 @@ class TestSetPipeline:
         e = Experimenter(path=tmp_path / 'reject', name='e1', data=sample_data)
         with pytest.raises(TypeError, match='built Pipeline'):
             e.set_pipeline(pipeline)
+
+    def test_a_draft_is_rejected(self, tmp_path, sample_data, pipeline):
+        """The same gate the Trainer has. Experimenting against a definition
+        under edit used to be allowed, but a Trial names the version it was
+        authored against and an adopted draft has no number to check it
+        against."""
+        e = Experimenter(path=tmp_path / 'draft', name='e1', data=sample_data)
+        with pytest.raises(ValueError, match='draft'):
+            e.set_pipeline(pipeline.draft())
 
     def test_set_pipeline_keeps_a_copy_in_the_run(self, exp, pipeline):
         """The run owns the Pipeline it works against, so reopening it needs

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1202,6 +1202,37 @@ class TestCheckDataCompatibility:
             t.set_pipeline(pl.build())
 
 
+class TestDraft:
+    """A Pipeline is draft or published, and nothing else. build() publishes;
+    draft() is how you look at a definition without committing it."""
+
+    def test_a_draft_is_unnumbered(self, sp):
+        drafted = sp.draft()
+        assert (drafted.version, drafted.status) == (None, 'draft')
+
+    def test_a_build_is_published_and_numbered(self, tmp_path):
+        p = PipelineBuilder(path=tmp_path / 'pl')
+        p.set_grp('g1', processor=DummyStage, method='transform', edges={'X': '{x1}'})
+        p.set_node('s1', grp='g1')
+        built = p.build()
+        assert (built.version, built.status) == (1, 'published')
+
+    def test_the_same_graph_either_way(self, tmp_path):
+        p = PipelineBuilder(path=tmp_path / 'pl')
+        p.set_grp('g1', processor=DummyStage, method='transform', edges={'X': '{x1}'})
+        p.set_node('s1', grp='g1')
+        assert p.draft().get_node_spec('s1') == p.build().get_node_spec('s1')
+
+    def test_drafting_does_not_publish(self, tmp_path):
+        """Asking what the working copy says must not be what commits it —
+        Project.stale_nodes leans on exactly this."""
+        p = PipelineBuilder(path=tmp_path / 'pl')
+        p.set_grp('g1', processor=DummyStage, method='transform', edges={'X': '{x1}'})
+        p.set_node('s1', grp='g1')
+        p.draft()
+        assert p._store.list_versions() == []
+
+
 class TestPipelineSQLite:
     def test_init_creates_db(self, tmp_path):
         p = PipelineBuilder(path=tmp_path, name='test')
@@ -1481,14 +1512,18 @@ class TestPipelineSync:
         assert 'n2' in p.grps['g1'].nodes
 
 class TestBuild:
-    """PipelineBuilder.build() -> immutable Pipeline structure."""
+    """The snapshot ``build()``/``draft()`` share -> immutable Pipeline structure.
+
+    Asked through ``draft()``, since these builders have no db: the graph is
+    the same either way, and publishing is not what is under test here.
+    """
 
     def test_returns_pipeline(self, sp):
         from mllabs._pipeline import Pipeline
-        assert isinstance(sp.build(), Pipeline)
+        assert isinstance(sp.draft(), Pipeline)
 
     def test_carries_pipeline_id_and_new_build_id(self, sp):
-        b1, b2 = sp.build(), sp.build()
+        b1, b2 = sp.draft(), sp.draft()
         assert b1.pipeline_id == b2.pipeline_id == sp.pipeline_id
         assert b1.build_id != b2.build_id
 
@@ -1496,58 +1531,58 @@ class TestBuild:
         p.set_grp('g1', processor=DummyStage, method='transform',
                   edges={'X': '{a}'}, params={'a': 1, 'b': 2})
         p.set_node('n1', grp='g1', edges={'X': '+ {b}'}, params={'b': 3, 'c': 4})
-        node = p.build().nodes['n1']
+        node = p.draft().nodes['n1']
         assert node.processor == DummyStage
         assert node.method == 'transform'
         assert node.edges['X'] == '{a} + {b}'
         assert node.params == {'a': 1, 'b': 3, 'c': 4}
 
     def test_group_name_kept_as_label_only(self, sp):
-        node = sp.build().get_node('s1')
+        node = sp.draft().get_node('s1')
         assert node.label == 'stage1'
 
     def test_node_attrs_shape_matches_builder(self, sp):
-        built = sp.build().get_node_spec('h1')
+        built = sp.draft().get_node_spec('h1')
         from_builder = sp.get_node_spec('h1')
         assert built == from_builder
 
     def test_datasource_snapshot(self, p):
         p.set_datasource({'a': 'numerical', 'b': 'binary'}, targets=['b'])
-        ds = p.build().datasource
+        ds = p.draft().datasource
         assert ds.schema == {'a': 'numerical', 'b': 'binary'}
         assert ds.targets == ['b']
 
     def test_datasource_is_none_key(self, sp):
-        built = sp.build()
+        built = sp.draft()
         assert built.nodes[None] is built.datasource
 
 class TestBuildIsolation:
     """A built Pipeline is a snapshot — later builder edits must not reach it."""
 
     def test_node_edit_does_not_affect_built(self, sp):
-        built = sp.build()
+        built = sp.draft()
         sp.set_node('s1', grp='stage1', edges={'X': '{x9}'})
         assert built.nodes['s1'].edges['X'] == '{x1}'
 
     def test_group_edit_does_not_affect_built(self, sp):
-        built = sp.build()
+        built = sp.draft()
         sp.set_grp('stage1', processor=AnotherProcessor,
                    method='transform', edges={'X': '{x1}'})
         assert built.nodes['s1'].processor == DummyStage
 
     def test_new_node_does_not_appear_in_built(self, sp):
-        built = sp.build()
+        built = sp.draft()
         sp.set_node('s2', grp='stage1')
         assert 's2' not in built.nodes
 
     def test_removed_node_stays_in_built(self, sp):
-        built = sp.build()
+        built = sp.draft()
         sp.remove_node('s1')
         assert 's1' in built.nodes
 
     def test_datasource_edit_does_not_affect_built(self, p):
         p.set_datasource({'a': 'numerical'}, targets=['a'])
-        built = p.build()
+        built = p.draft()
         p.set_datasource({'a': 'numerical', 'b': 'numerical'}, targets=['b'])
         assert built.datasource.schema == {'a': 'numerical'}
         assert built.datasource.targets == ['a']
@@ -1565,7 +1600,7 @@ class TestBuiltPipelineQueries:
         p.set_grp('g_head', processor=DummyHead, method='predict',
                   edges={'X': 's2:(*)', 'y': '{target}'})
         p.set_node('h1', grp='g_head')
-        return p.build()
+        return p.draft()
 
     def test_topo_order(self, chain):
         order = chain.topo_order()
@@ -1630,7 +1665,7 @@ class TestDiffFromDataSourceChange:
         p.set_datasource(schema, targets=targets)
         p.set_grp('g_stage', processor=DummyStage, method='transform', edges={'X': x_edge})
         p.set_node('s1', grp='g_stage')
-        return p.build()
+        return p.draft()
 
     def test_unrelated_column_added_does_not_stale(self):
         old = self._pipeline({'x1': 'numerical', 'target': 'binary'})
@@ -1668,7 +1703,7 @@ class TestDiffFromDataSourceChange:
             p.set_node('s1', grp='g_stage')
             p.set_grp('g_stage2', processor=DummyStage, method='transform', edges={'X': 's1:(*)'})
             p.set_node('s2', grp='g_stage2')
-            return p.build()
+            return p.draft()
 
         old = build({'x1': 'numerical', 'x2': 'numerical', 'target': 'binary'})
         new = build({'x1': 'numerical', 'target': 'binary'})

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -40,8 +40,9 @@ def store(tmp_path):
     return TrialStore(tmp_path / 'ts')
 
 
-def _trial(name='dt', params=None):
-    return Trial(name, TREE, EDGES, params=params or {'max_depth': 3})
+def _trial(name='dt', params=None, pipeline_version=None):
+    return Trial(name, TREE, EDGES, params=params or {'max_depth': 3},
+                 pipeline_version=pipeline_version)
 
 
 def dummy_metric(y, pred):
@@ -129,26 +130,30 @@ class TestPipelineVersions:
         builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
         assert builder.build().version == 2
 
-    def test_publishing_archives_the_previous(self, project, builder):
+    def test_publishing_demotes_nothing(self, project, builder):
+        """Every stored version stays published and stays adoptable; the newest
+        is only what an omitted version number resolves to."""
         builder.build()
         builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
         builder.build()
-        assert [(r['version'], r['status']) for r in project.list_pipeline_versions()] == \
-            [(0, 'archived'), (1, 'archived'), (2, 'published')]
+        assert [r['version'] for r in project.list_pipeline_versions()] == [0, 1, 2]
+        assert all(project.pipeline._store.get_status(v) == 'published'
+                   for v in (0, 1, 2))
 
-    def test_a_builder_with_no_db_stays_open(self):
-        """Nowhere to mint from, so it is the one unnumbered case — and the
-        one Trainer.set_pipeline refuses."""
+    def test_a_builder_with_no_db_cannot_build(self):
+        """Nowhere to publish, so build() says so rather than quietly handing
+        back something unnumbered. draft() is how you get the snapshot."""
         bare = PipelineBuilder()
         bare.set_datasource({'f1': 'numerical'})
-        built = bare.build()
-        assert (built.version, built.status) == (None, 'open')
+        with pytest.raises(ValueError, match='no db'):
+            bare.build()
+        drafted = bare.draft()
+        assert (drafted.version, drafted.status) == (None, 'draft')
 
     def test_a_new_project_starts_published_at_v0(self, project):
         """The empty Pipeline is a real published row, not an absence — so
         load_pipeline() always has something to return."""
-        assert [(r['version'], r['status']) for r in project.list_pipeline_versions()] == \
-            [(0, 'published')]
+        assert [r['version'] for r in project.list_pipeline_versions()] == [0]
         assert project.load_pipeline().is_empty
 
     def test_building_an_untouched_working_copy_stays_at_v0(self, project):
@@ -198,16 +203,18 @@ class TestPipelineVersions:
         with pytest.raises(KeyError):
             project.load_pipeline(99)
 
-    def test_archived_versions_can_be_removed(self, project, builder):
+    def test_an_older_version_can_be_removed(self, project, builder):
         builder.build()
         builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
         builder.build()
         project.remove_pipeline_version(1)
         assert [r['version'] for r in project.list_pipeline_versions()] == [0, 2]
 
-    def test_the_published_version_cannot_be_removed(self, project, builder):
+    def test_the_latest_version_cannot_be_removed(self, project, builder):
+        """It is what an omitted version resolves to, so removing it would move
+        that pointer with nothing in the call to say so."""
         builder.build()
-        with pytest.raises(ValueError, match='published'):
+        with pytest.raises(ValueError, match='latest'):
             project.remove_pipeline_version(1)
 
 
@@ -274,6 +281,64 @@ class TestSetTrial:
             project.set_trials(trials)
         assert project.trials.get_by_name('dt_1') is None
         assert project.trials.get_by_name('dt_0').params == {'max_depth': 3}
+
+
+class TestSetTrialStampsTheVersion:
+    """A Trial is defined against a Pipeline version, and this is where it is
+    filled in — the only place that both knows the registry and owns the
+    definition."""
+
+    def test_an_unstamped_trial_gets_the_latest_published(self, project, builder):
+        assert builder.build().version == 1
+        assert project.set_trial(_trial()) == 'dt'
+        assert project.trials.get_by_name('dt').pipeline_version == 1
+
+    def test_a_new_project_stamps_v0(self, project):
+        """Nothing built yet, so the empty Pipeline is what a Trial is against."""
+        project.set_trial(_trial())
+        assert project.trials.get_by_name('dt').pipeline_version == 0
+
+    def test_the_caller_s_object_is_stamped_too(self, project, builder):
+        """Mutated rather than copied, so the Trial still in hand says the same
+        thing the row does."""
+        builder.build()
+        trial = _trial()
+        project.set_trial(trial)
+        assert trial.pipeline_version == 1
+
+    def test_an_explicit_older_version_is_kept(self, project, builder):
+        builder.build()
+        builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
+        assert builder.build().version == 2
+        project.set_trial(_trial(pipeline_version=1))
+        assert project.trials.get_by_name('dt').pipeline_version == 1
+
+    def test_an_unpublished_version_is_refused(self, project, builder):
+        builder.build()
+        with pytest.raises(ValueError, match='has not.*published'):
+            project.set_trial(_trial(pipeline_version=7))
+        assert project.trials.get_by_name('dt') is None
+
+    def test_a_bumped_version_makes_a_succeeded_name_a_redefinition(self, project, builder):
+        """The stamp is part of the definition, so after the pipeline moves on
+        the freeze catches a re-registration instead of quietly re-pointing
+        results at a version that did not produce them."""
+        builder.build()
+        project.set_trial(_trial())
+        project.trials.record('dt', 'run_a', 0, 0, status='built')
+
+        builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
+        builder.build()
+        with pytest.raises(ValueError, match='run_a'):
+            project.set_trial(_trial())
+        assert project.trials.get_by_name('dt').pipeline_version == 1
+
+    def test_a_sweep_can_be_authored_against_one_version(self, project, builder):
+        builder.build()
+        trials = make_trials('dt', processor=TREE, edges=EDGES,
+                             param_grid={'max_depth': [3, 5]}, pipeline_version=0)
+        project.set_trials(trials)
+        assert [t.pipeline_version for t in project.trials.list_trials()] == [0, 0]
 
 
 class TestTrialRegistration:
@@ -665,7 +730,8 @@ class TestExperimenterUnderProject:
         e.exp(['dt'])
         build_id_1 = project.trials.get_info('dt', 'run_a')[(0, 0)]['build_id']
 
-        project.trials.register(Trial('dt', TREE, EDGES, params={'max_depth': 5, 'random_state': 0}))
+        project.trials.register(Trial('dt', TREE, EDGES, params={'max_depth': 5, 'random_state': 0},
+                                      pipeline_version=e.pipeline_version))
         e.exp(['dt'])
         build_id_2 = project.trials.get_info('dt', 'run_a')[(0, 0)]['build_id']
         assert build_id_2 == build_id_1
@@ -701,6 +767,84 @@ class TestExperimenterUnderProject:
         e.exp(['dt', 'bad'], n_jobs=2)
         assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built', (1, 0): 'built'}
         assert project.trials.get_status('bad', 'run_a')[(0, 0)] == 'error'
+
+
+class TestExpChecksTheVersion:
+    """A Trial runs only where it was authored. Collected results are keyed by
+    node name and fold with no version in them, so two versions of one name
+    would overwrite each other's metrics with nothing to say which won."""
+
+    def _exp(self, project, builder, sample_data, name='run_a', version=None):
+        return project.add_experimenter(
+            name, sample_data,
+            sp=ShuffleSplit(n_splits=1, test_size=0.2, random_state=0),
+            pipeline_version=version,
+        )
+
+    def test_a_matching_version_runs(self, project, builder, sample_data):
+        builder.build()
+        e = self._exp(project, builder, sample_data)
+        e.build()
+        project.set_trial(_trial())
+        e.exp(['dt'])
+        assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built'}
+
+    def test_a_trial_from_an_older_version_is_refused(self, project, builder, sample_data):
+        builder.build()
+        project.set_trial(_trial())                      # stamped v1
+        builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
+        assert builder.build().version == 2
+
+        e = self._exp(project, builder, sample_data)     # adopts the latest, v2
+        e.build()
+        with pytest.raises(ValueError, match='version 1'):
+            e.exp(['dt'])
+        assert project.trials.get_status('dt', 'run_a') == {}
+
+    def test_a_finished_trial_passes_after_a_version_bump(self, project, builder, sample_data):
+        """Nothing left to file, so nothing to refuse — re-handing a finished
+        round stays a no-op rather than becoming an error."""
+        builder.build()
+        e = self._exp(project, builder, sample_data)
+        e.build()
+        project.set_trial(_trial())
+        e.exp(['dt'])
+
+        builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
+        e.set_pipeline(project.load_pipeline(builder.build().version))
+        e.build()
+        e.exp(['dt'])                                    # no jobs, no complaint
+        assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built'}
+
+    def test_a_half_run_trial_is_still_refused_after_a_bump(self, project, builder, sample_data):
+        """Some folds left means new results would land beside the old ones."""
+        builder.build()
+        e = project.add_experimenter(
+            'run_b', sample_data,
+            sp=ShuffleSplit(n_splits=2, test_size=0.2, random_state=0))
+        e.build()
+        project.set_trial(_trial())
+        e.exp(['dt'])
+        project.trials.remove_hist(trial_name='dt')      # as if one fold never ran
+        project.trials.record('dt', 'run_b', 0, 0, status='built')
+
+        builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
+        e.set_pipeline(project.load_pipeline(builder.build().version))
+        with pytest.raises(ValueError, match='version 1'):
+            e.exp(['dt'])
+
+    def test_adopting_that_version_lets_it_run(self, project, builder, sample_data):
+        """Nothing is demoted, so the older version is still adoptable — which
+        is the way out of the refusal above."""
+        builder.build()
+        project.set_trial(_trial())
+        builder.set_node('scaler', grp='scale', edges={'X': '{target}'}, exist='replace')
+        builder.build()
+
+        e = self._exp(project, builder, sample_data, version=1)
+        e.build()
+        e.exp(['dt'])
+        assert project.trials.get_status('dt', 'run_a') == {(0, 0): 'built'}
 
 
 class TestTrialErrorReporting:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -192,24 +192,25 @@ class TestSelection:
         assert (trainer.path / 'pipeline.pkl').exists()
         assert trainer._store.fetch()['pipeline_version'] == built.version
 
-    def test_it_refuses_the_working_copy(self, pipeline, sample_data, sp_v):
+    def test_it_refuses_a_draft(self, pipeline, sample_data, sp_v):
         """What a Trainer produces is what gets deployed, so it has to be able
-        to say what it trained against — and a builder with no db mints no
-        version, so its build stays editable and unnamed."""
+        to say what it trained against — and a draft carries no number to say
+        it with."""
         bare = PipelineBuilder()
         bare.set_datasource({'f1': 'numerical', 'f2': 'numerical',
                              'f3': 'numerical', 'target': 'binary'})
         trainer = _make_trainer(pipeline, sample_data, sp_v)
-        with pytest.raises(ValueError, match='working copy'):
-            trainer.set_pipeline(bare.build())
+        with pytest.raises(ValueError, match='draft'):
+            trainer.set_pipeline(bare.draft())
 
-    def test_an_archived_version_is_fine(self, pipeline, sample_data, sp_v):
-        """Frozen is what matters, not current — an older version answers
-        "what was this trained against" as well as the published one does."""
+    def test_an_older_version_is_fine(self, pipeline, sample_data, sp_v):
+        """Nothing is demoted, so an older version is as adoptable as the
+        newest — which is what training a Predictor evaluated against it needs."""
         first = pipeline.build()
         pipeline.set_node('scaler', grp='scale', edges={'X': '{f1}'}, exist='replace')
-        pipeline.build()
-        assert pipeline._store.get_status(first.version) == 'archived'
+        latest = pipeline.build()
+        assert latest.version != first.version
+        assert pipeline._store.get_status(first.version) == 'published'
 
         trainer = _make_trainer(pipeline, sample_data, sp_v)
         trainer.set_pipeline(pipeline._store.load_version(first.version))
@@ -400,6 +401,57 @@ class TestTrain:
         trainer.set_pipeline(pipeline.build())
         trainer.train()
         assert _build_ids(trainer, 'dt') == before
+
+
+class TestPredictorVersion:
+    """A Predictor is defined against a Pipeline version, like a Trial. What
+    differs is where the stamp comes from: a Trainer knows what it adopted, so
+    it fills its own in rather than asking a registry it cannot reach."""
+
+    def test_an_unstamped_predictor_takes_the_adopted_version(
+            self, pipeline, sample_data, sp_v):
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        version = pipeline.build().version
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == version
+
+    def test_from_trial_carries_the_trial_s_version(self):
+        """The version rides along with the rest of the definition, so a
+        promoted candidate requires what it was actually evaluated on."""
+        trial = Trial('dt', DT, DT_EDGES, params={'max_depth': 3},
+                      pipeline_version=1)
+        predictor = Predictor.from_trial(trial, experimenter='run_a')
+        assert predictor.pipeline_version == 1
+        assert (predictor.src_trial, predictor.src_experimenter) == ('dt', 'run_a')
+
+    def test_a_predictor_from_another_version_is_refused(
+            self, pipeline, sample_data, sp_v):
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        latest = pipeline.build()
+        trainer.set_pipeline(latest)
+        stale = _dt()
+        stale.pipeline_version = latest.version + 1
+        with pytest.raises(ValueError, match='never evaluated'):
+            trainer.train([stale])
+
+    def test_adopting_a_new_version_brings_the_predictors_along(
+            self, pipeline, sample_data, sp_v):
+        """Adopting is what says which definition this Trainer trains against.
+        Stranding them behind would leave the reset artifacts unrebuildable."""
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == 1
+
+        pipeline.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
+                         method='transform', edges={'X': '{f1, f2, f3}'},
+                         params={'with_std': False})
+        trainer.set_pipeline(pipeline.build())
+        assert trainer.pipeline_version == 2
+        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == 2
+        trainer.train()
+        assert trainer.get_status('dt') == 'built'
 
 
 class TestPredictorStorage:

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -134,7 +134,7 @@ class TestTrialSpec:
     def test_spec_shape_matches_a_node_spec(self, pipeline, swept):
         """A Trial must look like a node to Connector/executor/Collector."""
         trial_spec = swept[0].get_spec()
-        node_spec = pipeline.build().get_node_spec('scaler')
+        node_spec = pipeline.draft().get_node_spec('scaler')
         assert type(trial_spec) is type(node_spec)
         assert trial_spec.__slots__ == node_spec.__slots__
 


### PR DESCRIPTION
Closes #143.

Settled in the [issue thread](https://github.com/sunkusun9/ml-labs/issues/143#issuecomment-5254759838): the version belongs to the Trial definition rather than to the history row — and getting there needed the Pipeline status model fixed underneath it, so both are here.

## Why not key the history by version

`experiment_hist` stamped a `pipeline_version` it never checked, and `record` is `INSERT OR REPLACE`, so a fold rerun under a newer definition overwrote the older version's outcome. Putting the version in the primary key was the obvious fix and the wrong one: collected results carry no version at all — `MetricCollector` keys on `(node, idx, inner_idx, split)`, `OutputCollector` writes `{path}/{node}/{outer}_{inner}.pkl`, `StackingCollector` `{path}/{node}.pkl` — so history would claim two runs while the metrics kept one, last write winning.

In the definition, the collision cannot happen. One name means one version, and `set_trial`'s existing frozen-name check refuses "same name, different version" with machinery that already exists.

## Pipeline status: draft or published

`archived` is gone. `publish()` stamps `PUBLISHED` on the object *before* pickling it, so a demoted version's pickle went on claiming to be current — no gate could be written against `pipeline.status` truthfully. With nothing demoted the stamp stays accurate forever.

- `versions` loses its `status` column: a row's existence *is* published, and a draft never reaches the store.
- An omitted version resolves to `MAX(version)`; `remove_pipeline_version` refuses the **latest** rather than requiring archived, since deleting what `None` points at would silently change what the next `add_experimenter` adopts.
- `open` becomes `draft` and stops being an accident of whether the builder has a db: `PipelineBuilder.draft()` returns the snapshot `build()` returns, unregistered, and `build()` always mints and raises when there is nowhere to mint into. `Project.stale_nodes` reached for `pipeline.copy().build()` precisely because a copy mints nothing (#142) — it now says `draft()`.

Every published version stays adoptable, so the restriction the previous comment worried about ("a Trainer could no longer train against an older definition") never has to exist.

## Two layers of gate

| | |
|---|---|
| **Adoption** — `set_pipeline` | published only, **both** sides, any version |
| **Run** — `exp()` / `train()` | the stamp must equal the adopted version |

Experimenter gains a gate it never had. Accepting a draft was defensible while nothing compared against the adopted version; it is not now, because an adopted draft holds no number to compare with.

## Stamps

- `Project.set_trial(s)` injects the latest published when a Trial carries none, accepts any published version explicitly, and rejects one never published. It mutates the Trial you still hold, so the object and the row do not disagree.
- `Trainer.train` stamps its own adopted version — the only version it can name without a registry it cannot reach.
- `Predictor.from_trial` copies the version with the rest of the definition, so a promoted candidate requires what it was actually evaluated on. No separate `src_pipeline_version`: that would be a second copy of the same value.

Two consequences worth naming:

- **`Trainer.set_pipeline` re-stamps the Predictors it holds.** Adopting is what says which definition this Trainer trains against; stranding them behind would leave the cascade's deleted artifacts unrebuildable and make the version-switch path unreachable. The `train()` gate is untouched — it guards a Predictor arriving from elsewhere, which is where training something unmeasured would actually happen.
- **The run gate fires only where a job would be created.** A name with every fold already built files nothing, so re-handing a finished round stays a no-op rather than becoming an error. A name with folds left is still refused — that is exactly where new results would land beside old ones. Found while updating the example notebook, which could not be re-run from the top without it.

## Deliberately coarse

A Trial reading none of the changed nodes is refused along with the rest — coarser than node staleness (`diff_from` walks `output_edges`) and than the Predictor cascade (`node_names() & reset`). Precision needs the *old* Pipeline to diff against, and an Experimenter holds only its own copy. A version scalar is the only check it can make from its own directory, and self-containment is worth more here than precision.

## Breaking

- `require_frozen_pipeline` → `require_published_pipeline`, and it applies to `Experimenter.set_pipeline` too.
- An archived version is no longer a thing to adopt or to delete; `remove_pipeline_version` refuses the latest instead.
- `PipelineBuilder()` without a path cannot `build()` — use `draft()`.
- `versions` rows no longer report a status.
- **No migration.** The dropped `status` column and the two new `pipeline_version` columns mean an older `pipeline.db` / `trials.db` will not open.

## Notes

- `experiment_hist.pipeline_version` stays and keeps being written. The redundancy argument holds only for rows written under the gate; rows already recorded were never gated, `get_hist(pipeline_version=)` filters on it, and #142 put it in the dicts `error_trials` returns.
- The s6e6 notebook's `run()` no longer re-authors names already registered — a Trial carries the version it was authored against, so authoring is once per name, and that is what lets the notebook be re-run from the top.
