### PR TITLE
feat: a Predictor retires, and publishing propagates (#133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Project(path, data, aug_data, cache_maxsize)   경로·데이터·캐시 소유 
   │         └─ CollectHist          수집 이력 (이 Experimenter만)
   └─ trainers{name: Trainer}        전체 데이터 학습 (trainers/{name}/) — Predictor를 학습
        ├─ TrainerStore              meta + splits + pipeline.pkl (이 Trainer만)
-       ├─ PredictorStore            Predictor 정의 (이 Trainer만 — 비교할 일이 없어서)
+       ├─ PredictorStore            Predictor 정의 + 상태 (이 Trainer만 — 비교할 일이 없어서)
        └─ to_inferencer() ──► Inferencer
 ```
 **경계**: Experimenter/Trainer 하나에 대한 것(splitter, 채택한 Pipeline, 아티팩트/이력, Collector,
@@ -52,7 +52,7 @@ Project(path, data, aug_data, cache_maxsize)   경로·데이터·캐시 소유 
 - **Trial / make_trials** (`_trial.py`): 평가할 구성 하나. Pipeline 밖에 있음
 - **TrialStore** (`_trial_store.py`): `trials`(정의) + `experiment_hist`(fold별 실행 이력). 저작은 `Project.set_trial`, 실행은 `Experimenter.exp`가 **이름으로** 꺼내 씀
 - **Predictor** (`_predictor.py`): Trainer가 학습하는 끝지점 출력 노드. Trial과 같은 실행 정의 + 출처(`src_trial`/`src_experimenter`)
-- **PredictorStore** (`_predictor_store.py`): `predictors`(정의) 하나뿐 — 이력은 Trainer의 두 번째 `NodeStore`가 가짐
+- **PredictorStore** (`_predictor_store.py`): `predictors`(정의 + `status`) 하나뿐 — fold별 이력은 Trainer의 두 번째 `NodeStore`가 가짐
 - **ProjectStore** (`_project_store.py`): `experimenters`/`trainers` **이름 목록만**
 - **ExperimenterStore / TrainerStore** (`_experimenter_store.py`, `_trainer_store.py`): Experimenter/Trainer 하나 전용 상태(meta + splitter BLOB + `pipeline.pkl`)
 - **Experimenter** (`_experimenter.py`): CV 실험 실행/관리. 생성자=신규, 복원=`load_experimenter()`
@@ -73,7 +73,9 @@ Project(path, data, aug_data, cache_maxsize)   경로·데이터·캐시 소유 
 | **built** | O | 빌드 완료, 결과 추출 가능 |
 | **error** | info only | 실행 중 에러 발생, 내역 보존 |
 
-Disk 칸은 **노드(와 Trainer의 Predictor)** 얘기다 — Trial은 아래 참조
+Disk 칸은 **노드** 얘기다 — Trial은 아래 참조, Predictor는 상태가 하나 더 있다
+
+**Predictor는 4-state**: `init`(등록됐고 아직 안 끝난 split이 있음) / `trained`(전 split built — `to_inferencer()`가 실을 수 있는 것) / `retired`(버전 스위치가 끝냄, terminal) / `error`(한 fold라도 실패면 에러). `predictors` 테이블의 `status` 컬럼에 있고, 셋은 디스크에서 복원되지만 **`retired`는 안 된다** — 폐기가 남기는 모양(아티팩트 없음 + 이력 행 있음)이 reset이 남기는 것과 같아서
 
 - 중간 상태(finalize)는 없다. 아티팩트를 없애는 방법은 `reset_nodes()`(완전 삭제, `init`으로 복귀) 하나뿐
 - **Experimenter엔 상태 게이트가 없다** — `open`/`close`/`status` 개념 자체가 없고 `build()`/`exp()`는 언제나 호출 가능
@@ -201,6 +203,11 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
 - **`remove_experimenter(name)` / `remove_trainer(name)`**: 디렉토리 삭제 + 색인 해제 + 레지스트리에서 제거. **Experimenter는 `experiment_hist` 행까지** 지운다 — 이름이 그 이력의 키라서, 남겨두면 다음에 같은 이름으로 추가한 것이 물려받고 `exp()`가 돌린 적 없는 fold를 건너뛴다. Trial *정의*는 프로젝트 소유라 안 건드림. Trainer는 프로젝트 전역 이력이 없어 디렉토리뿐
   - 디스크 밖에 남는 것: 그 Experimenter/Trainer의 `DataCache` 항목(scope가 랜덤 id라 도달 불가능한 채 LRU에서 밀릴 때까지 남음), 이미 손에 든 파이썬 객체
 - **Pipeline**: `pipeline` property(프로젝트당 하나인 `PipelineBuilder`, 두 번 물어도 같은 객체 — 한 db 위의 두 사본이 갈라지지 않게). `load_pipeline(version=None)`, `list_pipeline_versions()`, `remove_pipeline_version(version)`. 버전 lifecycle은 아래 "Pipeline 버전" 섹션
+- **`publish_pipeline(experimenters=True, trainers=False, dry_run=False)`**: 빌드 + 채택 전파 + 비용 보고. **순서가 존재 이유다** — `set_trial`은 최신 published를 찍고, 채택이 Experimenter에게 대조할 버전을 주고, `exp()`는 스탬프≠채택버전을 거절한다. 빌드만 하고 전파를 안 하면 다음에 저작한 Trial이 아무도 안 든 버전을 달게 되고, 그게 `exp()`에서 거절로 튀어나온다(원인에서 멀리 떨어진 자리). 이 순서는 여러 Experimenter/Trainer에 걸쳐서 **여기 말고 살 데가 없다**
+  - **Trainer가 기본 제외인 이유**: 값이 다르다. Experimenter는 다음 `build()`가 다시 만드는 노드 아티팩트를 잃지만, Trainer 채택은 입력이 바뀐 Predictor를 **폐기**(terminal)한다. 작업 흐름도 실험 → 결과 확인 → Trainer 승격 순이라, 실험 중의 publish가 이미 학습된 것에 손댈 이유가 없다
+  - 뒤처진 Trainer가 방치되는 게 아니다 — 자기 `pipeline.pkl` 사본과 Predictor의 버전 스탬프를 들고 자기 버전에서 계속 돌고, 어긋나면 `train()`이 거절한다
+  - 반환이 버전 번호가 아닌 이유: 채택 후엔 물어볼 대상이 없다(아티팩트가 없고 staleness는 삭제에 소비됨). 노드 리셋과 Predictor 폐기를 **따로** 보고한다 — 같은 손실이 아니므로
+  - `dry_run`은 `build()`가 아니라 `draft()`를 쓴다 — 가격을 묻는 행위가 결제가 되면 안 되므로(`stale_nodes`와 같은 이유)
   - **`load_pipeline`은 읽기만 한다** — 버전을 주면 그 번호, 안 주면 최신(`MAX(version)`). 예전엔 인자가 없으면 working copy를 build했는데, 그건 publish라서 "load"라는 이름이 버전을 찍었고 Experimenter 추가도 덩달아 찍었다. 발급은 `build()` 한 곳에만 있다
 - `trials`: `TrialStore`, `store`: `ProjectStore`
 - **`set_trial(trial)` / `set_trials(trials)`**: Trial 저작 진입점. **실행과 분리된 이유** — Trial은 프로젝트 소유인데 등록이 `Experimenter.exp()`의 부수효과였다. 그래서 실행하지 않고는 프로젝트에 넣을 수 없었고, 한 Experimenter가 다른 Experimenter가 이미 쓴 이름을 조용히 덮을 수 있었다
@@ -215,7 +222,9 @@ PipelineBuilder  — 가변. grps 계층, SQLite(pipeline.db), set_grp/set_node
   - **일부러 거칠다**: fold 일부만 돌다 끊긴 건 안 잡는다 — 그걸 판정하려면 fold 그리드와 대조해야 하는데 이 store는 그걸 모른다. 반환된 이름을 그냥 돌려도 안전하다(`exp()`가 끝난 fold를 건너뜀)
 - **`collect_errors(experimenter=None, collectors=None)`**: 수집 실패를 fold당 dict 하나로. 세 번째 에러 읽기이고(노드는 `Experimenter.error_nodes`, Trial은 위 `error_trials`), **유일하게 Experimenter를 거쳐야 읽는다** — Collector 이력은 레지스트리 소유고 레지스트리는 Experimenter별이라, 자기 store가 없어 `Experimenter.collect_errors`에 묻는다
   - 팬아웃하면서 **`experimenter` 키를 얹는다** — `collect_hist`엔 그 컬럼이 일부러 없고(어느 것이냐는 db가 어디 있느냐로 답한다), 여러 레지스트리를 가로지를 때만 필요해지는 값이라
-- **`stale_nodes(pipeline=None, experimenter=None)`**: 그 정의를 채택하면 어느 노드의 아티팩트가 날아가는지를 **채택 전에** 본다 → `{experimenter: [노드...]}`. `Experimenter.stale_nodes` 위임
+- **`stale_nodes(pipeline=None, experimenter=None, trainer=None)`**: 그 정의를 채택하면 어느 노드의 아티팩트가 날아가는지를 **채택 전에** 본다 → `{'experimenters': {name: [노드...]}, 'trainers': {name: [노드...]}}`. `Experimenter.stale_nodes`/`Trainer.stale_nodes` 위임
+  - **키가 나뉜 이유**: `exp/{name}`과 `trainers/{name}`은 별개 네임스페이스라 한 이름이 양쪽에 있을 수 있고, 평평한 dict면 둘 중 하나가 말없이 사라진다. 이름을 주면 준 것만 답하고 반대쪽은 빈 dict
+  - **양쪽 다 노드만 답한다 — Trainer에겐 과소평가다**: 채택은 Predictor 폐기도 일으키는데 그건 terminal이다. 전체 가격은 `publish_pipeline(dry_run=True, trainers=True)`
   - `pipeline=None`이면 **working copy**를 `self.pipeline.draft()`로 스냅샷 떠서 쓴다 — draft는 등록을 안 하므로 조회가 버전을 찍지 않는다. 찍으면 `add_experimenter`/`add_trainer`의 기본값이 최신이라 **미리보기가 다음 채택 대상을 바꿔버린다**
   - `load_pipeline()`을 넘기면 반대 방향 질문이 된다 — 각 Experimenter가 최신보다 얼마나 뒤처졌나
   - 노드 전용. Trial은 채택이 안 건드리므로 여기 안 나온다
@@ -367,7 +376,7 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - **`predictors`/`selected_nodes`는 property** — `predictors`는 `predictor_defs.list_predictors()`(상태로 안 들고 있음 → 리로드가 공짜), `selected_nodes`는 `_nodes_for(self.predictors)`로 매번 계산(Predictor가 없으면 전 노드)
 - `predictor_names()`, `predictor_specs()`
 - `train_folds`: `[TrainFold]` — split당 `TrainDataFlow` 하나
-- **`train(predictors=None, n_jobs=1, gpu_id_list=None, logger=None)`**: 넘긴 Predictor 중 `pipeline_version`이 `None`인 것은 **채택 버전으로 찍고**, 채택 버전과 다른 것은 `ValueError`. Trainer는 프로젝트를 몰라 "최신 published"를 못 구하지만 자기가 채택한 버전은 알고, 직접 저작한 Predictor는 곧 눈앞의 정의에 대한 것이라 그게 맞는 값이다. 그 다음 노드 먼저(위상 순서), 그 다음 Predictor `Job` 실행. 두 실행은 별개 executor 호출이라 각자 자기 store와 자기 `NodeInfoTracker`를 받음. skip 판정은 양쪽 다 디스크 기반(`store.status(name, split_idx, 0) == 'built'`) — **재정의는 그 자체로 재학습을 유발하지 않는다**(강제하려면 `reset_nodes([name])`)
+- **`train(predictors=None, n_jobs=1, gpu_id_list=None, logger=None)`**: 넘긴 Predictor 중 `pipeline_version`이 `None`인 것은 **채택 버전으로 찍고**, 채택 버전과 다른 것은 `ValueError` — **단 Job이 생기는 것에만** 걸린다(전 split이 built면 그 스탬프는 앞으로 돌릴 것에 대한 주장이 아니라 무엇이 그걸 만들었는지의 기록). `retired`인 것은 `predictors=None`이면 조용히 빠지고, 이름으로 지정하면 `ValueError`. Trainer는 프로젝트를 몰라 "최신 published"를 못 구하지만 자기가 채택한 버전은 알고, 직접 저작한 Predictor는 곧 눈앞의 정의에 대한 것이라 그게 맞는 값이다. 그 다음 노드 먼저(위상 순서), 그 다음 Predictor `Job` 실행. 두 실행은 별개 executor 호출이라 각자 자기 store와 자기 `NodeInfoTracker`를 받음. skip 판정은 양쪽 다 디스크 기반(`store.status(name, split_idx, 0) == 'built'`) — **재정의는 그 자체로 재학습을 유발하지 않는다**(강제하려면 `reset_nodes([name])`)
   - `predictors`는 `predictor_defs.register_all()`로 **upsert 등록**(replace 아님) — 이전 호출에서 학습한 Predictor의 정의와 아티팩트가 살아남는다. replace로 지우면 아티팩트만 남고 정의가 사라져 읽을 수 없게 됨
   - `predictors=None`이면 이미 등록된 것들을 그대로 이어서 학습(중단된 학습 재개)
   - `Trial`을 넘기면 `TypeError` — `Predictor.from_trial(trial, experimenter=)`로 명시 승격해야 출처가 기록됨
@@ -376,7 +385,14 @@ experiment_hist(trial_name, experimenter, outer_idx, inner_idx,  -- PK
 - `get_status(node_name)` / `get_node_error(node_name)`: `_store_for(name)`으로 두 store 중 하나를 골라 조회 — Predictor 에러도 기록됨
 - `process(data, v=None)`: generator, split마다 Predictor output을 `v`(DSL 문자열)로 필터 후 concat하여 yield. Predictor 모델은 노드 flow의 lazy 로드가 닿지 않는 store에 있으므로(그게 메모리에 안 딸려오게 하는 장치) `predictor_store`에서 꺼내 `flow.node_objs`에 직접 넣고, **edges는 정의에서 채운다** — 아티팩트에도 이 flow의 이력에도 없기 때문
 - `to_inferencer(v=None)`: 학습된 Processor를 추출하여 Inferencer 생성. `_trainer_spec()`(문자열/원시값 dict)을 출처로 찍어 넣음
-- `reset_nodes(nodes)`: 하위 종속 노드 포함 초기화. Predictor는 leaf라 그래프 캐스케이드 대상이 아니지만, 리셋된 노드를 읽는 Predictor는 `node_names()` 교집합으로 같이 리셋됨
+- **아티팩트가 사라지는 경로가 둘이고, 뜻이 반대다**:
+  - `reset_nodes(nodes)`: **초기화**. 하위 종속 노드 포함, 리셋된 노드를 읽는 Predictor도 같이. Pipeline 정의는 그대로라 그 Predictor는 같은 모델로 다시 학습된다 → `init`으로 복귀. 이미 `retired`인 건 안 건드림(재학습 요청은 부활이 아님)
+  - `set_pipeline(newer)`: **폐기**. 입력 노드 정의가 실제로 달라져 같은 모델을 못 만드므로 `retired`(terminal) — `train()`이 Job을 안 만들고, 이름으로 지정하면 `ValueError`
+  - 판정(`_reach_of`)과 삭제(`_drop_artifacts`)가 분리돼 있어 미리보기와 실제가 같은 traversal을 탄다
+- **`stale_nodes(pipeline)` / `retiring_predictors(pipeline)`**: 채택 전에 묻는 두 절반. `set_pipeline`이 후자를 실제로 호출하므로 미리보기가 실제와 갈라질 수 없다. 사후엔 답할 대상이 없음(아티팩트가 이미 없음)
+- **`_restamp_predictors(exclude)`**: 폐기를 면한 것만 채택 버전으로 옮긴다. 아티팩트가 살아남았다 = 읽는 노드가 두 버전에서 동일 정의 = 새 버전에서 학습해도 같은 모델이라 새 버전을 말해도 참. 폐기된 것은 실제로 학습된 버전을 계속 말한다
+- **`predictor_status(name)` / `predictor_statuses()`**: 상태 조회. `_observed_status`(디스크가 함의하는 상태 — 폐기는 여기서 절대 안 나옴)를 `train()` 끝에 `_sync_predictor_status`가 되쓴다
+- **`remove_predictor(name)` / `purge_retired()`**: 묘비 정리 — 정의+아티팩트+이력. 폐기가 셋을 다 남기므로(정의는 비문, 이력은 그 전에 뭐가 돌았는지) 걷어내는 건 별도 행위
 - 저장/로드: `save()`(meta + splits를 `_store`에 기록), 복원은 `Trainer.load_trainer()`. Pipeline은 `{path}/pipeline.pkl`, splitter/split_indices는 `__trainer.db`의 splits BLOB, **Predictor는 `predictor_defs`에서** 복원
 
 ### Predictor (`_predictor.py`)
@@ -390,11 +406,14 @@ Trainer가 학습하는 끝지점 출력 노드. `name`, `processor`, `method`, 
 ### PredictorStore (`_predictor_store.py`)
 ```sql
 predictors(name PK, desc, processor, method, adapter, params, edges, tag,
-           src_trial, src_experimenter, pipeline_version)
+           src_trial, src_experimenter, pipeline_version, status)
 ```
-- **정의만 있고 이력 테이블이 없다** — Predictor의 fold별 status/info는 그 Trainer의 `predictor_store`(`NodeStore`)의 `node_hist`에 아티팩트와 같이 있음. `TrialStore`가 두 절반을 다 갖는 것과 대비되는데, TrialStore는 프로젝트 전역이라 "어느 Experimenter가 돌렸나"를 답해야 하는 반면 여기는 store 자체가 이미 그 Trainer로 스코프돼 있어서
+- 상수는 이 모듈에: `INIT`/`TRAINED`/`RETIRED`/`ERROR`
+- **정의 + 생명주기 한 칸. 이력 테이블은 없다** — Predictor의 fold별 info는 그 Trainer의 `predictor_store`(`NodeStore`)의 `node_hist`에 아티팩트와 같이 있음. `TrialStore`가 두 절반을 다 갖는 것과 대비되는데, TrialStore는 프로젝트 전역이라 "어느 Experimenter가 돌렸나"를 답해야 하는 반면 여기는 store 자체가 이미 그 Trainer로 스코프돼 있어서
 - **Trainer별인 이유**: Trial은 **결과가 중심**이라 여러 Experimenter의 성적을 한곳에 모아 비교해야 한다. Predictor는 **아티팩트가 중심**이고 서로 비교할 일이 없다 — 답하는 질문이 "*이* Trainer가 뭘 학습하나"라서 프로젝트 레벨로 공유할 이유가 없음. `Trainer`가 `self.predictors`를 상태로 안 들고 이 store를 직접 읽는 property로 둔 근거이기도 함
-- `register`/`register_all`(upsert — `Trainer.train`이 쓰는 것)/`replace_all(predictors)`(통째 교체, 빠진 이름 삭제)/`remove(name)`/`has(predictor)`/`get_by_name(name)`/`list_predictors()`
+- **`status`가 예외인 이유**: 넷 중 셋은 디스크에서 복원되지만 `RETIRED`는 안 된다 — 폐기는 아티팩트를 지우고 이력 행은 남기는데, 그게 정확히 reset이 남기는 모양이라 디스크로는 둘을 못 가른다. 그리고 이 구분이 `_make_predictor_jobs`가 Job을 만들지 말지를 정하므로 캐시가 아니라 일을 한다
+- `register`/`register_all`(upsert — `Trainer.train`이 쓰는 것)/`replace_all(predictors)`(통째 교체, 빠진 이름 삭제)/`remove(name)`/`has(predictor)`/`get_by_name(name)`/`list_predictors()`/`set_status(name, status)`/`get_status(name)`/`list_status()`/`list_names(status=None)`
+  - `register`는 `INSERT OR REPLACE`가 아니라 **`ON CONFLICT DO UPDATE`** — 정의 필드만 쓰고 `status`는 건드리지 않는다. 아니면 `train()`의 재등록과 채택 후 restamp가 행을 다시 쓸 때마다 상태가 조용히 `init`으로 돌아간다. 상태는 `set_status`로만 바뀐다
 - `get_by_name`/`list_predictors`는 dict가 아니라 **`Predictor` 객체**를 반환(`TrialStore`와 다름) — `Trainer.predictors` property가 그대로 내놓기 때문
 - `ArtifactStore`를 상속하지 않음 — 아티팩트도 이력도 안 갖는 순수 정의 레지스트리
 
@@ -625,7 +644,9 @@ published라서 `versions` 테이블에 status 컬럼도 없다(행의 존재가
 - **판정 시점은 `set_pipeline` 하나지만, 그 답은 채택 전에 미리 볼 수 있다** — `Experimenter.stale_nodes(pipeline)` / `Project.stale_nodes()`. `set_pipeline`이 그 메소드를 호출해서 지우므로 미리보기가 실제와 어긋나지 않는다. 사후 조회가 없는 게 아니라 **사후엔 답할 대상이 없다**(판정 즉시 지워짐)
 - **Trial은 캐스케이드하지 않는다**: Trial은 Pipeline 밖이라 diff가 이름을 모르고, stale 노드를 읽은 Trial도 건드리지 않는다 — `Experimenter.set_pipeline`은 stale 노드만 `reset_nodes`로 지우고 끝. 이력도 그대로 남는다. **버전 스탬프가 더하는 건 삭제가 아니라 정지다** — 새 버전을 채택하면 옛 버전 Trial들이 그냥 그 Experimenter에서 안 돌게 된다(`ValueError`). 결과는 그 버전에 대한 기록으로 보존되고, 다시 돌리려면 그 버전을 채택하거나 새 이름으로 저작해야 함
 - **Trial 자신의 재정의도 감지하지 않는다**: `Experimenter._make_jobs`는 (버전 대조를 통과한 뒤엔) 오직 `experiment_hist`의 fold별 status만 본다 — 재정의된 trial이 이미 `'built'`면 조용히 스킵되므로, 다시 돌리려면 `remove_trial_result(name)`을 직접 호출. 다만 성공 이력이 있는 이름의 재정의는 `Project.set_trial`이 막는다
-- **Predictor는 반대로 캐스케이드한다**: Trainer엔 보존할 "과거 실행" 개념이 없으므로, 바뀐 노드를 읽는 Predictor는 그냥 stale이다. `Trainer.reset_nodes`가 `predictor.node_names() & 리셋된_노드` 교집합으로 같이 지운다. Trial/Predictor를 별도 클래스로 둔 판단이 실제로 갈라지는 지점. 그리고 `set_pipeline`이 이어서 재스탬프하므로 지워진 아티팩트를 곧바로 다시 만들 수 있다
+- **Predictor는 폐기된다**: 바뀐 노드를 읽는 Predictor는 자기 모델을 만든 입력이 사라진 것이라, 채택이 그걸 남겨둘 수도 없고 다시 만들 수도 없다 → `retired`(terminal). `train()`이 Job을 안 만들고, 이름으로 지정하면 거절. 미리 물으려면 `Trainer.retiring_predictors(pipeline)`. Trial/Predictor를 별도 클래스로 둔 판단이 실제로 갈라지는 지점
+  - **`reset_nodes`와는 반대 동작이다** — 그쪽은 정의가 그대로라 같은 모델이 다시 나오므로 `init`으로 복귀시킨다. 지우는 파일은 같고 뜻이 정반대
+  - 폐기를 면한 Predictor만 `_restamp_predictors`가 새 버전으로 옮긴다(아티팩트가 살아남았다 = 읽는 노드가 두 버전에서 동일 정의)
 
 ## Trial/Predictor 버전 스탬프 — 정의가 자기 버전을 들고 다닌다
 `pipeline_version`은 이력 행에 붙는 메모가 아니라 **정의의 필드**다. 그래서
@@ -838,7 +859,7 @@ published라서 `versions` 테이블에 status 컬럼도 없다(행의 존재가
     {split_idx}/0/{name}/           # 노드 obj.pkl / result.pkl
     __predictors/                   # Predictor는 별도 디렉토리
       __node_hist.db                #   Predictor용 NodeStore — 노드 것과 파일명이 같아 분리가 강제됨
-      __predictors.db               #   PredictorStore (정의만)
+      __predictors.db               #   PredictorStore (정의 + status)
       {split_idx}/0/{name}/         #   Predictor obj.pkl / result.pkl
 
   # Inferencer는 여기 없다 — 프로젝트가 저장을 관리하지 않는다("Inferencer는 프로젝트 밖" 참조)

--- a/docs/concepts/state-model.md
+++ b/docs/concepts/state-model.md
@@ -15,9 +15,9 @@ error ──► (reset_nodes) ──► init
 | **built** | ✓ | Execution complete; `obj.pkl` and `result.pkl` exist and results can be read |
 | **error** | history only | Execution raised; the traceback is recorded, no artifact is written |
 
-State is per node **per fold**. `get_status(name)` reports the state across all folds of a run.
+State is per node **per fold**. `get_status(name)` reports the state across all folds.
 
-`built` is decided by the artifact on disk — the store simply checks whether `obj.pkl` exists. `error` never appears there, only in the run's history table, which is where `error_nodes()` and `get_node_error()` look.
+`built` is decided by the artifact on disk — the store simply checks whether `obj.pkl` exists. `error` never appears there, only in the history table, which is where `error_nodes()` and `get_node_error()` look.
 
 If an upstream node is in `error`, everything downstream fails without any explicit propagation logic — its inputs are simply missing.
 
@@ -29,24 +29,38 @@ If an upstream node is in `error`, everything downstream fails without any expli
 | `exp(trial_names)` | `init → built` for Trials |
 | `train(predictors)` | `init → built` for nodes, then Predictors |
 | `reset_nodes(nodes)` | any → `init`, deleting the artifacts |
+| `set_pipeline(newer)` | stale nodes → `init`; the Predictors reading them → `retired` |
 
 There is no `finalized` state and no open/closed session. `build()` and `exp()` can be called at any time, and artifacts persist until you delete them with `reset_nodes()`.
 
 ## What gets re-run
 
-Being already `built` is what makes a run skip work, and that is decided from disk and history — never by comparing definitions.
+Being already `built` is what makes execution skip work, and that is decided from disk and history — never by comparing definitions.
 
 - **Nodes** — skipped when that fold's artifact exists.
 - **Trials** — skipped when `TrialStore.experiment_hist` records that fold as `'built'`.
 - **Predictors** — skipped when the artifact exists in the Trainer's predictor store.
 
-The consequence is worth stating plainly: **a fold already marked `'built'` is silently skipped, whatever the definition says now.** For Trials this is why `Project.set_trial` refuses to redefine a name that has a successful run behind it — the history would otherwise describe results a definition never produced. Running one again is explicit:
+The consequence is worth stating plainly: **a fold already marked `'built'` is silently skipped, whatever the definition says now.** For Trials this is why `Project.set_trial` refuses to redefine a name that has a successful execution behind it — the history would otherwise describe results a definition never produced. Running one again is explicit:
 
 ```python
-e.remove_trial_result('lgb')      # this run's results and its history
+e.remove_trial_result('lgb')      # this Experimenter's results and history
 ```
 
 For Predictors, which have no such guard, remove the artifact with `reset_nodes`.
+
+### A Predictor carries its own status
+
+Nodes and Trials are read from disk and history; a Predictor is not, because one of its states leaves no trace there.
+
+| | |
+|---|---|
+| `init` | registered, with at least one split still to train |
+| `trained` | every split built — what `to_inferencer()` can ship |
+| `retired` | ended by a version switch. Terminal |
+| `error` | at least one split failed |
+
+Retiring drops the artifacts and leaves the history rows standing, which is exactly what a reset leaves behind — so disk cannot tell the two apart, and without the status recorded `train()` would build a retired Predictor back into existence.
 
 ## Staleness — comparing two Pipelines
 
@@ -56,12 +70,14 @@ The one thing that *does* invalidate work automatically is adopting a new Pipeli
 
 No generation counters or content hashes are involved; definitions are compared by value. A useful consequence: **editing a node that a given Trial does not read leaves that Trial's results intact.**
 
-The diff is skipped entirely when what is being replaced is the **empty** Pipeline. That is the state of a run that has adopted nothing yet — a placeholder, not a claim that nothing was built — and reopening a run adopts its saved Pipeline over exactly that placeholder. Diffing against it would delete every artifact on disk.
+The diff is skipped entirely when what is being replaced is the **empty** Pipeline. That is the state of an Experimenter or Trainer that has adopted nothing yet — a placeholder, not a claim that nothing was built — and reopening one adopts its saved Pipeline over exactly that placeholder. Diffing against it would delete every artifact on disk.
 
 ### Trials and Predictors diverge here
 
 - **Trials are left alone.** A Trial leaves no artifact, and its `experiment_hist` row documents the pipeline version it actually ran against, which stays true after a newer version is adopted. Re-running is a separate, explicit act.
-- **Predictors cascade.** A Trainer has no notion of a historical run to preserve, so a Predictor reading a reset node is simply stale, and `reset_nodes()` clears it too.
+- **Predictors are retired.** A Predictor reading a stale node loses the inputs that produced its model, so adopting cannot leave it standing — and cannot rebuild it either. It is retired: terminal, skipped by `train()`, and refused if named. Ask `t.retiring_predictors(candidate)` beforehand; afterwards there is nothing left to ask.
+
+Retiring is not the same motion as `reset_nodes()`. A reset leaves the definitions untouched, so a Predictor caught by that cascade would train to exactly the model it had — it returns to `init` and the next `train()` makes it again. Same files deleted, opposite meaning.
 
 ## Related
 

--- a/docs/guide/project-pipeline.md
+++ b/docs/guide/project-pipeline.md
@@ -2,7 +2,7 @@
 
 ## Creating a project
 
-A `Project` is a directory. It hands out paths and owns what is shared across runs — the dataset, the pipeline, the Trial store, the cache.
+A `Project` is a directory. It hands out paths and owns what is shared across Experimenters and Trainers — the dataset, the pipeline, the Trial store, the cache.
 
 ```python
 from mllabs import Project
@@ -10,7 +10,7 @@ from mllabs import Project
 project = Project('exp', data=df)      # created if missing
 ```
 
-The dataset belongs here because it is the one thing a run cannot restore from its own directory. Give it once and `add_experimenter` / `add_trainer` and the registries stop asking for a dataframe. `project.set_data(df)` sets it later; `aug_data=` is the same, for data appended to inner train splits.
+The dataset belongs here because it is the one thing an Experimenter or Trainer cannot restore from its own directory. Give it once and `add_experimenter` / `add_trainer` and the registries stop asking for a dataframe. `project.set_data(df)` sets it later; `aug_data=` is the same, for data appended to inner train splits.
 
 Everything else is reached from it:
 
@@ -21,11 +21,11 @@ project.list_experimenters()           # names only
 project.experimenters                  # the objects, opened on demand
 ```
 
-Collectors are not among them — a registry belongs to the run that writes into it, as `e.collectors`. See [Collectors](collectors.md).
+Collectors are not among them — a registry belongs to the Experimenter that writes into it, as `e.collectors`. See [Collectors](collectors.md).
 
 **One pipeline per project.** What you actually want from several is to refer back to an earlier definition, and that is a version's job rather than a name's — so `pipeline/` holds one builder and its numbered versions.
 
-## Adding and removing runs
+## Adding and removing Experimenters and Trainers
 
 ```python
 project.add_experimenter('cv5', sp=..., splitter_params={'y': 'target'})
@@ -37,7 +37,7 @@ t = project.trainers['final']
 project.remove_experimenter('cv5')     # deletes the directory
 ```
 
-`add_*` is strictly an addition: a taken name raises. Constructing an Experimenter splits the data afresh and resets its provenance, so doing that over an existing one is damage rather than a reopen — and an accessor that quietly created when the name was free would turn a typo into a second run instead of an error.
+`add_*` is strictly an addition: a taken name raises. Constructing an Experimenter splits the data afresh and resets its provenance, so doing that over an existing one is damage rather than a reopen — and an accessor that quietly created when the name was free would turn a typo into a second Experimenter instead of an error.
 
 Two different questions decide whether a name is free. `ProjectStore` says what this project *manages*; `ExperimenterStore.stored_at(path)` says whether the directory is *occupied*, possibly by something built outside the project. Either one refuses, with a message saying which.
 
@@ -181,6 +181,30 @@ project.remove_pipeline_version(1)   # any but the latest
 
 The latest is what an omitted version number resolves to, so it cannot be removed — deleting it would silently change what the next `add_experimenter` adopts. Removing an older one breaks nothing that ran against it: every Experimenter and Trainer keeps its own Pipeline copy. What is lost is what a provenance pointer refers to.
 
+### Publishing and propagating
+
+Building alone leaves everything else where it was, and the ordering that matters is easy to miss: `set_trial` stamps a Trial with the **latest published** version, adopting is what gives an Experimenter a version to compare against, and `exp()` refuses a stamp that is not the adopted one. Build without adopting and the Trials you author next carry a version nothing holds — which surfaces as a refusal at `exp()`, some distance from the omission.
+
+`publish_pipeline()` is the pair, and reports what it cost:
+
+```python
+report = project.publish_pipeline()
+report['version']            # 3
+report['experimenters']      # {'phase2': ['scaler', 'tgt_delta']}   nodes dropped
+report['trainers']           # {} — not touched by default
+```
+
+Building an unchanged definition returns the version it already has, so calling it out of habit costs nothing and moves nothing.
+
+**Trainers stay out unless asked for.** The two sides do not pay the same price: an Experimenter loses node artifacts the next `build()` makes again, while adopting on a Trainer *retires* every Predictor whose inputs changed, and that is terminal. Work moves the other way round anyway — experiment, read the results, then promote into a Trainer.
+
+```python
+project.publish_pipeline(dry_run=True, trainers=True)   # price it first
+project.publish_pipeline(trainers=True)                 # then commit
+```
+
+Leaving a Trainer behind strands nothing. It keeps its own Pipeline copy and its Predictors carry the version they trained against, so it goes on working where it is, and `train()` refuses a mismatch rather than quietly doing the wrong thing.
+
 ### Looking without publishing
 
 `draft()` returns the same snapshot `build()` does, unregistered:
@@ -188,10 +212,14 @@ The latest is what an omitted version number resolves to, so it cannot be remove
 ```python
 snapshot = project.pipeline.draft()
 snapshot.version, snapshot.status    # (None, 'draft')
-project.stale_nodes()                # what adopting the current edits would cost
+
+project.stale_nodes()
+# {'experimenters': {'phase2': ['scaler']}, 'trainers': {'final': ['scaler']}}
 ```
 
-This is how a question stays a question — `stale_nodes()` leans on it so that asking what an edit would cost is not what commits the edit. A draft cannot be adopted: without a number, nothing that ran against it could say what that was.
+This is how a question stays a question — `stale_nodes()` and `publish_pipeline(dry_run=True)` both lean on it, so asking what an edit would cost is not what commits the edit. A draft cannot be adopted: without a number, nothing that ran against it could say what that was.
+
+The two sides answer under separate keys because `exp/{name}` and `trainers/{name}` are separate namespaces — one name can exist in both. Pass `experimenter=` or `trainer=` to narrow to exactly one, and the other side comes back empty. Both report **nodes**, which understates a Trainer: for the retirements too, use `publish_pipeline(dry_run=True, trainers=True)`.
 
 `PipelineBuilder()` constructed without a path has nowhere to publish, so `build()` raises there; `draft()` is how you get the snapshot.
 
@@ -220,7 +248,7 @@ p.remove_node('poly')
 p.copy_nodes(['scale', 'ohe'])       # into another builder
 ```
 
-Editing the builder never disturbs a run in progress: runs hold the built Pipeline, and adopting a new version is an explicit `set_pipeline()` call — see [Experimenter & Trials](experimenter-trials.md).
+Editing the builder never disturbs an execution in progress: an Experimenter or Trainer holds the built Pipeline, and adopting a new version is an explicit `set_pipeline()` call — see [Experimenter & Trials](experimenter-trials.md).
 
 ## Related
 

--- a/docs/guide/trainer-predictors.md
+++ b/docs/guide/trainer-predictors.md
@@ -84,6 +84,24 @@ t.predictor_names()
 t.selected_nodes        # the Pipeline nodes those Predictors read
 ```
 
+## Where a Predictor stands
+
+Each one carries a status, and `train()` writes back what it left on disk:
+
+| | |
+|---|---|
+| `init` | registered, with at least one split still to train |
+| `trained` | every split built — this is what `to_inferencer()` can ship |
+| `retired` | ended by a version switch its inputs did not survive. Terminal |
+| `error` | at least one split failed. One bad fold is a bad Predictor |
+
+```python
+t.predictor_status('lgb_final')     # 'trained'
+t.predictor_statuses()              # {name: status}
+```
+
+Three of the four could be read off disk, but `retired` could not: retiring drops the artifacts and leaves the history rows standing, which is exactly what a reset leaves behind. Without the status recorded, a retired Predictor looks like one waiting to be trained, and `train()` would build it back into existence.
+
 ## Two stores, on purpose
 
 | | |
@@ -127,18 +145,42 @@ inf.save('inferencers/v1')
 
 See [Inferencer](../serving/inferencer.md) for serving.
 
-## Resetting
+## Resetting, and retiring
+
+Two things drop a Predictor's artifact, and they are not the same thing.
+
+**Resetting** is asking for a rebuild:
 
 ```python
 t.reset_nodes(['scale'])
 ```
 
-Downstream nodes go with it, and so does any Predictor that reads one of the reset nodes — unlike an Experimenter, a Trainer has no historical run to preserve, so a Predictor trained against a changed node is simply stale.
+Downstream nodes go with it, and so does any Predictor reading one of them. The Pipeline definition is untouched, so those Predictors would train to the same model as before — they go back to `init`, and the next `train()` makes them again.
 
-Adopting a new Pipeline version does the same thing automatically for whatever the diff invalidated:
+**Retiring** is what a version switch does:
 
 ```python
-t.set_pipeline(project.load_pipeline('main', 3))
+t.set_pipeline(project.load_pipeline(3))
+```
+
+Here the definitions really did change. A Predictor whose inputs are gone cannot be trained back to the model it held, so it is retired rather than reset: terminal, skipped by `train()`, and refused if you name it explicitly. Wanting the same specification again means registering it under another name, against the version that can serve it.
+
+Ask before you commit to it:
+
+```python
+t.stale_nodes(candidate)            # nodes that would be reset
+t.retiring_predictors(candidate)    # Predictors that would end
+```
+
+Both run the traversal `set_pipeline` acts on, so a preview cannot disagree with the effect. Afterwards there is nothing left to ask — the artifacts are gone, and the staleness went into deciding to delete them.
+
+A Predictor that comes through the switch is **restamped** onto the adopted version: its artifact survived, which means the nodes it reads are defined identically in both versions, so it would train to the same model there. A retired one keeps naming the version it actually trained against, that being the only true thing left to say about it.
+
+Retiring leaves the definition and the history standing, as the record of what was there. Clear them when you want to:
+
+```python
+t.remove_predictor('lgb_final')     # definition, artifacts, history
+t.purge_retired()                   # every retired one; returns the names
 ```
 
 ## Samplers

--- a/mllabs/_predictor_store.py
+++ b/mllabs/_predictor_store.py
@@ -4,13 +4,24 @@ One table, ``predictors``, keyed by name — the same identity the artifacts
 use, so redefining a name overwrites its row exactly as it overwrites the
 artifact directory.
 
-Definitions only. A Predictor's per-split outcome (status, fit_time, error,
-...) is execution history and lives in the Trainer's predictor ``NodeStore``
-alongside the artifacts it describes, recorded by ``NodeInfoTracker`` the
-same way Pipeline nodes are. That split is why this store is much smaller
-than :class:`~mllabs.TrialStore`, which carries both halves: a TrialStore is
-project-wide and has to answer "which Experimenter ran this, and how did it
-go", whereas each Trainer's history is already scoped by being its own store.
+Definitions, plus one lifecycle field. A Predictor's per-split outcome
+(fit_time, error, which fold, ...) is execution history and lives in the
+Trainer's predictor ``NodeStore`` alongside the artifacts it describes,
+recorded by ``NodeInfoTracker`` the same way Pipeline nodes are. That split
+is why this store is much smaller than :class:`~mllabs.TrialStore`, which
+carries both halves: a TrialStore is project-wide and has to answer "which
+Experimenter ran this, and how did it go", whereas each Trainer's history is
+already scoped by being its own store.
+
+``status`` is the exception, and it earns the place. Three of its four values
+are recoverable from disk, but :data:`RETIRED` is not: retiring drops the
+artifacts and leaves the history rows standing, so what remains on disk is
+indistinguishable from a Predictor that was reset and is waiting to be
+trained. Retiring is an event that happened, not a fact still legible in what
+survives it, and the difference decides whether ``train()`` builds a Job.
+Keeping the other three here too costs a column and means one place answers
+"where does this Predictor stand" instead of a cross-reference only someone
+holding the convention can perform.
 
 Scoped per Trainer rather than per project for the same reason: what this
 answers is "what is *this* Trainer training", which is that Trainer's own
@@ -22,6 +33,17 @@ import sqlite3
 from pathlib import Path
 
 from ._predictor import Predictor
+
+#: Registered, with at least one split still to train.
+INIT = 'init'
+#: Every split built — this is what :meth:`Trainer.to_inferencer` can ship.
+TRAINED = 'trained'
+#: Ended by a Pipeline version switch its inputs did not survive. Terminal:
+#: no Job is ever built for it again. Wanting the same specification back
+#: means registering it afresh, under the version that can serve it.
+RETIRED = 'retired'
+#: At least one split failed. One bad fold is a bad Predictor.
+ERROR = 'error'
 
 _SCHEMA_SQL = """
     CREATE TABLE IF NOT EXISTS predictors (
@@ -35,7 +57,8 @@ _SCHEMA_SQL = """
         tag              TEXT,
         src_trial        TEXT,
         src_experimenter TEXT,
-        pipeline_version INTEGER
+        pipeline_version INTEGER,
+        status           TEXT NOT NULL DEFAULT 'init'
     );
 """
 
@@ -56,18 +79,34 @@ class PredictorStore:
             conn.executescript(_SCHEMA_SQL)
 
     def register(self, predictor):
-        """Store *predictor*'s definition under its name."""
+        """Store *predictor*'s definition under its name.
+
+        An upsert that writes every definition field and leaves ``status``
+        alone, rather than ``INSERT OR REPLACE``, which would silently return
+        a Predictor to :data:`INIT` every time its row is rewritten —
+        including on ``Trainer.train``'s re-registration of what it was just
+        handed, and on the restamp that follows adopting a version. Status
+        changes only through :meth:`set_status`, where something decided it.
+        """
         with sqlite3.connect(str(self.db_path)) as conn:
             conn.execute(
-                "INSERT OR REPLACE INTO predictors "
+                "INSERT INTO predictors "
                 "(name, desc, processor, method, adapter, params, edges, tag, "
-                "src_trial, src_experimenter, pipeline_version) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "src_trial, src_experimenter, pipeline_version, status) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(name) DO UPDATE SET "
+                "desc=excluded.desc, processor=excluded.processor, "
+                "method=excluded.method, adapter=excluded.adapter, "
+                "params=excluded.params, edges=excluded.edges, "
+                "tag=excluded.tag, src_trial=excluded.src_trial, "
+                "src_experimenter=excluded.src_experimenter, "
+                "pipeline_version=excluded.pipeline_version",
                 (predictor.name, predictor.desc, predictor.processor,
                  predictor.method, json.dumps(predictor.adapter),
                  json.dumps(predictor.params), json.dumps(predictor.edges),
                  json.dumps(predictor.tag), predictor.src_trial,
-                 predictor.src_experimenter, predictor.pipeline_version),
+                 predictor.src_experimenter, predictor.pipeline_version,
+                 INIT),
             )
 
     def register_all(self, predictors):
@@ -106,6 +145,36 @@ class PredictorStore:
                 and stored.params == predictor.params
                 and stored.edges == predictor.edges
                 and stored.pipeline_version == predictor.pipeline_version)
+
+    def set_status(self, name, status):
+        """Move *name* to *status*. No-op if the name is not stored."""
+        with sqlite3.connect(str(self.db_path)) as conn:
+            conn.execute("UPDATE predictors SET status = ? WHERE name = ?",
+                         (status, name))
+
+    def get_status(self, name):
+        """Stored status for *name*, or ``None`` if it is not registered."""
+        with sqlite3.connect(str(self.db_path)) as conn:
+            row = conn.execute(
+                "SELECT status FROM predictors WHERE name = ?", (name,)
+            ).fetchone()
+        return row[0] if row else None
+
+    def list_status(self):
+        """``{name: status}`` for every stored Predictor.
+
+        One query, so a caller deciding across the whole registry — which to
+        build Jobs for, which to restamp — does not ask per name.
+        """
+        with sqlite3.connect(str(self.db_path)) as conn:
+            rows = conn.execute(
+                "SELECT name, status FROM predictors ORDER BY rowid").fetchall()
+        return {name: status for name, status in rows}
+
+    def list_names(self, status=None):
+        """Stored names, optionally only those in *status*."""
+        return [n for n, s in self.list_status().items()
+                if status is None or s == status]
 
     def get_by_name(self, name):
         """Stored :class:`~mllabs.Predictor` for *name*, or ``None``."""

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -530,11 +530,24 @@ class Project:
         return {name: self.experimenters[name].uncollected_trials(collectors)
                 for name in self._experimenter_names(experimenter)}
 
-    def stale_nodes(self, pipeline=None, experimenter=None):
-        """What adopting a definition would cost each Experimenter, before adopting.
+    def stale_nodes(self, pipeline=None, experimenter=None, trainer=None):
+        """What adopting a definition would cost, before adopting — both sides.
 
-        Delegates to ``Experimenter.stale_nodes``, the same code ``set_pipeline``
-        resets by — a preview of the real thing, not a second opinion about it.
+        Delegates to ``Experimenter.stale_nodes`` and ``Trainer.stale_nodes``,
+        the same code each ``set_pipeline`` resets by — a preview of the real
+        thing, not a second opinion about it.
+
+        The two are reported under separate keys rather than in one mapping
+        because ``exp/{name}`` and ``trainers/{name}`` are separate
+        namespaces: one name can exist in both, and a flat dict would drop
+        whichever came second without saying so.
+
+        **Nodes only, on both sides — and that understates a Trainer.** A
+        node named here comes back on the next ``build()`` / ``train()``,
+        whereas adopting also retires every Predictor whose inputs changed,
+        which is terminal. For the whole price of a publish, ask
+        ``publish_pipeline(dry_run=True, trainers=True)``; this stays about
+        nodes, as its name says.
 
         Defaults to the working copy as a :meth:`PipelineBuilder.draft`, which
         is a snapshot and not a publication. Asking what an edit would cost must
@@ -551,17 +564,31 @@ class Project:
                 working copy as it stands. Pass :meth:`load_pipeline` output
                 instead to ask the other direction — how far behind the
                 published definition each Experimenter is.
-            experimenter (str, optional): Ask only this one. ``None`` asks every
-                Experimenter in the project.
+            experimenter (str, optional): Ask only this Experimenter.
+            trainer (str, optional): Ask only this Trainer.
+
+        Naming either narrows to exactly what was named: with neither given
+        every Experimenter and Trainer answers, with one given the other side
+        comes back empty rather than silently answering in full.
 
         Returns:
-            dict: ``{experimenter_name: [node_name, ...]}``, empty list for an
-            Experimenter the change does not touch.
+            dict: ``{'experimenters': {name: [node...]},
+            'trainers': {name: [node...]}}``, an empty list for one the
+            change does not touch.
         """
         if pipeline is None:
             pipeline = self.pipeline.draft()
-        return {name: self.experimenters[name].stale_nodes(pipeline)
-                for name in self._experimenter_names(experimenter)}
+        named = experimenter is not None or trainer is not None
+        exp_names = ([experimenter] if experimenter is not None
+                     else ([] if named else self.list_experimenters()))
+        trainer_names = ([trainer] if trainer is not None
+                         else ([] if named else self.list_trainers()))
+        return {
+            'experimenters': {name: self.experimenters[name].stale_nodes(pipeline)
+                              for name in exp_names},
+            'trainers': {name: self.trainers[name].stale_nodes(pipeline)
+                         for name in trainer_names},
+        }
 
     def _experimenter_names(self, experimenter=None):
         return self.list_experimenters() if experimenter is None else [experimenter]

--- a/mllabs/_project.py
+++ b/mllabs/_project.py
@@ -618,6 +618,88 @@ class Project:
         """
         return self._pipeline_store().load_version(version)
 
+    def publish_pipeline(self, experimenters=True, trainers=False, dry_run=False):
+        """Build the working copy, move Experimenters and Trainers onto it, and
+        report what that cost.
+
+        The sequence this exists for is: build, propagate, *then* author. It
+        has to hold, because the pieces enforcing it are not the ones that
+        would notice it broken. :meth:`set_trial` stamps a Trial with the
+        latest published version, adopting is what gives an Experimenter a
+        version to compare against, and ``exp()`` refuses a stamp that is not
+        the adopted one. Build without propagating and the Trials authored
+        next carry a version nothing holds — which surfaces as a refusal at
+        ``exp()``, some distance from the omission that caused it. One call
+        spanning the project is the only place that ordering can live: an
+        Experimenter knows nothing of its siblings, and a store knows nothing
+        of either.
+
+        **Trainers stay out unless asked for.** The two sides do not pay the
+        same price. An Experimenter loses node artifacts, which the next
+        ``build()`` makes again. A Trainer loses trained models: adopting
+        retires every Predictor whose inputs changed, and retirement is
+        terminal. Work usually moves the other way round anyway — experiment,
+        read the results, then promote into a Trainer — so a publish during
+        experimentation should not reach into what has already been trained.
+
+        Leaving one behind strands nothing. A Trainer keeps its own Pipeline
+        copy and its Predictors carry the version they were trained against,
+        so it goes on working at the version it holds; ``train()`` refuses a
+        mismatch rather than quietly doing the wrong thing. Moving it forward
+        stays available as its own decision, here or through
+        ``trainer.set_pipeline(project.load_pipeline())``.
+
+        Building an unchanged definition returns the version it already has,
+        so calling this out of habit costs nothing and moves nothing.
+
+        What comes back is the cost, not just the number: afterwards there is
+        nothing left to ask, the artifacts being gone and the staleness
+        consumed in deciding to delete them. The two losses are reported
+        apart because they are not the same loss (see
+        :meth:`Trainer.retiring_predictors`).
+
+        Propagation is sequential and not atomic: if one raises, the ones
+        before it have already adopted. Repeating the call is the repair,
+        adoption being idempotent once the version is held.
+
+        Args:
+            experimenters (bool): Propagate to this project's Experimenters.
+                Default ``True``.
+            trainers (bool): Propagate to its Trainers. Default ``False`` —
+                see above. Left ``False``, they are neither adopted into nor
+                opened, and are absent from the report.
+            dry_run (bool): Report the cost and adopt nothing. Uses
+                :meth:`PipelineBuilder.draft` rather than building, so asking
+                what a publish would cost does not perform one — the same
+                reason :meth:`stale_nodes` does. Pair it with
+                ``trainers=True`` to price a Trainer before committing to it.
+
+        Returns:
+            dict: ``{'version', 'experimenters', 'trainers'}``, where
+            ``experimenters`` is ``{name: [node...]}`` and ``trainers`` is
+            ``{name: {'nodes': [...], 'retired': [...]}}``. ``version`` is
+            ``None`` for a dry run — a draft carries no number.
+        """
+        pipeline = self.pipeline.draft() if dry_run else self.pipeline.build()
+        selected_exps = self.experimenters if experimenters else {}
+        selected_trainers = self.trainers if trainers else {}
+
+        report = {
+            'version': pipeline.version,
+            'experimenters': {name: exp.stale_nodes(pipeline)
+                              for name, exp in selected_exps.items()},
+            'trainers': {name: {'nodes': t.stale_nodes(pipeline),
+                                'retired': t.retiring_predictors(pipeline)}
+                         for name, t in selected_trainers.items()},
+        }
+        if dry_run:
+            return report
+        for exp in selected_exps.values():
+            exp.set_pipeline(pipeline)
+        for trainer in selected_trainers.values():
+            trainer.set_pipeline(pipeline)
+        return report
+
     def _seed_base_version(self):
         """Publish the empty Pipeline as version 0, once, at creation.
 

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -4,7 +4,7 @@ import numpy as np
 from ._data_wrapper import wrap, unwrap, DataWrapperProvider
 from ._flow import TrainDataFlow
 from ._store import NodeStore
-from ._predictor_store import PredictorStore
+from ._predictor_store import PredictorStore, INIT, TRAINED, RETIRED, ERROR
 from ._trainer_store import TrainerStore
 from ._trial import Trial
 from ._edge_dsl import parse, eval_expr, referenced_nodes
@@ -259,31 +259,82 @@ class Trainer:
         pipeline.check_data_compatibility(self.data)
         # See Experimenter.set_pipeline: the empty Pipeline means nothing has
         # been adopted, so there is nothing to invalidate against.
+        retiring = self.retiring_predictors(pipeline)
         if not self.pipeline.is_empty:
             stale = pipeline.diff_from(self.pipeline)
             if stale:
-                self.reset_nodes(sorted(stale))
+                affected, predictor_names = self._reach_of(sorted(stale))
+                self._drop_artifacts(affected, predictor_names)
         self.pipeline = pipeline
         self._store.save_pipeline(pipeline)
         self.save()
-        self._restamp_predictors()
+        for name in retiring:
+            self.predictor_defs.set_status(name, RETIRED)
+        self._restamp_predictors(exclude=retiring)
         return pipeline
 
-    def _restamp_predictors(self):
-        """Move the registered Predictors onto the version just adopted.
+    def retiring_predictors(self, pipeline):
+        """Which Predictors adopting *pipeline* would retire, before adopting.
 
-        Adopting a version here *is* the decision to train against it, so the
-        Predictors this Trainer already holds follow it rather than being
-        stranded: without this the reset above would delete their artifacts and
-        :meth:`train` would then refuse to rebuild them, leaving the whole
-        version-switch path unreachable.
+        The question has to be asked beforehand, because afterwards there is
+        nothing left to ask: the artifacts are gone and the only record of why
+        is the status this call decides. Same shape as
+        ``Experimenter.stale_nodes``, and for the same reason — this is the
+        code :meth:`set_pipeline` acts on, not a second opinion about it.
+
+        A Predictor is retired when the change reaches a node it reads, which
+        means the inputs that produced its artifact no longer exist under the
+        adopted definition. One that reads only nodes defined identically in
+        both versions keeps its artifact and is restamped onto the new version
+        instead: training it there would produce the same model, so claiming
+        the new version is true.
+
+        Nothing is retired twice, and adopting onto an empty Pipeline retires
+        nothing — there is no previous definition to have diverged from.
+
+        Args:
+            pipeline (Pipeline): The version being considered.
+
+        Returns:
+            list[str]: Predictor names, sorted.
+        """
+        require_built_pipeline(pipeline)
+        if self.pipeline.is_empty:
+            return []
+        stale = pipeline.diff_from(self.pipeline)
+        if not stale:
+            return []
+        affected, predictor_names = self._reach_of(sorted(stale))
+        statuses = self.predictor_defs.list_status()
+        return sorted(name for name in affected & predictor_names
+                      if statuses.get(name) != RETIRED)
+
+    def _restamp_predictors(self, exclude=()):
+        """Move the surviving Predictors onto the version just adopted.
+
+        Only the survivors. A Predictor whose artifact came through the switch
+        reads nodes defined identically in both versions, so it would train to
+        the same model under the new one and naming it is accurate. A retired
+        one is the opposite case — its inputs really did change — and it goes
+        on naming the version it was actually trained against, which is the
+        only true thing left to say about it.
 
         The gate in :meth:`train` is not weakened by this, because it guards a
         different motion — a Predictor arriving from elsewhere, promoted from a
         Trial evaluated against some other version. That one is still refused,
         which is the case where training would ship something unmeasured.
+
+        Args:
+            exclude (iterable[str]): Names not to move — the ones being
+                retired by this same adoption.
         """
+        exclude = set(exclude)
+        statuses = self.predictor_defs.list_status()
         for predictor in self.predictor_defs.list_predictors():
+            if predictor.name in exclude:
+                continue
+            if statuses.get(predictor.name) == RETIRED:
+                continue
             if predictor.pipeline_version != self.pipeline_version:
                 predictor.pipeline_version = self.pipeline_version
                 self.predictor_defs.register(predictor)
@@ -309,6 +360,43 @@ class Trainer:
     def predictor_specs(self):
         """``{name: ProcessorSpec}`` for the registered Predictors."""
         return {p.name: p.get_spec() for p in self.predictors}
+
+    def predictor_status(self, name):
+        """Where *name* stands: ``init`` / ``trained`` / ``retired`` /
+        ``error``, or ``None`` if it is not registered here."""
+        return self.predictor_defs.get_status(name)
+
+    def predictor_statuses(self):
+        """``{name: status}`` for every registered Predictor."""
+        return self.predictor_defs.list_status()
+
+    def _observed_status(self, name):
+        """The status implied by what is on disk right now.
+
+        Retirement is never among the answers, and cannot be: retiring drops
+        the artifacts and leaves the history rows, which is exactly what a
+        reset leaves behind too. That is the whole reason the status is
+        stored rather than derived — this method covers the other three.
+        """
+        if any(s == 'error' for s in self.predictor_store.get_status(name).values()):
+            return ERROR
+        n = len(self.train_folds)
+        built = sum(1 for i in range(n)
+                    if self.predictor_store.status(name, i, 0) == 'built')
+        return TRAINED if n and built == n else INIT
+
+    def _sync_predictor_status(self, names):
+        """Write back what training left on disk, retirement excepted."""
+        statuses = self.predictor_defs.list_status()
+        for name in names:
+            if statuses.get(name) == RETIRED:
+                continue
+            self.predictor_defs.set_status(name, self._observed_status(name))
+
+    def _has_pending(self, name):
+        """Whether any split of *name* still needs training."""
+        return any(self.predictor_store.status(name, i, 0) != 'built'
+                   for i in range(len(self.train_folds)))
 
     def _nodes_for(self, predictors):
         """Pipeline nodes *predictors* need, topologically ordered.
@@ -368,7 +456,18 @@ class Trainer:
                 return (r['info'] or {}).get('error')
         return None
 
-    def reset_nodes(self, nodes):
+    def _reach_of(self, nodes):
+        """Everything dropping *nodes* would take with it.
+
+        Returns ``(affected, predictor_names)``: the node and Predictor names
+        the drop reaches, and the set of names among them that are Predictors
+        rather than Pipeline nodes.
+
+        Split out from the dropping so that asking and doing run the same
+        traversal — :meth:`retiring_predictors` previews with it and
+        :meth:`set_pipeline` acts on it, which is what keeps a preview from
+        being a second opinion about the real thing.
+        """
         pipeline = self.pipeline
         predictor_names = set(self.predictor_names())
         selected_set = set(self.selected_nodes) | predictor_names
@@ -385,7 +484,8 @@ class Trainer:
                     if downstream in pipeline.nodes:
                         queue.append(downstream)
 
-        # A Predictor reading a reset node must be retrained too.
+        # A Predictor reading a dropped node cannot keep its own artifact:
+        # the inputs that produced it are gone.
         node_reset = affected & set(self.selected_nodes)
         if node_reset:
             for predictor in self.predictors:
@@ -394,6 +494,17 @@ class Trainer:
                 if predictor.node_names() & node_reset:
                     affected.add(predictor.name)
 
+        return affected, predictor_names
+
+    def _drop_artifacts(self, affected, predictor_names):
+        """Delete the artifacts of *affected*, and forget them in every flow.
+
+        Says nothing about what it means — :meth:`reset_nodes` calls it to
+        return a Predictor to ``init`` and :meth:`set_pipeline` calls it to
+        retire one. The files removed are the same either way; the difference
+        is the status written afterwards, and whether a Job is ever built
+        again.
+        """
         for name in affected:
             if name in predictor_names:
                 for fold in self.train_folds:
@@ -407,7 +518,56 @@ class Trainer:
         if self.cache is not None:
             self.cache.clear_nodes(affected)
 
+    def reset_nodes(self, nodes):
+        """Drop *nodes*' artifacts so the next :meth:`train` rebuilds them.
+
+        This is the initialising sense of the word, and it is deliberately
+        not the retiring one. Asking for a rebuild leaves the Pipeline
+        definition untouched, so a Predictor caught by the cascade will be fed
+        exactly the inputs it had before and would train to the same model —
+        there is nothing to end, and it goes back to ``init``.
+
+        A version switch is the other case, and takes the other path: there
+        the inputs really did change, the same model cannot be produced again,
+        and the Predictor is retired rather than reset (:meth:`set_pipeline`).
+        A Predictor already retired stays that way — a rebuild request is not
+        a resurrection.
+        """
+        affected, predictor_names = self._reach_of(nodes)
+        self._drop_artifacts(affected, predictor_names)
+        for name in affected & predictor_names:
+            if self.predictor_defs.get_status(name) != RETIRED:
+                self.predictor_defs.set_status(name, INIT)
         self.save()
+
+    def remove_predictor(self, name):
+        """Erase *name* from this Trainer entirely — definition, artifacts,
+        history.
+
+        Retiring deliberately leaves all three standing: the definition is the
+        inscription on the tombstone, and the history says what ran before it.
+        They accumulate, so clearing them is a separate act with its own call
+        rather than a side effect of the switch that ended the Predictor —
+        the shape ``Project.remove_trial`` has, for the same reason.
+
+        Works on any status, not only retired ones.
+        """
+        for fold in self.train_folds:
+            self.predictor_store.reset_node(name, fold.split_idx, 0)
+            fold.train_data_flows[0].node_objs.pop(name, None)
+            fold.train_data_flows[0]._node_edges.pop(name, None)
+        self.predictor_store.remove_hist(node_name=name)
+        self.predictor_defs.remove(name)
+        if self.cache is not None:
+            self.cache.clear_nodes([name])
+        self.save()
+
+    def purge_retired(self):
+        """Remove every retired Predictor. Returns the names removed."""
+        names = self.predictor_defs.list_names(status=RETIRED)
+        for name in names:
+            self.remove_predictor(name)
+        return names
 
     # ------------------------------------------------------------------
     # train
@@ -425,14 +585,22 @@ class Trainer:
         A split is skipped only if its artifact is already built — the same
         disk-based test :meth:`_make_node_jobs` uses, so a redefined
         Predictor does not by itself force a rerun of splits already built.
+
+        A retired Predictor is skipped whole. Its artifacts are gone, so the
+        disk test alone would hand it a Job for every split and train it back
+        into existence, which is precisely what retirement means not to
+        happen. Disk cannot tell that case from a reset one; the status can.
         """
         from ._executor import Job
         from .adapter import resolve_node_adapter
         from .adapter._base import GPU_NO
 
+        statuses = self.predictor_defs.list_status()
         gpu_cache = {}
         jobs = []
         for predictor in predictors:
+            if statuses.get(predictor.name) == RETIRED:
+                continue
             spec = predictor.get_spec()
             if predictor.name not in gpu_cache:
                 adapter = resolve_node_adapter(spec.processor, spec.adapter)
@@ -519,8 +687,11 @@ class Trainer:
         pipeline = self.pipeline
         pipeline.check_data_compatibility(self.data)
 
+        statuses = self.predictor_defs.list_status()
         if predictors is None:
-            predictors = self.predictors
+            # Resuming: retired names are not work left over, they are over.
+            predictors = [p for p in self.predictors
+                          if statuses.get(p.name) != RETIRED]
         else:
             predictors = list(predictors)
             for p in predictors:
@@ -529,11 +700,24 @@ class Trainer:
                         f"train() got a Trial ({p.name!r}); promote it with "
                         f"Predictor.from_trial(trial, experimenter=...) first"
                     )
+                if statuses.get(p.name) == RETIRED:
+                    raise ValueError(
+                        f"Predictor '{p.name}' is retired: a Pipeline version "
+                        f"switch changed the nodes it reads, so the model it "
+                        f"held cannot be produced again. Register the same "
+                        f"specification under another name to train it against "
+                        f"version {self.pipeline_version}."
+                    )
                 if p.pipeline_version is None:
                     p.pipeline_version = self.pipeline_version
             self.predictor_defs.register_all(predictors)
         for p in predictors:
-            if p.pipeline_version != self.pipeline_version:
+            # Only what would actually be trained. A Predictor whose splits
+            # are all built files no Job, so its version is a record of what
+            # produced it rather than a claim about what is about to run —
+            # and after a version switch that record is deliberately left
+            # behind (see _restamp_predictors).
+            if p.pipeline_version != self.pipeline_version and self._has_pending(p.name):
                 raise ValueError(
                     f"Predictor '{p.name}' is defined against pipeline version "
                     f"{p.pipeline_version}, and this Trainer has adopted "
@@ -603,6 +787,7 @@ class Trainer:
         else:
             logger.info(f"Train complete: {len(target_all)} node(s)")
 
+        self._sync_predictor_status([p.name for p in predictors])
         self.save()
 
     # ------------------------------------------------------------------

--- a/mllabs/_trainer.py
+++ b/mllabs/_trainer.py
@@ -273,6 +273,33 @@ class Trainer:
         self._restamp_predictors(exclude=retiring)
         return pipeline
 
+    def stale_nodes(self, pipeline):
+        """Pipeline nodes adopting *pipeline* would reset, sorted.
+
+        The node half of what a version switch costs;
+        :meth:`retiring_predictors` is the other. They are different kinds of
+        loss and are worth asking for separately — a node comes back on the
+        next :meth:`train`, a retired Predictor does not come back at all.
+
+        Same traversal :meth:`set_pipeline` acts on, so this is a preview
+        rather than a second opinion about it. The counterpart to
+        ``Experimenter.stale_nodes``, which a Trainer had no equivalent of.
+
+        Args:
+            pipeline (Pipeline): The version being considered.
+
+        Returns:
+            list[str]: Node names, sorted.
+        """
+        require_built_pipeline(pipeline)
+        if self.pipeline.is_empty:
+            return []
+        stale = pipeline.diff_from(self.pipeline)
+        if not stale:
+            return []
+        affected, predictor_names = self._reach_of(sorted(stale))
+        return sorted(affected - predictor_names)
+
     def retiring_predictors(self, pipeline):
         """Which Predictors adopting *pipeline* would retire, before adopting.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -934,6 +934,84 @@ class TestStaleNodes:
         assert project.stale_nodes(project.load_pipeline()) == {'run_a': ['scaler']}
 
 
+class TestPublishPipeline:
+    """Build, propagate, report — one call, because the ordering it enforces
+    spans every Experimenter and no single one can see it."""
+
+    @staticmethod
+    def _built_exp(project, builder, sample_data, name='run_a'):
+        e = project.add_experimenter(name, sample_data, pipeline_version=builder.build().version)
+        e.build()
+        return e
+
+    def test_publishing_moves_the_experimenters_onto_the_new_version(
+            self, project, builder, sample_data):
+        e = self._built_exp(project, builder, sample_data)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+
+        report = project.publish_pipeline()
+        assert report['version'] == project.load_pipeline().version
+        assert e.pipeline_version == report['version']
+
+    def test_the_report_names_what_it_cost(self, project, builder, sample_data):
+        """Not just the number. Afterwards there is nothing left to ask —
+        the artifacts are gone and the staleness went into deleting them."""
+        e = self._built_exp(project, builder, sample_data)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+
+        report = project.publish_pipeline()
+        assert report['experimenters'] == {'run_a': ['scaler']}
+        assert e.get_status('scaler') is None
+
+    def test_an_unchanged_definition_moves_nothing(self, project, builder, sample_data):
+        e = self._built_exp(project, builder, sample_data)
+        before = project.list_pipeline_versions()
+
+        report = project.publish_pipeline()
+        assert project.list_pipeline_versions() == before
+        assert report['experimenters'] == {'run_a': []}
+        assert e.get_status('scaler') == 'built'
+
+    def test_a_dry_run_prices_it_without_publishing(self, project, builder, sample_data):
+        e = self._built_exp(project, builder, sample_data)
+        before = project.list_pipeline_versions()
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+
+        report = project.publish_pipeline(dry_run=True)
+        assert report['version'] is None          # a draft carries no number
+        assert report['experimenters'] == {'run_a': ['scaler']}
+        assert project.list_pipeline_versions() == before
+        assert e.get_status('scaler') == 'built'  # adopted nothing
+
+    def test_trainers_stay_out_unless_asked_for(self, project, builder, sample_data):
+        """An Experimenter loses artifacts that rebuild; a Trainer loses
+        trained models for good. The default declines to spend the second."""
+        self._built_exp(project, builder, sample_data)
+        t = project.add_trainer('t1', sample_data, pipeline_version=builder.build().version)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+
+        report = project.publish_pipeline()
+        assert report['trainers'] == {}
+        assert t.pipeline_version == 1                    # left where it was
+        assert project.experimenters['run_a'].pipeline_version == report['version']
+
+        report = project.publish_pipeline(trainers=True)
+        # Names, not a claim that an artifact stood there — the same reading
+        # Experimenter.stale_nodes has.
+        assert report['trainers'] == {'t1': {'nodes': ['scaler'], 'retired': []}}
+        assert t.pipeline_version == report['version']
+
+    def test_experimenters_can_be_declined_too(self, project, builder, sample_data):
+        e = self._built_exp(project, builder, sample_data)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+
+        report = project.publish_pipeline(experimenters=False)
+        assert report['experimenters'] == {}
+        assert e.get_status('scaler') == 'built'
+        assert e.pipeline_version == 1        # the version was still minted
+        assert project.load_pipeline().version == report['version']
+
+
 class TestPendingTrials:
     """Registered Trials that errored or never ran — one list, because both
     still owe a run. Hand-written, this filter tends to catch only the second

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -892,46 +892,69 @@ class TestStaleNodes:
     answer exists, since set_pipeline turns it straight into deletions."""
 
     @staticmethod
-    def _built_run(project, builder, sample_data, name='run_a'):
+    def _built_exp(project, builder, sample_data, name='run_a'):
         e = project.add_experimenter(name, sample_data, pipeline_version=builder.build().version)
         e.build()
         return e
 
     def test_untouched_working_copy_costs_nothing(self, project, builder, sample_data):
-        e = self._built_run(project, builder, sample_data)
-        assert project.stale_nodes() == {'run_a': []}
+        e = self._built_exp(project, builder, sample_data)
+        assert project.stale_nodes() == {'experimenters': {'run_a': []}, 'trainers': {}}
         assert e.get_status('scaler') == 'built'
 
     def test_edit_names_the_node_it_would_drop(self, project, builder, sample_data):
-        self._built_run(project, builder, sample_data)
+        self._built_exp(project, builder, sample_data)
         builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
-        assert project.stale_nodes() == {'run_a': ['scaler']}
+        assert project.stale_nodes()['experimenters'] == {'run_a': ['scaler']}
+
+    def test_trainers_answer_too(self, project, builder, sample_data):
+        """Under their own key: exp/{name} and trainers/{name} are separate
+        namespaces, so one flat mapping would drop a shared name silently."""
+        self._built_exp(project, builder, sample_data, 'shared')
+        project.add_trainer('shared', sample_data, pipeline_version=builder.build().version)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+
+        assert project.stale_nodes() == {
+            'experimenters': {'shared': ['scaler']},
+            'trainers': {'shared': ['scaler']},
+        }
 
     def test_asking_does_not_publish(self, project, builder, sample_data):
-        """The working copy is built through copy(), which has no db — a
-        preview that minted a version would demote the published one and
-        change what add_experimenter() adopts next."""
-        self._built_run(project, builder, sample_data)
+        """The working copy is built through draft(), which mints nothing — a
+        preview that minted a version would change what add_experimenter()
+        adopts next."""
+        self._built_exp(project, builder, sample_data)
         before = project.list_pipeline_versions()
         builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
         project.stale_nodes()
         assert project.list_pipeline_versions() == before
 
-    def test_narrowed_to_one_run(self, project, builder, sample_data):
-        self._built_run(project, builder, sample_data, 'run_a')
-        self._built_run(project, builder, sample_data, 'run_b')
+    def test_narrowed_to_one_experimenter(self, project, builder, sample_data):
+        """Naming one narrows to exactly that: the other side comes back empty
+        rather than quietly answering in full."""
+        self._built_exp(project, builder, sample_data, 'run_a')
+        self._built_exp(project, builder, sample_data, 'run_b')
+        project.add_trainer('t1', sample_data, pipeline_version=builder.build().version)
         builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
-        assert project.stale_nodes(experimenter='run_a') == {'run_a': ['scaler']}
+        assert project.stale_nodes(experimenter='run_a') == {
+            'experimenters': {'run_a': ['scaler']}, 'trainers': {}}
+
+    def test_narrowed_to_one_trainer(self, project, builder, sample_data):
+        self._built_exp(project, builder, sample_data, 'run_a')
+        project.add_trainer('t1', sample_data, pipeline_version=builder.build().version)
+        builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
+        assert project.stale_nodes(trainer='t1') == {
+            'experimenters': {}, 'trainers': {'t1': ['scaler']}}
 
     def test_published_pipeline_asks_the_other_direction(self, project, builder, sample_data):
-        """How far behind a run is: it adopted v0, the project has since
-        published the node."""
+        """How far behind an Experimenter is: it adopted v0, the project has
+        since published the node."""
         e = project.add_experimenter('run_a', sample_data,
                                      pipeline_version=builder.build().version)
         e.build()
         builder.set_node('scaler', grp='scale', exist='replace', params={'with_std': False})
         builder.build()
-        assert project.stale_nodes(project.load_pipeline()) == {'run_a': ['scaler']}
+        assert project.stale_nodes(project.load_pipeline())['experimenters'] == {'run_a': ['scaler']}
 
 
 class TestPublishPipeline:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -369,22 +369,89 @@ class TestTrain:
         trainer.train([redefined])
         assert _build_ids(trainer, 'dt') != before
 
-    def test_node_edit_cascades_into_the_predictor(self, pipeline, sample_data, sp_v):
+    def test_node_edit_rebuilds_the_node_and_retires_the_predictor(
+            self, pipeline, sample_data, sp_v):
+        """The two halves of a version switch part company here. The node is
+        reset — its definition changed, and rebuilding it is what the new
+        version asks for. The Predictor reading it is retired: the inputs that
+        produced its model are gone, so there is nothing to rebuild it to."""
         trainer = _make_trainer(pipeline, sample_data, sp_v)
         trainer.set_pipeline(pipeline.build())
         trainer.train(_predictors())
-        before = {name: _build_ids(trainer, name) for name in ['scaler', 'dt']}
+        before = _build_ids(trainer, 'scaler')
 
         pipeline.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
                          method='transform', edges={'X': '{f1, f2, f3}'},
                          params={'with_std': False})
         trainer.set_pipeline(pipeline.build())
         assert trainer.get_status('scaler') is None
-        assert trainer.get_status('dt') is None      # cascaded via node_names()
-        trainer.train()
+        assert trainer.get_status('dt') is None
+        assert trainer.predictor_status('dt') == 'retired'
 
-        for name in ['scaler', 'dt']:
-            assert _build_ids(trainer, name) != before[name]
+        trainer.train()
+        assert _build_ids(trainer, 'scaler') != before   # node came back
+        assert trainer.get_status('dt') is None          # the Predictor did not
+
+    def test_a_retired_predictor_is_refused_by_name(self, pipeline, sample_data, sp_v):
+        """Resuming skips it silently; naming it says the caller believes it is
+        still trainable, and that is worth an error rather than a no-op."""
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+
+        pipeline.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
+                         method='transform', edges={'X': '{f1, f2, f3}'},
+                         params={'with_std': False})
+        trainer.set_pipeline(pipeline.build())
+        with pytest.raises(ValueError, match='retired'):
+            trainer.train([_dt()])
+
+    def test_retiring_predictors_previews_the_same_names(
+            self, pipeline, sample_data, sp_v):
+        """Asked before adopting, answered by the code adoption acts on."""
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+
+        pipeline.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
+                         method='transform', edges={'X': '{f1, f2, f3}'},
+                         params={'with_std': False})
+        nxt = pipeline.build()
+        assert trainer.retiring_predictors(nxt) == ['dt']
+        trainer.set_pipeline(nxt)
+        assert trainer.predictor_status('dt') == 'retired'
+        # Nothing is retired twice, and there is nothing left to retire.
+        assert trainer.retiring_predictors(nxt) == []
+
+    def test_reset_nodes_initialises_rather_than_retires(
+            self, pipeline, sample_data, sp_v):
+        """Asking for a rebuild leaves the definition alone, so the Predictor
+        would train to the same model — it goes back to init and does."""
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+        before = _build_ids(trainer, 'dt')
+
+        trainer.reset_nodes(['scaler'])
+        assert trainer.predictor_status('dt') == 'init'
+        trainer.train()
+        assert trainer.predictor_status('dt') == 'trained'
+        assert _build_ids(trainer, 'dt') != before
+
+    def test_purge_retired_clears_the_tombstones(self, pipeline, sample_data, sp_v):
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+
+        pipeline.set_grp('scale', processor='sklearn.preprocessing.StandardScaler',
+                         method='transform', edges={'X': '{f1, f2, f3}'},
+                         params={'with_std': False})
+        trainer.set_pipeline(pipeline.build())
+        assert trainer.predictor_defs.get_by_name('dt') is not None   # tombstone stands
+
+        assert trainer.purge_retired() == ['dt']
+        assert trainer.predictor_defs.get_by_name('dt') is None
+        assert trainer.predictor_store.get_hist(node_name='dt') == []
 
     def test_unrelated_node_edit_leaves_the_predictor_alone(self, pipeline, sample_data, sp_v):
         pipeline.set_grp('other', processor='sklearn.preprocessing.StandardScaler',
@@ -435,10 +502,30 @@ class TestPredictorVersion:
         with pytest.raises(ValueError, match='never evaluated'):
             trainer.train([stale])
 
-    def test_adopting_a_new_version_brings_the_predictors_along(
+    def test_adopting_brings_the_survivors_along(self, pipeline, sample_data, sp_v):
+        """A Predictor whose artifact came through the switch reads nodes
+        defined identically in both versions, so it would train to the same
+        model there — naming the adopted version is accurate."""
+        pipeline.set_grp('other', processor='sklearn.preprocessing.StandardScaler',
+                         method='transform', edges={'X': '{f1}'})
+        pipeline.set_node('unused', grp='other')
+        trainer = _make_trainer(pipeline, sample_data, sp_v)
+        trainer.set_pipeline(pipeline.build())
+        trainer.train(_predictors())
+        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == 1
+
+        pipeline.set_grp('other', processor='sklearn.preprocessing.StandardScaler',
+                         method='transform', edges={'X': '{f1}'},
+                         params={'with_mean': False})
+        trainer.set_pipeline(pipeline.build())
+        assert trainer.pipeline_version == 2
+        assert trainer.predictor_status('dt') == 'trained'
+        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == 2
+
+    def test_a_retired_predictor_keeps_the_version_it_trained_under(
             self, pipeline, sample_data, sp_v):
-        """Adopting is what says which definition this Trainer trains against.
-        Stranding them behind would leave the reset artifacts unrebuildable."""
+        """The opposite case: its inputs did change, so the version it was
+        actually trained against is the only true thing left to say."""
         trainer = _make_trainer(pipeline, sample_data, sp_v)
         trainer.set_pipeline(pipeline.build())
         trainer.train(_predictors())
@@ -449,9 +536,11 @@ class TestPredictorVersion:
                          params={'with_std': False})
         trainer.set_pipeline(pipeline.build())
         assert trainer.pipeline_version == 2
-        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == 2
+        assert trainer.predictor_status('dt') == 'retired'
+        assert trainer.predictor_defs.get_by_name('dt').pipeline_version == 1
+
+        # A stranded version no longer blocks the healthy work around it.
         trainer.train()
-        assert trainer.get_status('dt') == 'built'
 
 
 class TestPredictorStorage:


### PR DESCRIPTION
Closes #133.

The issue asked which parts of project setup belong to the library. Two of its three candidates were withdrawn: `dsl_set` is a notebook helper and stays one, and the collector registration table dissolves into #131 if definitions round-trip as documents. What remained is the third — building a Pipeline and adopting it are two calls with an ordering between them that nothing enforced, and every notebook wrote the same helper to keep them together.

Reaching that needed a prerequisite. Propagation could not touch Trainers while adopting a version there destroyed trained models without saying so.

## A Predictor retires; a reset only initialises

Adopting a version on a Trainer dropped Predictor artifacts and called it `reset` — the same word `reset_nodes` uses for a node, where it means the opposite. A node comes back: its definition is unchanged, so rebuilding produces what was there. A Predictor whose inputs changed cannot. One word was doing both jobs and the destructive one was silent.

- `reset_nodes` keeps only the initialising sense: artifacts dropped, Predictors back to `init`, rebuilt by the next `train()`.
- A version switch retires instead: terminal, no Job ever built again, refused if named explicitly.
- `predictors` gains a status — `init` / `trained` / `retired` / `error`, the last aggregated as "any split that errored". Three are recoverable from disk; `retired` is not, since retiring leaves exactly what a reset leaves. It has work to do rather than being a cache: `_make_predictor_jobs` skips only built splits, so without it a retired Predictor is handed a Job for every split and trained back into existence.
- `retiring_predictors(pipeline)` asks before adopting, on the traversal `set_pipeline` acts on.
- Restamping narrows to survivors. It used to move every registered Predictor onto the adopted version, staleness never consulted — so a model trained under v5 was relabelled v3. A survivor reads nodes defined identically in both versions and would train to the same model there; a retired one goes on naming what it actually trained under.
- The `train()` gate narrows with it, applying only where a Job would be created. It previously raised on the first mismatch across the whole list, which is why restamping had to move everything.
- `remove_predictor` / `purge_retired` clear the tombstones as a separate act.

## Publishing propagates

`Project.publish_pipeline(experimenters=True, trainers=False, dry_run=False)` builds, adopts, and reports the cost.

The ordering it holds: `set_trial` stamps the latest published version, adopting gives an Experimenter a version to compare against, and `exp()` refuses a stamp that is not the adopted one. Build without propagating and the Trials authored next carry a version nothing holds — surfacing as a refusal at `exp()`, some distance from the omission. That ordering spans everything the project manages and has nowhere else to live.

Trainers stay out by default because the two sides do not pay the same price: an Experimenter loses artifacts the next `build()` makes again, a Trainer loses trained models for good. Leaving one behind strands nothing — it keeps its own Pipeline copy, its Predictors carry the version they trained against, and `train()` refuses a mismatch rather than quietly doing the wrong thing.

`dry_run` prices it through `draft()` rather than `build()`, so asking what a publish would cost does not perform one.

`Project.stale_nodes` now answers for Trainers too, under a separate key — `exp/{name}` and `trainers/{name}` are separate namespaces, and a flat mapping would drop a shared name silently.

## Breaking

- `Project.stale_nodes` returns `{'experimenters': ..., 'trainers': ...}` instead of a flat `{name: [nodes]}`.
- `PredictorStore.predictors` gains a `status` column, so an older `__predictors.db` will not open.
- `Trainer.reset_nodes` no longer ends a Predictor's life; a version switch does.

## Tests

`tests/test_trainer.py` and `tests/test_project.py`, 195 passing locally. Two existing tests encoded the old model (a Predictor rebuilt after a node edit; every Predictor restamped on adoption) and were rewritten to the new one. The full suite has not been run in this environment — xgboost and catboost are absent here.

## Not in this PR

The example notebook still writes its own `adopt()` helper, which `publish_pipeline` is what replaces. Worth a follow-up, since #133 was built on that notebook as evidence.
